### PR TITLE
Add the lupen CLI

### DIFF
--- a/Lupen.xcodeproj/project.pbxproj
+++ b/Lupen.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		BF0000000000000000000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = PD0000000000000000000001 /* Sparkle */; };
 		BF0000000000000000000002 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = PD0000000000000000000002 /* GRDB */; };
 		BF0000000000000000000003 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = PD0000000000000000000003 /* GRDB */; };
+		BF0000000000000000000004 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = PD0000000000000000000004 /* ArgumentParser */; };
+		BF0000000000000000000005 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = PD0000000000000000000005 /* ArgumentParser */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +52,7 @@
 			files = (
 				BF0000000000000000000001 /* Sparkle in Frameworks */,
 				BF0000000000000000000002 /* GRDB in Frameworks */,
+				BF0000000000000000000004 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -58,6 +61,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF0000000000000000000003 /* GRDB in Frameworks */,
+				BF0000000000000000000005 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +119,7 @@
 			packageProductDependencies = (
 				PD0000000000000000000001 /* Sparkle */,
 				PD0000000000000000000002 /* GRDB */,
+				PD0000000000000000000004 /* ArgumentParser */,
 			);
 			productName = Lupen;
 			productReference = RF0000000000000000000001 /* Lupen.app */;
@@ -139,6 +144,7 @@
 			name = LupenTests;
 			packageProductDependencies = (
 				PD0000000000000000000003 /* GRDB */,
+				PD0000000000000000000005 /* ArgumentParser */,
 			);
 			productName = LupenTests;
 			productReference = RF0000000000000000000002 /* LupenTests.xctest */;
@@ -166,6 +172,7 @@
 			packageReferences = (
 				PR0000000000000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				PR0000000000000000000002 /* XCRemoteSwiftPackageReference "GRDB" */,
+				PR0000000000000000000003 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = GR0000000000000000000001 /* Products */;
@@ -458,6 +465,14 @@
 				version = 7.11.0;
 			};
 		};
+		PR0000000000000000000003 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -475,6 +490,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = PR0000000000000000000002 /* XCRemoteSwiftPackageReference "GRDB" */;
 			productName = GRDB;
+		};
+		PD0000000000000000000004 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = PR0000000000000000000003 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+		PD0000000000000000000005 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = PR0000000000000000000003 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Lupen.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lupen.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "23611ae21d62ab2ee131c4a9c2cc14b3126c0cd46fd543225a6f4bfe4990eae9",
+  "originHash" : "463ebd6d951da7c24d2221296c519336edf5f2cc683435b3140dc2686932f81b",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     }
   ],

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -911,6 +911,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         verifyUsageMenuItem = verifyItem
         windowMenu.addItem(verifyItem)
 
+        // The log window is a maintainer-only diagnostic; its entry points
+        // (this menu item and the dashboard toolbar button) ship in DEBUG
+        // builds only.
+        #if DEBUG
         let logsItem = NSMenuItem(
             title: "Logs…",
             action: #selector(openLogs(_:)),
@@ -919,6 +923,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         logsItem.keyEquivalentModifierMask = [.command, .shift]
         logsItem.target = self
         windowMenu.addItem(logsItem)
+        #endif
 
         windowMenu.addItem(.separator())
 

--- a/Lupen/CLI/CLIDateRange.swift
+++ b/Lupen/CLI/CLIDateRange.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Resolves the CLI's period options (`--since/--until`, `--last`,
+/// `--month`) into an inclusive `[from, to]` window passed to the store's
+/// range queries (`timestamp >= from AND timestamp <= to`, with `nil`
+/// meaning unbounded on that side).
+///
+/// Pure and calendar-injectable so the window math is unit-testable
+/// without wall-clock flakiness. The three styles are mutually exclusive
+/// — mixing them is a usage error rather than a silently-merged window.
+enum CLIDateRange {
+    struct Resolved: Equatable {
+        let from: Date?
+        let to: Date?
+    }
+
+    enum ResolveError: Error, CustomStringConvertible, Equatable {
+        case conflictingOptions
+        case badDate(String)
+        case badRelative(String)
+        case badMonth(String)
+
+        var description: String {
+            switch self {
+            case .conflictingOptions:
+                return "Use only one of --last, --month, or --since/--until."
+            case .badDate(let value):
+                return "Invalid date '\(value)'. Expected YYYY-MM-DD."
+            case .badRelative(let value):
+                return "Invalid --last '\(value)'. Expected forms like 30d, 4w, 1m."
+            case .badMonth(let value):
+                return "Invalid --month '\(value)'. Expected YYYY-MM."
+            }
+        }
+    }
+
+    static func resolve(
+        since: String?,
+        until: String?,
+        last: String?,
+        month: String?,
+        now: Date,
+        calendar: Calendar
+    ) throws -> Resolved {
+        let hasSinceUntil = (since != nil) || (until != nil)
+        let groupsUsed = [hasSinceUntil, last != nil, month != nil].filter { $0 }.count
+        if groupsUsed > 1 { throw ResolveError.conflictingOptions }
+
+        if let last {
+            return Resolved(from: try relativeStart(last, now: now, calendar: calendar), to: now)
+        }
+        if let month {
+            return try monthRange(month, calendar: calendar)
+        }
+        return Resolved(
+            from: try since.map { try startOfDay($0, calendar: calendar) },
+            to: try until.map { try endOfDay($0, calendar: calendar) }
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func relativeStart(_ raw: String, now: Date, calendar: Calendar) throws -> Date {
+        guard let unit = raw.last, let value = Int(raw.dropLast()), value > 0 else {
+            throw ResolveError.badRelative(raw)
+        }
+        let component: Calendar.Component
+        switch unit {
+        case "d": component = .day
+        case "w": component = .weekOfYear
+        case "m": component = .month
+        default: throw ResolveError.badRelative(raw)
+        }
+        guard let start = calendar.date(byAdding: component, value: -value, to: now) else {
+            throw ResolveError.badRelative(raw)
+        }
+        return start
+    }
+
+    private static func formatter(_ format: String, calendar: Calendar) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = format
+        formatter.isLenient = false
+        return formatter
+    }
+
+    /// Strict parse: requires the input to round-trip back to the same
+    /// string. `DateFormatter` accepts wrong separators / out-of-range
+    /// fields more leniently than `isLenient = false` implies (e.g.
+    /// `2026/06/01` under `yyyy-MM-dd`, or `2026-13` rolling into the next
+    /// year), so the round-trip is what actually rejects malformed input.
+    private static func strictDate(_ raw: String, format: String, calendar: Calendar) -> Date? {
+        let formatter = formatter(format, calendar: calendar)
+        guard let date = formatter.date(from: raw), formatter.string(from: date) == raw else {
+            return nil
+        }
+        return date
+    }
+
+    private static func startOfDay(_ raw: String, calendar: Calendar) throws -> Date {
+        guard let date = strictDate(raw, format: "yyyy-MM-dd", calendar: calendar) else {
+            throw ResolveError.badDate(raw)
+        }
+        return calendar.startOfDay(for: date)
+    }
+
+    private static func endOfDay(_ raw: String, calendar: Calendar) throws -> Date {
+        let start = try startOfDay(raw, calendar: calendar)
+        guard let nextDay = calendar.date(byAdding: .day, value: 1, to: start) else {
+            throw ResolveError.badDate(raw)
+        }
+        return inclusiveEnd(beforeStartOf: nextDay)
+    }
+
+    private static func monthRange(_ raw: String, calendar: Calendar) throws -> Resolved {
+        guard let monthStart = strictDate(raw, format: "yyyy-MM", calendar: calendar) else {
+            throw ResolveError.badMonth(raw)
+        }
+        let start = calendar.startOfDay(for: monthStart)
+        guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: start) else {
+            throw ResolveError.badMonth(raw)
+        }
+        return Resolved(from: start, to: inclusiveEnd(beforeStartOf: nextMonth))
+    }
+
+    /// Inclusive upper bound for a `timestamp <= to` query, given the
+    /// exclusive next-period start. Backs off one millisecond rather than
+    /// one second: stored timestamps carry millisecond precision, so a
+    /// `-1s` end would silently drop activity in the final second of an
+    /// `--until` day / `--month`.
+    private static func inclusiveEnd(beforeStartOf nextPeriodStart: Date) -> Date {
+        nextPeriodStart.addingTimeInterval(-0.001)
+    }
+
+    /// Human label for the selected period, derived from the raw flags so
+    /// it reads the way the user typed it (`last 30d`, `2026-06`, …).
+    /// Pure so it can be unit-tested without constructing the option set.
+    static func label(since: String?, until: String?, last: String?, month: String?) -> String {
+        if let last { return "last \(last)" }
+        if let month { return month }
+        switch (since, until) {
+        case let (start?, end?): return "\(start) → \(end)"
+        case let (start?, nil): return "since \(start)"
+        case let (nil, end?): return "through \(end)"
+        default: return "all time"
+        }
+    }
+}

--- a/Lupen/CLI/CLIDispatch.swift
+++ b/Lupen/CLI/CLIDispatch.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Decides whether the Lupen executable was invoked as the `lupen`
+/// command-line tool rather than launched as the GUI app.
+///
+/// The same binary serves both roles (see `main.swift`): a Homebrew cask
+/// — or `lupen install-cli` — symlinks `Lupen.app/Contents/MacOS/Lupen`
+/// onto the PATH as `lupen`, so `argv[0]` is `…/lupen` for CLI use and
+/// `…/Lupen` for a Finder / LaunchServices launch. The decision is kept
+/// as a pure function so the branch is unit-testable without spawning a
+/// process.
+///
+/// A process is treated as CLI when EITHER:
+///   * the invoked name (`argv[0]` basename) is exactly `lupen`, or
+///   * the first argument is a recognized subcommand or a help/version
+///     flag.
+///
+/// A plain GUI launch has neither (no subcommand; `argv[0]` is `Lupen`,
+/// capitalised), so the dashboard still opens. An XCTest host matches
+/// neither either: its `argv[0]` is the test runner and its arguments are
+/// XCTest's own. The name comparison is case-sensitive on purpose — the
+/// bundle executable is `Lupen`, the PATH symlink is `lupen`, so the two
+/// never collide.
+enum CLIDispatch {
+    /// The command name a PATH symlink uses.
+    static let commandName = "lupen"
+
+    enum Mode: Equatable {
+        /// Run the CLI (`LupenCLI`) and exit.
+        case cli
+        /// Continue to the normal GUI launch path.
+        case passthrough
+    }
+
+    /// Help/version flags that should route to the CLI even when the
+    /// binary is invoked under its bundle name (e.g. `Lupen --version`).
+    private static let cliFlags: Set<String> = ["--help", "-h", "--version"]
+
+    static func mode(
+        for arguments: [String],
+        knownCommands: Set<String>
+    ) -> Mode {
+        guard let invokedPath = arguments.first else { return .passthrough }
+
+        let invokedName = (invokedPath as NSString).lastPathComponent
+        if invokedName == commandName { return .cli }
+
+        // First token after argv[0]. A GUI launch passes none, or passes
+        // LaunchServices noise like `-psn_0_123` / `-NSDocument…` which
+        // matches neither set below.
+        if let first = arguments.dropFirst().first {
+            if cliFlags.contains(first) { return .cli }
+            if knownCommands.contains(first) { return .cli }
+        }
+        return .passthrough
+    }
+}

--- a/Lupen/CLI/CLIEngine.swift
+++ b/Lupen/CLI/CLIEngine.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Single point of store access for the CLI. Opens the per-provider
+/// SQLite index the GUI app maintains, optionally refreshes it from the
+/// source logs, and exposes its `ProviderStore` (which conforms to
+/// `ReportsRepository`) to the subcommands.
+///
+/// `ProviderDatabase`/`ProviderStore` are `Sendable` and carry no
+/// `@MainActor` constraint, so they run fine in a CLI process with no run
+/// loop (GRDB is synchronous). The index is just a cache of the raw
+/// `~/.claude` / `~/.codex` logs, so the CLI is self-sufficient: it never
+/// requires the app to have run — a cold first run builds the index from
+/// the logs itself (see `CLIRefresher`).
+///
+/// Opening the index is itself a write: `ProviderDatabase.open` creates the
+/// provider directory and bootstraps (or, on a schema bump, rebuilds) the
+/// schema. The refresh that follows populates it; the report queries are
+/// read-only. A cross-process lock (`CLIProcessLock`) keeps two concurrent
+/// `lupen` refreshes from doing duplicate work.
+struct CLIEngine {
+    let provider: ProviderKind
+    let store: ProviderStore
+    let bootstrapOutcome: ProviderDatabase.BootstrapOutcome
+    /// Whether a refresh was requested (false under `--no-refresh`).
+    let didRefresh: Bool
+    /// Result of the refresh, or nil when none was requested.
+    let refreshOutcome: CLIRefresher.Outcome?
+
+    static func open(
+        provider: ProviderKind,
+        refresh: Bool,
+        appSupportRoot: URL = LupenPaths.applicationSupportRoot(),
+        progress: (String) -> Void = { CLIOutput.note($0) }
+    ) throws -> CLIEngine {
+        let database = try ProviderDatabase.open(provider: provider, appSupportRoot: appSupportRoot)
+        let store = ProviderStore(database: database)
+
+        var outcome: CLIRefresher.Outcome?
+        if refresh {
+            let lockURL = LupenPaths.refreshLockURL(for: provider, appSupportRoot: appSupportRoot)
+            if let lock = CLIProcessLock.acquire(at: lockURL, timeout: 30) {
+                defer { lock.release() }
+                outcome = CLIRefresher.run(
+                    source: CLIRefresher.source(for: provider),
+                    store: store,
+                    progress: progress
+                )
+            } else {
+                outcome = .skippedLockHeld
+            }
+        }
+
+        return CLIEngine(
+            provider: provider,
+            store: store,
+            bootstrapOutcome: database.outcome,
+            didRefresh: refresh,
+            refreshOutcome: outcome
+        )
+    }
+
+    /// Optional one-line freshness hint for stderr (keeps stdout clean for
+    /// piped consumers). Stays quiet when nothing notable happened.
+    func freshnessNote() -> String? {
+        Self.freshnessNote(
+            bootstrap: bootstrapOutcome,
+            didRefresh: didRefresh,
+            outcome: refreshOutcome
+        )
+    }
+
+    /// Pure freshness-message logic (no store access), so the branch
+    /// matrix is unit-testable.
+    static func freshnessNote(
+        bootstrap: ProviderDatabase.BootstrapOutcome,
+        didRefresh: Bool,
+        outcome: CLIRefresher.Outcome?
+    ) -> String? {
+        if case .rebuilt = bootstrap {
+            // A schema bump wipes the index on open. Only a refresh repopulates
+            // it — under --no-refresh the index is empty and the report is zeros,
+            // so don't claim a reindex that didn't happen.
+            return didRefresh
+                ? "Index rebuilt for a new version — reindexed from your logs."
+                : "Index reset for a new version — run without --no-refresh to reindex."
+        }
+        guard didRefresh else {
+            return "Showing the on-disk index (--no-refresh)."
+        }
+        guard let outcome else { return nil }
+        if outcome.skipped {
+            return "Another Lupen process is indexing; showing the current index."
+        }
+        if outcome.imported > 0 {
+            let plural = outcome.imported == 1 ? "" : "s"
+            return "↻ Indexed \(outcome.imported) updated session\(plural)."
+        }
+        return nil
+    }
+}

--- a/Lupen/CLI/CLIOutput.swift
+++ b/Lupen/CLI/CLIOutput.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Rendering helpers for CLI output. Two formats: a plain human table
+/// (default) and `--json` for scripting/piping. Progress and hints go to
+/// stderr (`CLIOutput.note`) so a `lupen … --json | jq` pipeline only
+/// ever sees clean JSON on stdout.
+enum CLIOutput {
+    /// Print a human-facing line to stdout.
+    static func line(_ string: String = "") {
+        print(string)
+    }
+
+    /// Print a hint/progress message to stderr, keeping stdout clean for
+    /// piped consumers.
+    static func note(_ string: String) {
+        FileHandle.standardError.write(Data((string + "\n").utf8))
+    }
+
+    /// Serialize a JSON-object/array value to stdout (pretty, stable key
+    /// order for diff-friendly output).
+    static func printJSON(_ object: Any) throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        if let string = String(data: data, encoding: .utf8) {
+            print(string)
+        }
+    }
+}
+
+/// Value formatting shared across subcommands. Kept dependency-free
+/// (no `NumberFormatter`, which is non-`Sendable` and awkward as a static)
+/// so it stays trivially correct under Swift 6 strict concurrency.
+enum CLIFormat {
+    /// `$12.40`. Two decimal places, matching the GUI's cost display.
+    static func money(_ value: Double) -> String {
+        String(format: "$%.2f", value)
+    }
+
+    /// Thousands-grouped integer, e.g. `8,231,004`. Uses `.magnitude`
+    /// rather than `abs()` so `Int.min` formats instead of trapping.
+    static func int(_ value: Int) -> String {
+        let negative = value < 0
+        var grouped = ""
+        var count = 0
+        for character in String(value.magnitude).reversed() {
+            if count != 0, count % 3 == 0 { grouped.append(",") }
+            grouped.append(character)
+            count += 1
+        }
+        return (negative ? "-" : "") + String(grouped.reversed())
+    }
+}
+
+extension ProviderKind {
+    /// Display name for CLI headers.
+    var cliLabel: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .codex:      return "Codex"
+        }
+    }
+}

--- a/Lupen/CLI/CLIProcessLock.swift
+++ b/Lupen/CLI/CLIProcessLock.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Darwin
+
+/// Cross-process advisory lock (POSIX `flock`) guarding the CLI's index
+/// refresh. Two concurrent `lupen` invocations would otherwise both run a
+/// full cold index into the same SQLite file — correct (writes are
+/// idempotent and WAL serialises them) but wasteful. Holding this lock
+/// around the refresh means only one process indexes at a time; the other
+/// waits briefly, then reads whatever the winner produced.
+///
+/// `flock` is advisory and per-open-file-description, so it also conflicts
+/// across separate `open()`s within one process — which is exactly what
+/// makes the behaviour unit-testable. It does not (and need not) prevent
+/// the GUI app from writing concurrently: GRDB's WAL + 5 s busy timeout
+/// already guarantee no corruption there; this lock only coordinates
+/// CLI-vs-CLI refresh work.
+final class CLIProcessLock {
+    private let fileDescriptor: Int32
+    private var released = false
+
+    private init(fileDescriptor: Int32) {
+        self.fileDescriptor = fileDescriptor
+    }
+
+    /// Acquire an exclusive lock on `url`, retrying (~100 ms steps) up to
+    /// `timeout`. Returns `nil` if another process holds it past the
+    /// timeout, or if the lock file can't be opened — callers then proceed
+    /// lock-less (reading the current index) rather than failing.
+    static func acquire(at url: URL, timeout: TimeInterval) -> CLIProcessLock? {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // O_NOFOLLOW + 0600: the lock lives in the user's own app-support dir
+        // and its contents are never read or written (we only flock the fd),
+        // so refuse to follow a symlink planted at the path and keep it private.
+        // A failed open just means we proceed lock-less, which is the documented
+        // fallback.
+        let descriptor = open(url.path, O_RDWR | O_CREAT | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else { return nil }
+
+        var remainingSteps = max(0, Int((timeout / 0.1).rounded()))
+        while true {
+            if flock(descriptor, LOCK_EX | LOCK_NB) == 0 {
+                return CLIProcessLock(fileDescriptor: descriptor)
+            }
+            // EWOULDBLOCK → held elsewhere; anything else is a real error.
+            if errno != EWOULDBLOCK {
+                close(descriptor)
+                return nil
+            }
+            if remainingSteps <= 0 {
+                close(descriptor)
+                return nil
+            }
+            remainingSteps -= 1
+            usleep(100_000)  // 100 ms
+        }
+    }
+
+    /// Release the lock and close the descriptor. Idempotent.
+    func release() {
+        guard !released else { return }
+        released = true
+        flock(fileDescriptor, LOCK_UN)
+        close(fileDescriptor)
+    }
+
+    /// Safety net: if a caller ever drops the lock without calling `release()`,
+    /// don't leak the descriptor or hold the advisory lock for the rest of the
+    /// process. (Production callers use `defer { release() }`; this guards
+    /// future ones.)
+    deinit {
+        if !released {
+            flock(fileDescriptor, LOCK_UN)
+            close(fileDescriptor)
+        }
+    }
+}

--- a/Lupen/CLI/CLIRefresher.swift
+++ b/Lupen/CLI/CLIRefresher.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Incrementally refreshes a provider's SQLite index from its source logs
+/// before the CLI queries it — the headless equivalent of what the GUI app
+/// does on launch. Drives the very same `ProviderIndexCoordinator`
+/// (fingerprint-based incremental scan → priority-ordered detail imports)
+/// so the CLI and the app stay byte-for-byte consistent; there is no
+/// second, divergent import path.
+///
+/// Blocking by design: a one-shot `lupen` run wants the freshest numbers,
+/// so it waits for the import queue to drain. The first run on a cold index
+/// can take a while (full backfill); subsequent runs are cheap because
+/// unchanged files are skipped by fingerprint.
+enum CLIRefresher {
+    struct Outcome: Sendable, Equatable {
+        /// Units (sessions) imported or re-imported this run.
+        let imported: Int
+        /// Units that failed (kept their prior state; retried next run).
+        let failed: Int
+        /// True when the refresh was skipped (another process held the
+        /// lock) and the caller is reading the current on-disk index.
+        let skipped: Bool
+
+        static let skippedLockHeld = Outcome(imported: 0, failed: 0, skipped: true)
+    }
+
+    /// Production source directory for a provider (honours the same
+    /// `CLAUDE_CONFIG_DIR` / `CODEX_HOME` overrides as the GUI app).
+    static func source(for provider: ProviderKind) -> ProviderIndexSource {
+        switch provider {
+        case .claudeCode: return .claude(projectsDirectory: FileDiscovery().projectsDirectory)
+        case .codex:      return .codex(codexHome: CodexSessionDiscovery().codexHome)
+        }
+    }
+
+    /// Run one refresh generation to completion and report the tally.
+    /// `progress` is invoked (on the calling thread) at most every
+    /// `progressInterval` while a long cold index drains.
+    static func run(
+        source: ProviderIndexSource,
+        store: ProviderStore,
+        progressInterval: TimeInterval = 3,
+        progress: (String) -> Void = { _ in }
+    ) -> Outcome {
+        let coordinator = ProviderIndexCoordinator(source: source, store: store)
+        let tally = Tally()
+        coordinator.start(eventSink: { event in tally.record(event) })
+        // `waitUntilIdle` returns as soon as the queue drains, or after the
+        // interval if still working — so a fast/incremental refresh returns
+        // immediately and only a slow cold index emits progress.
+        while !coordinator.waitUntilIdle(timeout: progressInterval) {
+            let snapshot = tally.snapshot()
+            progress("indexing… \(snapshot.imported) session(s) so far")
+        }
+        // Match the GUI's on-idle reconciliation: collapse compact-continuation
+        // replays onto their canonical session and re-finalize per-session costs,
+        // so resume/replay sessions report the same numbers Verify Costs computes.
+        // Idempotent — a no-op once the lineage map has settled.
+        _ = try? ClaudeContinuationResolver.run(store: store)
+        let snapshot = tally.snapshot()
+        return Outcome(imported: snapshot.imported, failed: snapshot.failed, skipped: false)
+    }
+
+    /// Thread-safe event accumulator: the coordinator delivers events on
+    /// its own queue while the caller blocks in `waitUntilIdle`.
+    private final class Tally: @unchecked Sendable {
+        private let lock = NSLock()
+        private var imported = 0
+        private var failed = 0
+
+        func record(_ event: ProviderIndexEvent) {
+            lock.lock()
+            defer { lock.unlock() }
+            switch event {
+            case .unitImported: imported += 1
+            case .unitFailed: failed += 1
+            case .metadataScanCompleted, .idle: break
+            }
+        }
+
+        func snapshot() -> (imported: Int, failed: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (imported, failed)
+        }
+    }
+}

--- a/Lupen/CLI/CLITable.swift
+++ b/Lupen/CLI/CLITable.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Darwin
+
+/// Minimal fixed-width table renderer shared by the report subcommands.
+/// Numeric columns right-align; the header bolds when color is enabled.
+/// Display width is grapheme count — fine for the ASCII/number cells the
+/// reports emit. Cells are sanitized of control characters before
+/// measuring/printing, so an attacker-influenced value (skill names come
+/// from prompt text) can't inject ANSI escapes or break column alignment.
+struct CLITable {
+    enum Align { case left, right }
+
+    struct Column {
+        let header: String
+        let align: Align
+        init(_ header: String, align: Align = .left) {
+            self.header = header
+            self.align = align
+        }
+    }
+
+    let columns: [Column]
+    let rows: [[String]]
+
+    func render(color: Bool) -> String {
+        let headers = columns.map { Self.sanitize($0.header) }
+        let safeRows = rows.map { $0.map(Self.sanitize) }
+
+        var widths = headers.map { $0.count }
+        for row in safeRows {
+            for (index, cell) in row.enumerated() where index < widths.count {
+                widths[index] = max(widths[index], cell.count)
+            }
+        }
+
+        func pad(_ value: String, width: Int, align: Align) -> String {
+            let gap = max(0, width - value.count)
+            let spaces = String(repeating: " ", count: gap)
+            return align == .left ? value + spaces : spaces + value
+        }
+
+        func line(_ cells: [String]) -> String {
+            columns.enumerated().map { index, column in
+                pad(index < cells.count ? cells[index] : "", width: widths[index], align: column.align)
+            }
+            .joined(separator: "  ")
+        }
+
+        var lines: [String] = []
+        let headerLine = line(headers)
+        lines.append(color ? CLIStyle.bold(headerLine) : headerLine)
+        lines.append(contentsOf: safeRows.map(line))
+        // Trim trailing padding so right-most left-aligned cells don't carry
+        // a ragged tail of spaces.
+        return lines
+            .map { $0.replacingOccurrences(of: "[ ]+$", with: "", options: .regularExpression) }
+            .joined(separator: "\n")
+    }
+
+    /// Strip C0 control characters (incl. ESC, TAB, NUL) and DEL. ESC would
+    /// otherwise reach the terminal as a live escape sequence (even under
+    /// --no-color) and inflate the grapheme count used for alignment.
+    static func sanitize(_ value: String) -> String {
+        String(String.UnicodeScalarView(
+            value.unicodeScalars.filter { $0.value >= 0x20 && $0.value != 0x7F }
+        ))
+    }
+}
+
+/// CSV serialization with RFC-4180 quoting plus spreadsheet formula-injection
+/// guarding. Fields are produced by `render`; `escape` is the RFC step alone.
+enum CLICSV {
+    static func render(header: [String], rows: [[String]]) -> String {
+        ([header] + rows)
+            .map { $0.map(field).joined(separator: ",") }
+            .joined(separator: "\n")
+    }
+
+    /// A fully-prepared CSV field: control-sanitized, formula-guarded, then
+    /// RFC-4180 quoted.
+    static func field(_ raw: String) -> String {
+        escape(guardingFormula(sanitize(raw)))
+    }
+
+    /// Strip control characters that would inject ANSI when a `.csv` is later
+    /// viewed in a terminal — but keep newlines, which are legitimate
+    /// multi-line field content that RFC-4180 quoting handles. (Skill/session
+    /// names and titles come from prompt text, so they're untrusted.)
+    static func sanitize(_ value: String) -> String {
+        String(String.UnicodeScalarView(value.unicodeScalars.filter {
+            $0.value == 0x0A || ($0.value >= 0x20 && $0.value != 0x7F)
+        }))
+    }
+
+    /// Neutralize spreadsheet formula injection: a field whose first
+    /// character is `= + - @` (or a leading tab/CR that some apps treat as
+    /// a formula lead-in) is prefixed with a single quote so Excel / Sheets
+    /// / LibreOffice render it as text. Skill names flow from prompt input,
+    /// so `/=cmd(...)` would otherwise become a live cell formula.
+    static func guardingFormula(_ field: String) -> String {
+        guard let first = field.first, "=+-@\t\r".contains(first) else { return field }
+        return "'" + field
+    }
+
+    /// RFC-4180 quoting: quote fields containing a comma, quote, or newline;
+    /// double embedded quotes.
+    static func escape(_ field: String) -> String {
+        guard field.contains(",") || field.contains("\"") || field.contains("\n") else {
+            return field
+        }
+        return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+}
+
+/// Terminal styling helpers. Color is on only for an interactive stdout
+/// with color not disabled by `--no-color` or the `NO_COLOR` convention.
+enum CLIStyle {
+    static func useColor(disabled: Bool) -> Bool {
+        if disabled { return false }
+        if ProcessInfo.processInfo.environment["NO_COLOR"] != nil { return false }
+        return isatty(fileno(stdout)) != 0
+    }
+
+    static func bold(_ text: String) -> String {
+        "\u{001B}[1m\(text)\u{001B}[0m"
+    }
+}

--- a/Lupen/CLI/Commands/BreakdownCommands.swift
+++ b/Lupen/CLI/Commands/BreakdownCommands.swift
@@ -1,0 +1,171 @@
+import ArgumentParser
+import Foundation
+
+// Single-dimension cost breakdowns that reuse one report type: per-model
+// and per-project. Both are "labeled rows of (count, cost)".
+
+struct ModelsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "models",
+        abstract: "Cost and usage per model.",
+        discussion: "Sort with --sort cost (default), count, or name."
+    )
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+
+    func run() throws {
+        let range = try options.resolveRange()
+        let sort = try BreakdownSort.parse(rowOptions.sort, default: .cost)
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let rows = try engine.store.modelUsageAggregates(from: range.from, to: range.to)
+            .map { CLIBreakdownReport.Row(key: $0.model, count: $0.usageCount, costUSD: $0.costUSD) }
+        try CLIBreakdownReport(
+            provider: options.provider, periodLabel: options.periodLabel,
+            keyName: "model", labelHeader: "MODEL", countHeader: "USES", countNoun: "model",
+            rows: rows, sort: sort, limit: rowOptions.limit
+        ).emit(options: options)
+    }
+}
+
+struct ProjectsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "projects",
+        abstract: "Cost and session count per project.",
+        discussion: "Sort with --sort cost (default), count, or name."
+    )
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+
+    func run() throws {
+        let range = try options.resolveRange()
+        let sort = try BreakdownSort.parse(rowOptions.sort, default: .cost)
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let rows = try engine.store.projectAggregates(from: range.from, to: range.to)
+            .map { CLIBreakdownReport.Row(key: $0.projectPath ?? "(unknown)", count: $0.sessionCount, costUSD: $0.costUSD) }
+        try CLIBreakdownReport(
+            provider: options.provider, periodLabel: options.periodLabel,
+            keyName: "project", labelHeader: "PROJECT", countHeader: "SESSIONS", countNoun: "project",
+            rows: rows, sort: sort, limit: rowOptions.limit,
+            displayTransform: ProjectLabelFormatter.decode
+        ).emit(options: options)
+    }
+}
+
+enum BreakdownSort: String {
+    case cost, count, name
+
+    static func parse(_ raw: String?, default fallback: BreakdownSort) throws -> BreakdownSort {
+        guard let raw else { return fallback }
+        guard let sort = BreakdownSort(rawValue: raw.lowercased()) else {
+            throw ValidationError("Invalid --sort '\(raw)'. Use cost, count, or name.")
+        }
+        return sort
+    }
+}
+
+/// Shared "label · count · cost" breakdown (models, projects).
+struct CLIBreakdownReport {
+    struct Row: Equatable {
+        let key: String
+        let count: Int
+        let costUSD: Double
+        var avgCostUSD: Double { count > 0 ? costUSD / Double(count) : 0 }
+    }
+
+    let provider: ProviderKind
+    let periodLabel: String
+    let keyName: String          // JSON/CSV key for the label column
+    let labelHeader: String
+    let countHeader: String
+    let countNoun: String
+    /// Table-only label prettifier (e.g. decode a munged project path). The
+    /// raw key is preserved in --json/--csv for scripting.
+    let displayTransform: (String) -> String
+
+    /// Rows shown after sort + limit.
+    let shownRows: [Row]
+    /// All rows in the period (pre-limit) for the footer.
+    let totalGroups: Int
+    let totalCostUSD: Double
+
+    init(
+        provider: ProviderKind, periodLabel: String,
+        keyName: String, labelHeader: String, countHeader: String, countNoun: String,
+        rows: [Row], sort: BreakdownSort, limit: Int?,
+        displayTransform: @escaping (String) -> String = { $0 }
+    ) {
+        self.provider = provider
+        self.periodLabel = periodLabel
+        self.keyName = keyName
+        self.labelHeader = labelHeader
+        self.countHeader = countHeader
+        self.countNoun = countNoun
+        self.displayTransform = displayTransform
+        self.totalGroups = rows.count
+        self.totalCostUSD = rows.reduce(0) { $0 + $1.costUSD }
+        self.shownRows = CLIBreakdownReport.sortedLimited(rows, sort: sort, limit: limit)
+    }
+
+    static func sortedLimited(_ rows: [Row], sort: BreakdownSort, limit: Int?) -> [Row] {
+        var rows = rows
+        switch sort {
+        case .cost:  rows.sort { $0.costUSD != $1.costUSD ? $0.costUSD > $1.costUSD : $0.key < $1.key }
+        case .count: rows.sort { $0.count != $1.count ? $0.count > $1.count : $0.key < $1.key }
+        case .name:  rows.sort { $0.key < $1.key }
+        }
+        if let limit, limit >= 0, rows.count > limit {
+            rows = Array(rows.prefix(limit))
+        }
+        return rows
+    }
+
+    func emit(options: CLIGlobalOptions) throws {
+        if options.json {
+            try CLIOutput.printJSON(jsonArray)
+        } else if options.csv {
+            CLIOutput.line(csv)
+        } else {
+            printTable(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+    }
+
+    func printTable(color: Bool) {
+        guard !shownRows.isEmpty else {
+            CLIOutput.line("No usage for \(periodLabel).")
+            return
+        }
+        CLIOutput.line("\(provider.cliLabel) · \(periodLabel)")
+        CLIOutput.line()
+
+        let table = CLITable(
+            columns: [
+                .init(labelHeader),
+                .init(countHeader, align: .right),
+                .init("COST", align: .right),
+                .init("$/\(countNoun.uppercased())", align: .right),
+            ],
+            rows: shownRows.map { [displayTransform($0.key), CLIFormat.int($0.count), CLIFormat.money($0.costUSD), CLIFormat.money($0.avgCostUSD)] }
+        )
+        CLIOutput.line(table.render(color: color))
+        CLIOutput.line()
+        let prefix = shownRows.count < totalGroups
+            ? "TOTAL  top \(shownRows.count) of \(totalGroups) \(countNoun)s"
+            : "TOTAL  \(totalGroups) \(countNoun)(s)"
+        CLIOutput.line("\(prefix) · \(CLIFormat.money(totalCostUSD))")
+    }
+
+    var jsonArray: [[String: Any]] {
+        shownRows.map { [keyName: $0.key, "count": $0.count, "costUsd": $0.costUSD, "avgCostUsd": $0.avgCostUSD] }
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: [keyName, "count", "costUsd", "avgCostUsd"],
+            rows: shownRows.map { [$0.key, String($0.count), String(format: "%.6f", $0.costUSD), String(format: "%.6f", $0.avgCostUSD)] }
+        )
+    }
+}

--- a/Lupen/CLI/Commands/BudgetStatuslineCommands.swift
+++ b/Lupen/CLI/Commands/BudgetStatuslineCommands.swift
@@ -1,0 +1,124 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen budget --over <usd>` — exit 4 when spend over the period exceeds
+/// a threshold. A CI / cron / pre-commit guard ("fail if this week cost
+/// more than $20").
+struct BudgetCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "budget",
+        abstract: "Exit 4 when spend exceeds a threshold (a CI / cron guard).",
+        discussion: "Scope with --last/--month/--since/--until; default is all time. Exit 0 = within, 4 = over."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+    @Option(name: .long, help: "Budget in USD. Spend above this exits 4.")
+    var over: Double
+
+    func validate() throws {
+        // Reject nan/inf: `nan < 0` is false and `cost > nan` is always
+        // false, so a non-finite threshold would make the gate never trip.
+        guard over.isFinite else { throw ValidationError("--over must be a finite number.") }
+        if over < 0 { throw ValidationError("--over must be 0 or greater.") }
+    }
+
+    func run() throws {
+        let range = try options.resolveRange()
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let report = CLIBudgetReport(
+            provider: options.provider, periodLabel: options.periodLabel,
+            costUSD: try engine.store.totalCostUSD(from: range.from, to: range.to),
+            budgetUSD: over
+        )
+        if options.json {
+            try CLIOutput.printJSON(report.jsonObject)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            CLIOutput.line(report.line)
+        }
+        if report.isOver { throw ExitCode(4) }
+    }
+}
+
+struct CLIBudgetReport {
+    let provider: ProviderKind
+    let periodLabel: String
+    let costUSD: Double
+    let budgetUSD: Double
+
+    var isOver: Bool { costUSD > budgetUSD }
+
+    var line: String {
+        let status = isOver ? "OVER budget" : "within budget"
+        return "\(provider.cliLabel) · \(periodLabel): \(CLIFormat.money(costUSD)) of \(CLIFormat.money(budgetUSD)) — \(status)"
+    }
+
+    var jsonObject: [String: Any] {
+        [
+            "provider": provider.rawValue,
+            "period": periodLabel,
+            "costUsd": costUSD,
+            "budgetUsd": budgetUSD,
+            "overBudget": isOver,
+        ]
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: ["provider", "period", "costUsd", "budgetUsd", "overBudget"],
+            rows: [[provider.rawValue, periodLabel, String(format: "%.6f", costUSD), String(format: "%.6f", budgetUSD), String(isOver)]]
+        )
+    }
+}
+
+/// `lupen statusline` — a single compact spend figure for a shell prompt,
+/// tmux, or a Claude Code `statusLine.command`. Defaults to today's spend
+/// and never refreshes (it must be instant on every prompt render). This is
+/// NOT the internal `--statusline-tap` helper (which samples rate limits).
+struct StatuslineCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "statusline",
+        abstract: "A compact one-line spend figure for a shell prompt / statusline."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+
+    func run() throws {
+        let range = try CLIStatusline.range(
+            last: options.last, month: options.month, since: options.since, until: options.until,
+            now: Date(), calendar: .current
+        )
+        // Never refresh: a statusline runs on every prompt render and must
+        // not block importing logs. (Opening the index may create it on a
+        // first run, or rebuild it after an app-version schema bump, but it
+        // never imports.) Stay silent — no freshness note — so a bare
+        // `$(lupen statusline)` capture is a single clean token.
+        let engine = try CLIEngine.open(provider: options.provider, refresh: false)
+        let cost = try engine.store.totalCostUSD(from: range.from, to: range.to)
+
+        if options.json {
+            try CLIOutput.printJSON(["provider": options.provider.rawValue, "costUsd": cost])
+        } else if options.csv {
+            CLIOutput.line(CLICSV.render(header: ["costUsd"], rows: [[String(format: "%.6f", cost)]]))
+        } else {
+            CLIOutput.line(CLIFormat.money(cost))
+        }
+    }
+}
+
+enum CLIStatusline {
+    /// Period for the statusline: today (start of day → now) when no period
+    /// flag is given, otherwise the resolved window.
+    static func range(
+        last: String?, month: String?, since: String?, until: String?,
+        now: Date, calendar: Calendar
+    ) throws -> CLIDateRange.Resolved {
+        if last == nil, month == nil, since == nil, until == nil {
+            return CLIDateRange.Resolved(from: calendar.startOfDay(for: now), to: now)
+        }
+        return try CLIDateRange.resolve(since: since, until: until, last: last, month: month, now: now, calendar: calendar)
+    }
+}

--- a/Lupen/CLI/Commands/SearchResumeCommands.swift
+++ b/Lupen/CLI/Commands/SearchResumeCommands.swift
@@ -1,0 +1,197 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen search <text>` — full-text search across every prompt, grouped by
+/// session. Pairs with `lupen resume` to jump back into a found session.
+struct SearchCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "search",
+        abstract: "Find sessions by any prompt text they contain."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+    @Argument(help: "Text to search for (quote multi-word queries).")
+    var query: String
+    @Option(name: .long, help: "Max sessions to show.")
+    var limit = 20
+
+    func validate() throws {
+        if limit < 0 { throw ValidationError("--limit must be 0 or greater.") }
+    }
+
+    func run() throws {
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        // Sanitize the query into an FTS5 prefix expression (as the GUI's
+        // search does) so metacharacters in user input can't make MATCH
+        // throw; an all-whitespace query simply matches nothing.
+        let hits: [StoreSearchHit]
+        if let match = ProviderStore.ftsPrefixQuery(from: query) {
+            hits = try engine.store.search(matching: match, limit: 500)
+        } else {
+            hits = []
+        }
+        let report = CLISearchReport(
+            provider: options.provider, query: query,
+            rows: CLISearchReport.group(hits: hits, limit: limit)
+        )
+
+        if options.json {
+            try CLIOutput.printJSON(report.jsonArray)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            report.printTable(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+    }
+}
+
+/// Data + rendering for `lupen search`.
+struct CLISearchReport {
+    struct Row: Equatable {
+        let sessionId: String
+        let hits: Int
+        let snippet: String
+    }
+
+    let provider: ProviderKind
+    let query: String
+    let rows: [Row]
+
+    /// Group FTS hits by session (preserving FTS rank order), keep the first
+    /// snippet per session, and cap to `limit` sessions. Pure.
+    static func group(hits: [StoreSearchHit], limit: Int) -> [Row] {
+        var order: [String] = []
+        var byId: [String: (hits: Int, snippet: String)] = [:]
+        for hit in hits {
+            if byId[hit.sessionId] == nil {
+                order.append(hit.sessionId)
+                byId[hit.sessionId] = (0, hit.snippet)
+            }
+            byId[hit.sessionId]?.hits += 1
+        }
+        let rows = order.map { Row(sessionId: $0, hits: byId[$0]?.hits ?? 0, snippet: byId[$0]?.snippet ?? "") }
+        return (limit >= 0 && rows.count > limit) ? Array(rows.prefix(limit)) : rows
+    }
+
+    func printTable(color: Bool) {
+        guard !rows.isEmpty else {
+            CLIOutput.line("No matches for \"\(query)\".")
+            return
+        }
+        CLIOutput.line("\(provider.cliLabel) · search \"\(query)\"")
+        CLIOutput.line()
+        let table = CLITable(
+            columns: [.init("SESSION"), .init("HITS", align: .right), .init("MATCH")],
+            rows: rows.map { [CLITopReport.shortID($0.sessionId), CLIFormat.int($0.hits), CLITopReport.truncate($0.snippet, 70)] }
+        )
+        CLIOutput.line(table.render(color: color))
+        CLIOutput.line()
+        CLIOutput.line("\(rows.count) session(s) matched. Resume one with: lupen resume <id>  (full ids in --json)")
+    }
+
+    var jsonArray: [[String: Any]] {
+        rows.map { ["sessionId": $0.sessionId, "hits": $0.hits, "snippet": $0.snippet] }
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: ["sessionId", "hits", "snippet"],
+            rows: rows.map { [$0.sessionId, String($0.hits), $0.snippet] }
+        )
+    }
+}
+
+/// `lupen resume <id>` — print (or run) the shell command that reopens a
+/// session in its CLI (`claude --resume` / `codex resume`).
+struct ResumeCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "resume",
+        abstract: "Print the command to resume a session in its CLI.",
+        discussion: "Pass a full session id (from `lupen search` / `top --json`). --run executes it instead of printing."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+    @Argument(help: "Session id to resume.")
+    var sessionId: String
+    @Flag(name: .customLong("run"), help: "Execute the resume command instead of printing it.")
+    var runNow = false
+
+    func run() throws {
+        // Resume reads the existing index (no refresh needed to look up a known id).
+        let engine = try CLIEngine.open(provider: options.provider, refresh: false)
+        guard let row = try engine.store.session(id: sessionId) else {
+            throw ValidationError(
+                "No session '\(sessionId)' for \(options.provider.cliLabel). Use the full id from `lupen search` or `lupen top --json`."
+            )
+        }
+
+        let cwd = CLIResume.resolveCwd(provider: options.provider, projectPath: row.projectPath)
+        // Claude needs the original cwd to re-find the session, so a cd-less
+        // command wouldn't actually resume. Rather than print a broken
+        // command, fail with the bare command so the user can cd themselves.
+        if cwd == nil, options.provider == .claudeCode {
+            throw ValidationError(
+                "Couldn't resolve this session's project directory; `claude --resume` needs it. cd to the project, then run: claude --resume '\(row.rawId)'"
+            )
+        }
+        let command = SessionResumer.buildShellCommand(
+            provider: options.provider, cwd: cwd, sessionId: row.rawId
+        )
+
+        if runNow {
+            CLIResume.run(command)
+        } else {
+            // Strip control chars before printing: the command embeds the
+            // session id and decoded project path (log-derived), so an exotic
+            // control byte there must not reach the terminal raw as an escape
+            // sequence. The --run path is unaffected (its single-quoting holds).
+            CLIOutput.line(CLITable.sanitize(command))
+        }
+    }
+}
+
+enum CLIResume {
+    /// Best-effort working directory for the resume `cd` (stage-1 decode +
+    /// existence check, mirroring SessionResumer). Returns nil when it can't
+    /// be resolved — the caller decides whether that's fatal.
+    static func resolveCwd(
+        provider: ProviderKind,
+        projectPath: String?,
+        directoryExists: (String) -> Bool = CLIResume.directoryExists
+    ) -> String? {
+        guard let encoded = projectPath, !encoded.isEmpty else { return nil }
+        switch provider {
+        case .codex:
+            return directoryExists(encoded) ? encoded : nil
+        case .claudeCode:
+            let decoded = ProjectPathDecoder.decodeFullPath(encoded)
+            return directoryExists(decoded) ? decoded : nil
+        }
+    }
+
+    static func directoryExists(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    /// Run the resume command inheriting the terminal so the resumed CLI is
+    /// interactive, then exit with its status.
+    static func run(_ command: String) -> Never {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        do {
+            try process.run()
+            process.waitUntilExit()
+            exit(process.terminationStatus)
+        } catch {
+            CLIOutput.note("Failed to run resume command: \(error.localizedDescription)")
+            exit(1)
+        }
+    }
+}

--- a/Lupen/CLI/Commands/SkillsCommand.swift
+++ b/Lupen/CLI/Commands/SkillsCommand.swift
@@ -1,0 +1,200 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen skills` — per-skill usage over the period: how many times each
+/// skill ran, what it cost, the average per run, and the model it leans on.
+/// Lupen's signature view; ccusage/tokscale don't break cost down by skill.
+struct SkillsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "skills",
+        abstract: "Per-skill usage: invocations, cost, $/run, and top model.",
+        discussion: "Sort with --sort cost (default), count, or name."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+
+    func run() throws {
+        let range = try options.resolveRange()
+        let sort = try SkillSort.parse(rowOptions.sort, default: .cost)
+
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let aggregates = try engine.store.skillAggregates(from: range.from, to: range.to)
+        let modelCosts = try engine.store.skillModelCosts(from: range.from, to: range.to)
+        let rows = CLISkillsReport.build(
+            aggregates: aggregates, modelCosts: modelCosts, sort: sort, limit: rowOptions.limit
+        )
+        let report = CLISkillsReport(
+            provider: options.provider,
+            periodLabel: options.periodLabel,
+            rows: rows,
+            totalSkills: aggregates.count,
+            totalRuns: aggregates.reduce(0) { $0 + $1.invocationCount },
+            totalCostUSD: aggregates.reduce(0) { $0 + $1.costUSD }
+        )
+
+        if options.json {
+            try CLIOutput.printJSON(report.jsonArray)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            report.printTable(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+    }
+}
+
+enum SkillSort: String {
+    case cost, count, name
+
+    static func parse(_ raw: String?, default fallback: SkillSort) throws -> SkillSort {
+        guard let raw else { return fallback }
+        guard let sort = SkillSort(rawValue: raw.lowercased()) else {
+            throw ValidationError("Invalid --sort '\(raw)'. Use cost, count, or name.")
+        }
+        return sort
+    }
+}
+
+/// Data + rendering for `lupen skills`.
+struct CLISkillsReport {
+    struct Row: Equatable {
+        let skill: String
+        let runs: Int
+        let costUSD: Double
+        let topModel: String?
+
+        var avgCostUSD: Double { runs > 0 ? costUSD / Double(runs) : 0 }
+    }
+
+    let provider: ProviderKind
+    let periodLabel: String
+    /// Rows actually shown (after --limit).
+    let rows: [Row]
+    /// Totals over ALL skills in the period (pre-limit), so the TOTAL line
+    /// reflects the period rather than a truncated top-N.
+    let totalSkills: Int
+    let totalRuns: Int
+    let totalCostUSD: Double
+
+    /// Pure assembly: join aggregates with each skill's top model, sort
+    /// deterministically, and apply the row limit. Kept testable (no store).
+    static func build(
+        aggregates: [StoreSkillAggregate],
+        modelCosts: [StoreGroupedModelCost],
+        sort: SkillSort,
+        limit: Int?
+    ) -> [Row] {
+        let topModel = topModelBySkill(modelCosts)
+        var rows = aggregates.map { aggregate in
+            Row(
+                skill: aggregate.skillName,
+                runs: aggregate.invocationCount,
+                costUSD: aggregate.costUSD,
+                topModel: topModel[aggregate.skillName]
+            )
+        }
+        // Skill name is the unique secondary key, so equal cost/count rows
+        // (and the underlying SQL order, which has no tie-break) stay
+        // reproducible across runs.
+        switch sort {
+        case .cost:
+            rows.sort { $0.costUSD != $1.costUSD ? $0.costUSD > $1.costUSD : $0.skill < $1.skill }
+        case .count:
+            rows.sort { $0.runs != $1.runs ? $0.runs > $1.runs : $0.skill < $1.skill }
+        case .name:
+            rows.sort { $0.skill < $1.skill }
+        }
+        if let limit, limit >= 0, rows.count > limit {
+            rows = Array(rows.prefix(limit))
+        }
+        return rows
+    }
+
+    /// The highest-cost model for each skill. Ties break on the
+    /// lexicographically smaller model name so the pick is deterministic
+    /// regardless of the (unordered) SQL row order.
+    static func topModelBySkill(_ modelCosts: [StoreGroupedModelCost]) -> [String: String] {
+        var best: [String: (model: String, cost: Double)] = [:]
+        for entry in modelCosts {
+            if let current = best[entry.groupKey] {
+                if current.cost > entry.costUSD { continue }
+                if current.cost == entry.costUSD, current.model <= entry.model { continue }
+            }
+            best[entry.groupKey] = (entry.model, entry.costUSD)
+        }
+        return best.mapValues(\.model)
+    }
+
+    // MARK: - Rendering
+
+    func printTable(color: Bool) {
+        guard !rows.isEmpty else {
+            CLIOutput.line("No skill usage for \(periodLabel).")
+            return
+        }
+        CLIOutput.line("\(provider.cliLabel) · \(periodLabel)")
+        CLIOutput.line()
+
+        let table = CLITable(
+            columns: [
+                .init("SKILL"),
+                .init("RUNS", align: .right),
+                .init("COST", align: .right),
+                .init("$/RUN", align: .right),
+                .init("TOP MODEL"),
+            ],
+            rows: rows.map { row in
+                [
+                    row.skill,
+                    CLIFormat.int(row.runs),
+                    CLIFormat.money(row.costUSD),
+                    CLIFormat.money(row.avgCostUSD),
+                    row.topModel ?? "—",
+                ]
+            }
+        )
+        CLIOutput.line(table.render(color: color))
+        CLIOutput.line()
+        CLIOutput.line(totalLine)
+    }
+
+    /// TOTAL reflects ALL skills in the period; flags when the table shows
+    /// only a top-N subset so the total doesn't read as the shown rows' sum.
+    var totalLine: String {
+        let runs = CLIFormat.int(totalRuns)
+        let cost = CLIFormat.money(totalCostUSD)
+        if rows.count < totalSkills {
+            return "TOTAL  top \(rows.count) of \(totalSkills) skills · \(runs) run(s) · \(cost)"
+        }
+        return "TOTAL  \(totalSkills) skill(s) · \(runs) run(s) · \(cost)"
+    }
+
+    var jsonArray: [[String: Any]] {
+        rows.map { row in
+            [
+                "skill": row.skill,
+                "runs": row.runs,
+                "costUsd": row.costUSD,
+                "avgCostUsd": row.avgCostUSD,
+                "topModel": row.topModel as Any? ?? NSNull(),
+            ]
+        }
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: ["skill", "runs", "costUsd", "avgCostUsd", "topModel"],
+            rows: rows.map { row in
+                [
+                    row.skill,
+                    String(row.runs),
+                    String(format: "%.6f", row.costUSD),
+                    String(format: "%.6f", row.avgCostUSD),
+                    row.topModel ?? "",
+                ]
+            }
+        )
+    }
+}

--- a/Lupen/CLI/Commands/SummaryCommand.swift
+++ b/Lupen/CLI/Commands/SummaryCommand.swift
@@ -1,0 +1,110 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen summary` (the default subcommand) — whole-period totals for the
+/// selected provider: cost, sessions, turns, requests, and a token
+/// breakdown.
+struct SummaryCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "summary",
+        abstract: "Show cost and usage totals for the selected period."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+
+    func run() throws {
+        let range = try options.resolveRange()
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let totals = try engine.store.usageTotals(from: range.from, to: range.to)
+        let counts = try engine.store.requestActivityCounts(from: range.from, to: range.to)
+
+        let report = CLISummaryReport(
+            provider: options.provider,
+            periodLabel: options.periodLabel,
+            range: range,
+            totals: totals,
+            sessionCount: counts.sessionCount,
+            turnCount: counts.turnCount
+        )
+
+        if options.json {
+            try CLIOutput.printJSON(report.jsonObject)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            report.printTable()
+        }
+    }
+}
+
+/// Data + rendering for `lupen summary`.
+struct CLISummaryReport {
+    let provider: ProviderKind
+    let periodLabel: String
+    let range: CLIDateRange.Resolved
+    let totals: StoreUsageTotals
+    let sessionCount: Int
+    let turnCount: Int
+
+    func printTable() {
+        CLIOutput.line("\(provider.cliLabel) · \(periodLabel)")
+        CLIOutput.line()
+        CLIOutput.line("  Cost      \(CLIFormat.money(totals.costUSD))")
+        CLIOutput.line("  Sessions  \(CLIFormat.int(sessionCount))")
+        CLIOutput.line("  Turns     \(CLIFormat.int(turnCount))")
+        CLIOutput.line("  Requests  \(CLIFormat.int(totals.requestCount))")
+        CLIOutput.line("  Tokens    \(CLIFormat.int(totals.contextTokens))")
+    }
+
+    var jsonObject: [String: Any] {
+        [
+            "provider": provider.rawValue,
+            "period": [
+                "label": periodLabel,
+                "from": Self.iso(range.from),
+                "to": Self.iso(range.to),
+            ],
+            "costUsd": totals.costUSD,
+            "sessions": sessionCount,
+            "turns": turnCount,
+            "requests": totals.requestCount,
+            "tokens": [
+                "input": totals.inputTokens,
+                "output": totals.outputTokens,
+                "reasoning": totals.reasoningOutputTokens,
+                "cacheCreation": totals.cacheCreationInputTokens,
+                "cacheRead": totals.cacheReadInputTokens,
+                "context": totals.contextTokens,
+            ],
+        ]
+    }
+
+    /// ISO-8601 (UTC) string for a bound, or JSON `null` when unbounded.
+    private static func iso(_ date: Date?) -> Any {
+        guard let date else { return NSNull() }
+        return ISO8601DateFormatter().string(from: date)
+    }
+
+    /// Key/value CSV (a single report, so one metric per row).
+    var csv: String {
+        CLICSV.render(
+            header: ["metric", "value"],
+            rows: [
+                ["provider", provider.rawValue],
+                ["period", periodLabel],
+                ["costUsd", String(format: "%.6f", totals.costUSD)],
+                ["sessions", String(sessionCount)],
+                ["turns", String(turnCount)],
+                ["requests", String(totals.requestCount)],
+                ["inputTokens", String(totals.inputTokens)],
+                ["outputTokens", String(totals.outputTokens)],
+                ["reasoningTokens", String(totals.reasoningOutputTokens)],
+                ["cacheCreationTokens", String(totals.cacheCreationInputTokens)],
+                ["cacheReadTokens", String(totals.cacheReadInputTokens)],
+                ["contextTokens", String(totals.contextTokens)],
+            ]
+        )
+    }
+}

--- a/Lupen/CLI/Commands/TimeReportCommands.swift
+++ b/Lupen/CLI/Commands/TimeReportCommands.swift
@@ -1,0 +1,234 @@
+import ArgumentParser
+import Foundation
+
+// Time-series reports: cost/usage per day, week, or month. All three roll
+// up the store's per-day buckets (local-time, as in the GUI Reports view)
+// in pure code, so they share one report type and renderer. Weekly grouping
+// uses ISO weeks (Monday start) regardless of locale — the GUI's "this week"
+// follows the user's locale instead; the CLI deliberately fixes Monday.
+
+private let timeSortDiscussion = "Sort with --sort date (default) or cost. --limit keeps the most recent N (or the costliest N under --sort cost)."
+
+struct DailyCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "daily", abstract: "Cost and usage per day.", discussion: timeSortDiscussion
+    )
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+    func run() throws { try TimeReportRunner.run(granularity: .day, options: options, rowOptions: rowOptions) }
+}
+
+struct WeeklyCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "weekly", abstract: "Cost and usage per ISO week (Monday start).", discussion: timeSortDiscussion
+    )
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+    func run() throws { try TimeReportRunner.run(granularity: .week, options: options, rowOptions: rowOptions) }
+}
+
+struct MonthlyCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "monthly", abstract: "Cost and usage per calendar month.", discussion: timeSortDiscussion
+    )
+    @OptionGroup var options: CLIGlobalOptions
+    @OptionGroup var rowOptions: CLIRowOptions
+    func run() throws { try TimeReportRunner.run(granularity: .month, options: options, rowOptions: rowOptions) }
+}
+
+enum TimeReportRunner {
+    static func run(granularity: TimeGranularity, options: CLIGlobalOptions, rowOptions: CLIRowOptions) throws {
+        let range = try options.resolveRange()
+        let sort = try TimeSort.parse(rowOptions.sort, default: .date)
+
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let daily = try engine.store.usageBuckets(hourly: false, from: range.from, to: range.to)
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: granularity, sort: sort, limit: rowOptions.limit)
+        let report = CLITimeReport(
+            provider: options.provider,
+            periodLabel: options.periodLabel,
+            granularity: granularity,
+            rows: rows,
+            totalPeriods: CLITimeReport.distinctBucketCount(dailyBuckets: daily, granularity: granularity),
+            totalCostUSD: daily.reduce(0) { $0 + $1.costUSD },
+            totalRequests: daily.reduce(0) { $0 + $1.requestCount },
+            totalTokens: daily.reduce(0) { $0 + $1.tokenCount }
+        )
+
+        if options.json {
+            try CLIOutput.printJSON(report.jsonArray)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            report.printTable(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+    }
+}
+
+enum TimeGranularity {
+    case day, week, month
+
+    var columnHeader: String {
+        switch self {
+        case .day: return "DATE"
+        case .week: return "WEEK OF"
+        case .month: return "MONTH"
+        }
+    }
+
+    var noun: String {
+        switch self {
+        case .day: return "day"
+        case .week: return "week"
+        case .month: return "month"
+        }
+    }
+}
+
+enum TimeSort: String {
+    case date, cost
+
+    static func parse(_ raw: String?, default fallback: TimeSort) throws -> TimeSort {
+        guard let raw else { return fallback }
+        guard let sort = TimeSort(rawValue: raw.lowercased()) else {
+            throw ValidationError("Invalid --sort '\(raw)'. Use date or cost.")
+        }
+        return sort
+    }
+}
+
+/// Data + rendering for the time-series reports.
+struct CLITimeReport {
+    struct Row: Equatable {
+        let label: String
+        let costUSD: Double
+        let requests: Int
+        let tokens: Int
+    }
+
+    let provider: ProviderKind
+    let periodLabel: String
+    let granularity: TimeGranularity
+    let rows: [Row]
+    /// Distinct buckets in the period (pre-limit) so TOTAL reflects the
+    /// whole period and can flag a truncated subset.
+    let totalPeriods: Int
+    let totalCostUSD: Double
+    let totalRequests: Int
+    let totalTokens: Int
+
+    /// Roll the store's per-day buckets up to the requested granularity,
+    /// sort, and limit. Pure — no store access.
+    static func build(
+        dailyBuckets: [StoreUsageBucket],
+        granularity: TimeGranularity,
+        sort: TimeSort,
+        limit: Int?
+    ) -> [Row] {
+        var byKey: [String: (cost: Double, requests: Int, tokens: Int)] = [:]
+        for bucket in dailyBuckets {
+            let key = key(forDay: bucket.bucketKey, granularity: granularity)
+            var aggregate = byKey[key] ?? (0, 0, 0)
+            aggregate.cost += bucket.costUSD
+            aggregate.requests += bucket.requestCount
+            aggregate.tokens += bucket.tokenCount
+            byKey[key] = aggregate
+        }
+        var rows = byKey.map { Row(label: $0.key, costUSD: $0.value.cost, requests: $0.value.requests, tokens: $0.value.tokens) }
+        switch sort {
+        case .date:
+            rows.sort { $0.label < $1.label }  // keys are zero-padded → lexical == chronological
+        case .cost:
+            rows.sort { $0.costUSD != $1.costUSD ? $0.costUSD > $1.costUSD : $0.label < $1.label }
+        }
+        if let limit, limit >= 0, rows.count > limit {
+            // Chronological series: keep the most RECENT N (the tail), still
+            // in ascending display order. Cost-ranked: keep the top N (head).
+            rows = sort == .date ? Array(rows.suffix(limit)) : Array(rows.prefix(limit))
+        }
+        return rows
+    }
+
+    static func distinctBucketCount(dailyBuckets: [StoreUsageBucket], granularity: TimeGranularity) -> Int {
+        Set(dailyBuckets.map { key(forDay: $0.bucketKey, granularity: granularity) }).count
+    }
+
+    /// Map a `YYYY-MM-DD` day key to its bucket key for the granularity.
+    static func key(forDay day: String, granularity: TimeGranularity) -> String {
+        switch granularity {
+        case .day: return day
+        case .month: return String(day.prefix(7))  // YYYY-MM
+        case .week: return weekStart(forDay: day) ?? day
+        }
+    }
+
+    /// Monday of the ISO week containing `day` (local time), as YYYY-MM-DD.
+    /// Falls back to the day itself if the key can't be parsed.
+    static func weekStart(forDay day: String) -> String? {
+        let parser = DateFormatter()
+        parser.locale = Locale(identifier: "en_US_POSIX")
+        parser.calendar = Calendar(identifier: .iso8601)
+        parser.timeZone = Calendar.current.timeZone
+        parser.dateFormat = "yyyy-MM-dd"
+        guard let date = parser.date(from: day) else { return nil }
+
+        var calendar = Calendar(identifier: .iso8601)  // Monday-first, ISO weeks
+        calendar.timeZone = Calendar.current.timeZone
+        guard let start = calendar.dateInterval(of: .weekOfYear, for: date)?.start else { return nil }
+        return parser.string(from: start)
+    }
+
+    // MARK: - Rendering
+
+    func printTable(color: Bool) {
+        guard !rows.isEmpty else {
+            CLIOutput.line("No usage for \(periodLabel).")
+            return
+        }
+        CLIOutput.line("\(provider.cliLabel) · \(periodLabel)")
+        CLIOutput.line()
+
+        // TOKENS is the store's per-bucket token sum (input + output + cache);
+        // it excludes Codex reasoning tokens, matching the GUI Reports buckets
+        // — so it can read slightly lower than `summary`'s context-token figure.
+        let table = CLITable(
+            columns: [
+                .init(granularity.columnHeader),
+                .init("COST", align: .right),
+                .init("REQUESTS", align: .right),
+                .init("TOKENS", align: .right),
+            ],
+            rows: rows.map { row in
+                [row.label, CLIFormat.money(row.costUSD), CLIFormat.int(row.requests), CLIFormat.int(row.tokens)]
+            }
+        )
+        CLIOutput.line(table.render(color: color))
+        CLIOutput.line()
+        CLIOutput.line(totalLine)
+    }
+
+    var totalLine: String {
+        let cost = CLIFormat.money(totalCostUSD)
+        let requests = CLIFormat.int(totalRequests)
+        let tokens = CLIFormat.int(totalTokens)
+        // "showing N of M" (not "top"): the shown rows may be the most-recent
+        // N (date sort) rather than a ranking. Totals always reflect the period.
+        let prefix = rows.count < totalPeriods
+            ? "TOTAL  showing \(rows.count) of \(totalPeriods) \(granularity.noun)s"
+            : "TOTAL  \(totalPeriods) \(granularity.noun)(s)"
+        return "\(prefix) · \(cost) · \(requests) req · \(tokens) tok"
+    }
+
+    var jsonArray: [[String: Any]] {
+        rows.map { ["period": $0.label, "costUsd": $0.costUSD, "requests": $0.requests, "tokens": $0.tokens] }
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: ["period", "costUsd", "requests", "tokens"],
+            rows: rows.map { [$0.label, String(format: "%.6f", $0.costUSD), String($0.requests), String($0.tokens)] }
+        )
+    }
+}

--- a/Lupen/CLI/Commands/TopCommand.swift
+++ b/Lupen/CLI/Commands/TopCommand.swift
@@ -1,0 +1,193 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen top` — the most expensive sessions or days in the period.
+/// Answers the question a daily total can't: "what actually ran up the
+/// bill?" Always ranked by cost, descending.
+struct TopCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "top",
+        abstract: "The most expensive sessions or days in the period.",
+        discussion: "Rank with --by sessions (default) or days; --limit sets how many (default 10)."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+    @Option(name: .long, help: "What to rank: sessions or days.")
+    var by: TopDimension = .sessions
+    @Option(name: .long, help: "How many to show.")
+    var limit = 10
+
+    func validate() throws {
+        if limit < 0 { throw ValidationError("--limit must be 0 or greater.") }
+    }
+
+    func run() throws {
+        let range = try options.resolveRange()
+
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+
+        let periodCost = try engine.store.totalCostUSD(from: range.from, to: range.to)
+        let rows: [CLITopReport.Row]
+        let totalCount: Int
+        switch by {
+        case .sessions:
+            rows = try engine.store.topSessionCosts(from: range.from, to: range.to, limit: limit)
+                .map { CLITopReport.Row(key: $0.sessionId, project: $0.projectPath, title: $0.title, costUSD: $0.costUSD, requests: $0.requestCount) }
+            // Count the same population the rows come from (visible, non-superseded),
+            // not requestActivityCounts (which counts every session with activity,
+            // incl. re-homed replay shells) — otherwise "top N of M" inflates M.
+            totalCount = try engine.store.visibleSessionCount(from: range.from, to: range.to)
+        case .days:
+            let buckets = try engine.store.usageBuckets(hourly: false, from: range.from, to: range.to)
+            rows = CLITopReport.topDays(buckets, limit: limit)
+            totalCount = buckets.count
+        }
+
+        let report = CLITopReport(
+            provider: options.provider, periodLabel: options.periodLabel,
+            dimension: by, rows: rows, totalCount: totalCount, periodCostUSD: periodCost
+        )
+        if options.json {
+            try CLIOutput.printJSON(report.jsonArray)
+        } else if options.csv {
+            CLIOutput.line(report.csv)
+        } else {
+            report.printTable(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+    }
+}
+
+enum TopDimension: String, CaseIterable, ExpressibleByArgument {
+    case sessions, days
+    static var allValueStrings: [String] { allCases.map(\.rawValue) }
+}
+
+/// Data + rendering for `lupen top`.
+struct CLITopReport {
+    struct Row: Equatable {
+        let key: String          // session id, or YYYY-MM-DD for days
+        let project: String?     // sessions only
+        let title: String?       // sessions only
+        let costUSD: Double
+        let requests: Int
+    }
+
+    let provider: ProviderKind
+    let periodLabel: String
+    let dimension: TopDimension
+    let rows: [Row]
+    /// All sessions/days in the period (pre-limit), so the footer can anchor
+    /// the shown top-N against the whole period.
+    let totalCount: Int
+    let periodCostUSD: Double
+
+    /// Top-cost days from per-day buckets (pure: sort by cost desc, take N).
+    static func topDays(_ buckets: [StoreUsageBucket], limit: Int) -> [Row] {
+        let ranked = buckets.sorted {
+            $0.costUSD != $1.costUSD ? $0.costUSD > $1.costUSD : $0.bucketKey < $1.bucketKey
+        }
+        return Array(ranked.prefix(max(0, limit)))
+            .map { Row(key: $0.bucketKey, project: nil, title: nil, costUSD: $0.costUSD, requests: $0.requestCount) }
+    }
+
+    /// Short session id for display. The full id stays in `--json`/`--csv`
+    /// for scripting.
+    static func shortID(_ id: String) -> String {
+        id.count > 8 ? String(id.prefix(8)) : id
+    }
+
+    static func truncate(_ value: String, _ max: Int) -> String {
+        value.count > max ? String(value.prefix(max - 1)) + "…" : value
+    }
+
+    // MARK: - Rendering
+
+    func printTable(color: Bool) {
+        guard !rows.isEmpty else {
+            CLIOutput.line("No usage for \(periodLabel).")
+            return
+        }
+        CLIOutput.line("\(provider.cliLabel) · \(periodLabel)")
+        CLIOutput.line()
+
+        let table: CLITable
+        switch dimension {
+        case .sessions:
+            table = CLITable(
+                columns: [
+                    .init("#", align: .right),
+                    .init("COST", align: .right),
+                    .init("REQ", align: .right),
+                    .init("SESSION"),
+                    .init("TITLE"),
+                ],
+                rows: rows.enumerated().map { index, row in
+                    [
+                        String(index + 1),
+                        CLIFormat.money(row.costUSD),
+                        CLIFormat.int(row.requests),
+                        Self.shortID(row.key),
+                        row.title.map { Self.truncate($0, 60) } ?? "—",
+                    ]
+                }
+            )
+        case .days:
+            table = CLITable(
+                columns: [
+                    .init("#", align: .right),
+                    .init("DAY"),
+                    .init("COST", align: .right),
+                    .init("REQ", align: .right),
+                ],
+                rows: rows.enumerated().map { index, row in
+                    [String(index + 1), row.key, CLIFormat.money(row.costUSD), CLIFormat.int(row.requests)]
+                }
+            )
+        }
+        CLIOutput.line(table.render(color: color))
+        CLIOutput.line()
+        CLIOutput.line(totalLine)
+    }
+
+    var totalLine: String {
+        let noun = dimension == .sessions ? "session" : "day"
+        let cost = CLIFormat.money(periodCostUSD)
+        if rows.count < totalCount {
+            return "TOTAL  top \(rows.count) of \(totalCount) \(noun)s · \(cost) period total"
+        }
+        return "TOTAL  \(totalCount) \(noun)(s) · \(cost) period total"
+    }
+
+    var jsonArray: [[String: Any]] {
+        rows.map { row in
+            switch dimension {
+            case .sessions:
+                return [
+                    "sessionId": row.key,
+                    "project": row.project as Any? ?? NSNull(),
+                    "title": row.title as Any? ?? NSNull(),
+                    "costUsd": row.costUSD,
+                    "requests": row.requests,
+                ]
+            case .days:
+                return ["day": row.key, "costUsd": row.costUSD, "requests": row.requests]
+            }
+        }
+    }
+
+    var csv: String {
+        switch dimension {
+        case .sessions:
+            return CLICSV.render(
+                header: ["sessionId", "project", "title", "costUsd", "requests"],
+                rows: rows.map { [$0.key, $0.project ?? "", $0.title ?? "", String(format: "%.6f", $0.costUSD), String($0.requests)] }
+            )
+        case .days:
+            return CLICSV.render(
+                header: ["day", "costUsd", "requests"],
+                rows: rows.map { [$0.key, String(format: "%.6f", $0.costUSD), String($0.requests)] }
+            )
+        }
+    }
+}

--- a/Lupen/CLI/Commands/UtilityCommands.swift
+++ b/Lupen/CLI/Commands/UtilityCommands.swift
@@ -1,0 +1,184 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen config` — where Lupen reads and writes for the current provider.
+/// Read-only; handy for support and "is it looking at the right place?".
+struct ConfigCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "config",
+        abstract: "Show the paths and versions Lupen uses for the current provider."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+
+    /// The (ordered) key/value rows config prints. Pure + hoisted so the
+    /// JSON/CSV key contract is unit-testable.
+    static func fields(
+        provider: ProviderKind,
+        appSupport: URL = LupenPaths.applicationSupportRoot()
+    ) -> [(String, String)] {
+        let index = LupenPaths.indexDatabaseURL(for: provider, appSupportRoot: appSupport)
+        let sourceDir = provider == .claudeCode
+            ? FileDiscovery().projectsDirectory
+            : CodexSessionDiscovery().sessionsDirectory
+        return [
+            ("version", CLIVersion.current),
+            ("schema", String(ProviderDatabase.schemaVersion)),
+            ("provider", provider.rawValue),
+            ("sourceDir", sourceDir.path),
+            ("indexDb", index.path),
+            ("appSupport", appSupport.path),
+        ]
+    }
+
+    func run() throws {
+        let fields = ConfigCommand.fields(provider: options.provider)
+
+        if options.json {
+            try CLIOutput.printJSON(Dictionary(uniqueKeysWithValues: fields.map { ($0.0, $0.1) }))
+        } else if options.csv {
+            CLIOutput.line(CLICSV.render(header: ["key", "value"], rows: fields.map { [$0.0, $0.1] }))
+        } else {
+            let width = fields.map(\.0.count).max() ?? 0
+            for (key, value) in fields {
+                CLIOutput.line("  \(key.padding(toLength: width, withPad: " ", startingAt: 0))  \(value)")
+            }
+        }
+    }
+}
+
+/// `lupen refresh` — update the index from the logs now, without a report.
+/// Useful to pre-warm the index (e.g. in a cron job before `statusline`).
+struct RefreshCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "refresh",
+        abstract: "Index new/changed logs now (no report)."
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+
+    func run() throws {
+        let engine = try CLIEngine.open(provider: options.provider, refresh: true)
+        CLIOutput.line(CLIRefreshMessage.text(for: engine.refreshOutcome))
+    }
+}
+
+/// Pure summary of a refresh outcome for `lupen refresh` — surfaces both
+/// imported and failed counts so a partial failure isn't reported as
+/// "up to date".
+enum CLIRefreshMessage {
+    static func text(for outcome: CLIRefresher.Outcome?) -> String {
+        guard let outcome else { return "Index already up to date." }
+        if outcome.skipped { return "Another Lupen process is indexing; skipped." }
+        var parts: [String] = []
+        if outcome.imported > 0 { parts.append("Indexed \(outcome.imported) updated session(s).") }
+        if outcome.failed > 0 { parts.append("\(outcome.failed) session(s) failed (retried next run).") }
+        return parts.isEmpty ? "Index already up to date." : parts.joined(separator: " ")
+    }
+}
+
+/// `lupen install-cli` — symlink the `lupen` command onto your PATH. For DMG
+/// installs; the Homebrew cask does this automatically via its `binary`
+/// stanza, so brew users don't need it.
+struct InstallCLICommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install-cli",
+        abstract: "Symlink `lupen` onto your PATH (DMG installs; brew does it for you)."
+    )
+
+    @Option(name: .long, help: "Directory to link into (must be on your PATH).")
+    var binDir: String?
+
+    func run() throws {
+        guard let executable = Bundle.main.executableURL?.resolvingSymlinksInPath() else {
+            throw ValidationError("Couldn't locate the Lupen executable.")
+        }
+
+        guard let dir = CLIInstall.chooseDir(
+            override: binDir,
+            candidates: CLIInstall.candidateDirs,
+            isWritableDir: CLIInstall.isWritableDir,
+            ensureDir: CLIInstall.ensureUserDir
+        ) else {
+            CLIOutput.note("No writable PATH directory found. Symlink it yourself:")
+            let suggestedDir = CLIInstall.candidateDirs.first ?? "/usr/local/bin"
+            CLIOutput.line("ln -s '\(executable.path)' \(suggestedDir)/lupen")
+            throw ExitCode(3)
+        }
+
+        let link = URL(fileURLWithPath: dir).appendingPathComponent("lupen")
+        switch CLIInstall.decide(at: link.path) {
+        case .refuseExistingFile:
+            throw ValidationError("\(link.path) already exists and isn't a Lupen symlink; remove it first.")
+        case .replaceSymlink:
+            try? FileManager.default.removeItem(at: link)
+            fallthrough
+        case .create:
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: executable)
+        }
+
+        CLIOutput.line("Installed: \(link.path) → \(executable.path)")
+        if !CLIInstall.dirOnPath(dir) {
+            CLIOutput.note("\(dir) isn't on your PATH yet — add it to use `lupen` directly.")
+        }
+    }
+}
+
+enum CLIInstall {
+    static let candidateDirs = ["/opt/homebrew/bin", "/usr/local/bin", "~/.local/bin"]
+
+    enum LinkDecision: Equatable {
+        case create            // nothing there
+        case replaceSymlink    // an existing symlink we can update
+        case refuseExistingFile // a real file/dir — don't clobber
+    }
+
+    /// First usable target directory: an explicit override, else the first
+    /// candidate that exists-and-is-writable (creating `~/.local/bin` if
+    /// that's the fallback). Returns an expanded absolute path, or nil.
+    static func chooseDir(
+        override: String?,
+        candidates: [String],
+        isWritableDir: (String) -> Bool,
+        ensureDir: (String) -> Bool
+    ) -> String? {
+        if let override {
+            let path = (override as NSString).expandingTildeInPath
+            return isWritableDir(path) ? path : nil
+        }
+        for candidate in candidates {
+            let path = (candidate as NSString).expandingTildeInPath
+            if isWritableDir(path) { return path }
+            // Allow creating a user-owned fallback dir (~/.local/bin).
+            if candidate.hasPrefix("~"), ensureDir(path), isWritableDir(path) { return path }
+        }
+        return nil
+    }
+
+    static func decide(at path: String) -> LinkDecision {
+        // `attributesOfItem` does NOT follow symlinks, so it detects an
+        // existing link (even a dangling one) as `.typeSymbolicLink`; it
+        // throws (→ nil) only when nothing exists at the path.
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else {
+            return .create
+        }
+        return (attrs[.type] as? FileAttributeType) == .typeSymbolicLink ? .replaceSymlink : .refuseExistingFile
+    }
+
+    // MARK: - FS probes (overridable for tests)
+
+    static func isWritableDir(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        let fm = FileManager.default
+        return fm.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue && fm.isWritableFile(atPath: path)
+    }
+
+    static func ensureUserDir(_ path: String) -> Bool {
+        (try? FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)) != nil
+    }
+
+    static func dirOnPath(_ dir: String) -> Bool {
+        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        return path.split(separator: ":").map(String.init).contains(dir)
+    }
+}

--- a/Lupen/CLI/Commands/VerifyCommand.swift
+++ b/Lupen/CLI/Commands/VerifyCommand.swift
@@ -1,0 +1,229 @@
+import ArgumentParser
+import Foundation
+
+/// `lupen verify` — recompute every session's cost independently from the
+/// raw logs and diff it against the indexed (reported) value, exactly like
+/// the GUI's Verify Costs window. Exits non-zero (4) when anything diverges,
+/// so it can gate CI / a pre-commit check. Lupen's trust differentiator:
+/// ccusage/tokscale report a number; this proves it.
+///
+/// Audits the whole corpus — period flags don't scope an independent
+/// recompute, so `--since`/`--until`/`--last`/`--month` are ignored here.
+struct VerifyCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "verify",
+        abstract: "Recompute costs from the logs and flag any drift (exit 4 on mismatch).",
+        discussion: """
+            Audits the whole corpus, so --since/--until/--last/--month are ignored. \
+            Exit codes: 0 = clean, 4 = drift, 3 = no logs found. Full session ids \
+            are in --json / --csv.
+            """
+    )
+
+    @OptionGroup var options: CLIGlobalOptions
+
+    func run() throws {
+        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        if let note = engine.freshnessNote() { CLIOutput.note(note) }
+        if options.periodLabel != "all time" {
+            CLIOutput.note("verify audits all sessions; period filters are ignored.")
+        }
+
+        let verifier: any ProviderUsageVerifier = options.provider == .claudeCode
+            ? ClaudeUsageVerifier()
+            : CodexUsageVerifier()
+        // Discover the truth file set from disk (independent of the index),
+        // so an on-disk session the index missed surfaces as a divergence
+        // rather than hiding.
+        let files: [URL]
+        switch options.provider {
+        case .claudeCode:
+            files = FileDiscovery().discoverJSONLFiles(in: FileDiscovery().projectsDirectory).map(\.url)
+        case .codex:
+            files = CodexSessionDiscovery().discoverRolloutFiles()
+        }
+        CLIOutput.note("Recomputing costs from \(files.count) file(s)…")
+
+        let report = verifier.computeReport(files: files)
+        let verification = verifier.verify(report: report, againstSQLite: engine.store)
+
+        let verifyReport = CLIVerifyReport(
+            provider: options.provider,
+            verifiedSessionCount: report.perSession.count,
+            rows: CLIVerifyReport.build(divergences: verification.divergences),
+            pendingCount: verification.pendingSessionIds.count,
+            issueCount: report.issues.count
+        )
+
+        if options.json {
+            try CLIOutput.printJSON(verifyReport.jsonObject)
+        } else if options.csv {
+            CLIOutput.line(verifyReport.csv)
+        } else {
+            verifyReport.printReport(color: CLIStyle.useColor(disabled: options.noColor))
+        }
+
+        // No logs found is NOT a clean pass — a misconfigured CI runner
+        // (wrong HOME, unmounted volume) would otherwise gate green on an
+        // empty audit. Distinct exit 3 lets the gate fail loudly.
+        if files.isEmpty {
+            throw ExitCode(3)
+        }
+        if verifyReport.hasDrift {
+            throw ExitCode(4)
+        }
+    }
+}
+
+/// Data + rendering for `lupen verify`.
+struct CLIVerifyReport {
+    struct Row: Equatable {
+        let sessionId: String
+        let viewCostUSD: Double?
+        let truthCostUSD: Double?
+        let kinds: [String]
+
+        var delta: Double? {
+            guard let view = viewCostUSD, let truth = truthCostUSD else { return nil }
+            return view - truth
+        }
+    }
+
+    let provider: ProviderKind
+    let verifiedSessionCount: Int
+    /// Diverging sessions only.
+    let rows: [Row]
+    let pendingCount: Int
+    let issueCount: Int
+
+    var hasDrift: Bool { !rows.isEmpty }
+
+    /// Group divergences by session into mismatch rows (pure: no store).
+    static func build(divergences: [GroundTruthVerifier.Divergence]) -> [Row] {
+        var bySession: [String: (view: Double?, truth: Double?, kinds: Set<String>)] = [:]
+        for divergence in divergences {
+            var entry = bySession[divergence.sessionId] ?? (nil, nil, [])
+            entry.kinds.insert(kindLabel(divergence.kind))
+            if case .costMismatch(let view, let truth) = divergence.kind {
+                entry.view = view
+                entry.truth = truth
+            }
+            bySession[divergence.sessionId] = entry
+        }
+        var rows = bySession.map { sessionId, entry in
+            Row(sessionId: sessionId, viewCostUSD: entry.view, truthCostUSD: entry.truth, kinds: entry.kinds.sorted())
+        }
+        rows.sort { lhs, rhs in
+            let lhsDelta = abs(lhs.delta ?? 0), rhsDelta = abs(rhs.delta ?? 0)
+            return lhsDelta != rhsDelta ? lhsDelta > rhsDelta : lhs.sessionId < rhs.sessionId
+        }
+        return rows
+    }
+
+    /// Short token for a divergence kind.
+    static func kindLabel(_ kind: GroundTruthVerifier.Divergence.Kind) -> String {
+        switch kind {
+        case .costMismatch: return "cost"
+        case .inputTokenMismatch: return "input"
+        case .outputTokenMismatch: return "output"
+        case .reasoningOutputTokenMismatch: return "reasoning"
+        case .cacheCreationInputMismatch: return "cacheCreate"
+        case .cacheReadMismatch: return "cacheRead"
+        case .cacheCreation1hMismatch: return "cache1h"
+        case .cacheCreation5mMismatch: return "cache5m"
+        case .requestCountMismatch: return "requestCount"
+        case .missingPickedRequestId: return "missingRequestId"
+        case .sessionMissingInView: return "missingInView"
+        case .missingUsageEvent: return "missingUsage"
+        case .unknownPricing: return "unknownPricing"
+        case .sourceRejected: return "sourceRejected"
+        case .parserRejectedLine: return "parserRejected"
+        }
+    }
+
+    /// Compact MISMATCH cell: the full kind list can be 8+ tokens (a session
+    /// that diverges on everything), which would blow the table past 80
+    /// columns. Show the first few; the complete list stays in --json/--csv.
+    static func mismatchSummary(_ kinds: [String]) -> String {
+        guard kinds.count > 3 else { return kinds.joined(separator: ", ") }
+        return kinds.prefix(3).joined(separator: ", ") + " +\(kinds.count - 3) more"
+    }
+
+    // MARK: - Rendering
+
+    func printReport(color: Bool) {
+        CLIOutput.line("\(provider.cliLabel) · cost verification")
+        CLIOutput.line()
+
+        if rows.isEmpty {
+            if verifiedSessionCount == 0 {
+                CLIOutput.line("No sessions found to verify.")
+            } else {
+                CLIOutput.line("✓ \(verifiedSessionCount) session(s) verified — indexed costs match the recomputed truth.")
+            }
+        } else {
+            let table = CLITable(
+                columns: [
+                    .init("SESSION"),
+                    .init("VIEW", align: .right),
+                    .init("TRUTH", align: .right),
+                    .init("Δ", align: .right),
+                    .init("MISMATCH"),
+                ],
+                rows: rows.map { row in
+                    [
+                        CLITopReport.shortID(row.sessionId),
+                        row.viewCostUSD.map(CLIFormat.money) ?? "—",
+                        row.truthCostUSD.map(CLIFormat.money) ?? "—",
+                        row.delta.map(CLIFormat.money) ?? "—",
+                        Self.mismatchSummary(row.kinds),
+                    ]
+                }
+            )
+            CLIOutput.line(table.render(color: color))
+            CLIOutput.line()
+            CLIOutput.line("✗ \(rows.count) of \(verifiedSessionCount) session(s) diverge from the recomputed truth.")
+        }
+
+        if pendingCount > 0 {
+            CLIOutput.note("\(pendingCount) session(s) still importing — rerun after indexing settles.")
+        }
+        if issueCount > 0 {
+            CLIOutput.note("\(issueCount) data issue(s) (unknown pricing / rejected lines) — open Verify Costs for detail.")
+        }
+    }
+
+    var jsonObject: [String: Any] {
+        [
+            "provider": provider.rawValue,
+            "verifiedSessions": verifiedSessionCount,
+            "drift": hasDrift,
+            "pending": pendingCount,
+            "issues": issueCount,
+            "mismatches": rows.map { row in
+                [
+                    "sessionId": row.sessionId,
+                    "viewCostUsd": row.viewCostUSD as Any? ?? NSNull(),
+                    "truthCostUsd": row.truthCostUSD as Any? ?? NSNull(),
+                    "costDelta": row.delta as Any? ?? NSNull(),
+                    "kinds": row.kinds,
+                ]
+            },
+        ]
+    }
+
+    var csv: String {
+        CLICSV.render(
+            header: ["sessionId", "viewCostUsd", "truthCostUsd", "costDelta", "kinds"],
+            rows: rows.map { row in
+                [
+                    row.sessionId,
+                    row.viewCostUSD.map { String(format: "%.6f", $0) } ?? "",
+                    row.truthCostUSD.map { String(format: "%.6f", $0) } ?? "",
+                    row.delta.map { String(format: "%.6f", $0) } ?? "",
+                    row.kinds.joined(separator: ";"),
+                ]
+            }
+        )
+    }
+}

--- a/Lupen/CLI/LupenCLI.swift
+++ b/Lupen/CLI/LupenCLI.swift
@@ -1,0 +1,165 @@
+import ArgumentParser
+import Foundation
+
+/// Root of the `lupen` command-line tool. Subcommands read the same
+/// on-disk SQLite index the GUI app maintains (see `CLIEngine`) and print
+/// usage/cost reports. Lives in the app target so it links the existing
+/// Store/Domain engine directly — no duplicate parsing logic.
+struct LupenCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "lupen",
+        abstract: "Itemized cost and usage reports for Claude Code and Codex — computed locally.",
+        discussion: """
+            Select a period with one of --last (e.g. 30d, 4w, 1m), --month \
+            (YYYY-MM), or --since/--until (YYYY-MM-DD). These styles are \
+            mutually exclusive; with none, all recorded usage is included.
+            """,
+        version: CLIVersion.current,
+        subcommands: [
+            SummaryCommand.self, SkillsCommand.self,
+            DailyCommand.self, WeeklyCommand.self, MonthlyCommand.self,
+            TopCommand.self, ModelsCommand.self, ProjectsCommand.self,
+            SearchCommand.self, ResumeCommand.self,
+            BudgetCommand.self, StatuslineCommand.self, VerifyCommand.self,
+            RefreshCommand.self, ConfigCommand.self, InstallCLICommand.self,
+        ],
+        defaultSubcommand: SummaryCommand.self
+    )
+
+    /// Subcommand names `CLIDispatch` uses to recognise a CLI invocation
+    /// of the shared binary. `CLIDispatchTests` pins this to the registered
+    /// `configuration.subcommands` so the two never drift.
+    static let knownCommandNames: Set<String> = [
+        "summary", "skills", "daily", "weekly", "monthly", "top", "models", "projects",
+        "search", "resume", "budget", "statusline", "verify",
+        "refresh", "config", "install-cli",
+    ]
+}
+
+/// The CLI's reported version. When invoked through a PATH symlink (the
+/// Homebrew cask / `install-cli` case), `Bundle.main` can fail to locate the
+/// enclosing `.app`, so resolve the executable's real path and read
+/// `Contents/Info.plist` directly. Falls back to `Bundle.main`, then a dev
+/// sentinel for unbundled debug runs.
+enum CLIVersion {
+    static var current: String {
+        if let executable = Bundle.main.executableURL?.resolvingSymlinksInPath() {
+            // …/Lupen.app/Contents/MacOS/Lupen → up two → …/Contents/Info.plist
+            let infoPlist = executable
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Info.plist")
+            if let info = NSDictionary(contentsOf: infoPlist),
+               let version = info["CFBundleShortVersionString"] as? String {
+                return version
+            }
+        }
+        return (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0-dev"
+    }
+}
+
+/// `--provider claude-code|codex`. Conformance lives in the CLI layer so
+/// the Domain type stays free of any ArgumentParser dependency. A custom
+/// `init?(argument:)` accepts CLI-conventional spellings (kebab-case)
+/// while keeping them decoupled from the persisted raw values
+/// (`claudeCode`, stored in `app_settings.json` — must stay stable).
+extension ProviderKind: ExpressibleByArgument {
+    init?(argument: String) {
+        switch argument.lowercased() {
+        case "claude-code", "claudecode", "claude", "cc": self = .claudeCode
+        case "codex": self = .codex
+        default: return nil
+        }
+    }
+
+    static var allValueStrings: [String] { ["claude-code", "codex"] }
+
+    var defaultValueDescription: String {
+        switch self {
+        case .claudeCode: return "claude-code"
+        case .codex:      return "codex"
+        }
+    }
+}
+
+/// Options shared by every subcommand. Added as an `@OptionGroup` so the
+/// flags read identically across the tool (the ccusage-style vocabulary:
+/// `--since/--until`, `--last`, `--month`, `--json`).
+struct CLIGlobalOptions: ParsableArguments {
+    @Option(name: .long, help: "Provider to report on.")
+    var provider: ProviderKind = .claudeCode
+
+    @Option(name: .long, help: "Start date (YYYY-MM-DD), inclusive. Pair with --until.")
+    var since: String?
+
+    @Option(name: .long, help: "End date (YYYY-MM-DD), inclusive. Pair with --since.")
+    var until: String?
+
+    @Option(name: .long, help: "Relative window ending now, e.g. 30d, 4w, 1m.")
+    var last: String?
+
+    @Option(name: .long, help: "Calendar month, YYYY-MM.")
+    var month: String?
+
+    @Flag(name: .long, help: "Emit JSON instead of a human table.")
+    var json = false
+
+    @Flag(name: .long, help: "Emit CSV instead of a human table.")
+    var csv = false
+
+    @Flag(name: .long, help: "Disable ANSI color in table output.")
+    var noColor = false
+
+    @Flag(
+        inversion: .prefixedNo,
+        help: "Refresh the index from the logs before reporting (default). --no-refresh reads the on-disk index as-is."
+    )
+    var refresh = true
+
+    func validate() throws {
+        if json && csv {
+            throw ValidationError("Use only one of --json or --csv.")
+        }
+    }
+
+    /// Resolve the period flags into a `[from, to]` window for the store
+    /// queries. `now`/`calendar` are injectable for tests; production uses
+    /// the wall clock and the user's current calendar. Resolution errors
+    /// are surfaced as `ValidationError` so ArgumentParser prints a clean
+    /// usage message (and a `--help` hint) with the usage exit code.
+    func resolveRange(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) throws -> CLIDateRange.Resolved {
+        do {
+            return try CLIDateRange.resolve(
+                since: since, until: until, last: last, month: month,
+                now: now, calendar: calendar
+            )
+        } catch let error as CLIDateRange.ResolveError {
+            throw ValidationError(error.description)
+        }
+    }
+
+    /// Human label for the selected period.
+    var periodLabel: String {
+        CLIDateRange.label(since: since, until: until, last: last, month: month)
+    }
+}
+
+/// Options for row-shaped reports (skills, and the upcoming daily/monthly/
+/// top). Kept out of `CLIGlobalOptions` so single-value commands like
+/// `summary`/`verify` don't advertise `--limit`/`--sort` they can't honor.
+struct CLIRowOptions: ParsableArguments {
+    @Option(name: .long, help: "Limit the number of rows shown.")
+    var limit: Int?
+
+    @Option(name: .long, help: "Sort order (see the command's help for valid values).")
+    var sort: String?
+
+    func validate() throws {
+        if let limit, limit < 0 {
+            throw ValidationError("--limit must be 0 or greater.")
+        }
+    }
+}

--- a/Lupen/Domain/Providers/LupenPaths.swift
+++ b/Lupen/Domain/Providers/LupenPaths.swift
@@ -73,4 +73,14 @@ enum LupenPaths {
         providerRoot(for: provider, appSupportRoot: appSupportRoot)
             .appendingPathComponent("index.sqlite3")
     }
+
+    /// Advisory lock file the CLI holds while refreshing this provider's
+    /// index, so two `lupen` runs don't index in parallel.
+    static func refreshLockURL(
+        for provider: ProviderKind,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(for: provider, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("refresh.lock")
+    }
 }

--- a/Lupen/Domain/SessionResumer.swift
+++ b/Lupen/Domain/SessionResumer.swift
@@ -285,7 +285,7 @@ final class SessionResumer {
     /// escaping *except* another single quote, which
     /// `shellEscapeSingleQuoted` handles with the canonical `'\''`
     /// close-literal-reopen trick.
-    static func buildShellCommand(provider: ProviderKind, cwd: String?, sessionId: String) -> String {
+    nonisolated static func buildShellCommand(provider: ProviderKind, cwd: String?, sessionId: String) -> String {
         let safeSid = shellEscapeSingleQuoted(sessionId)
         let resume = "\(provider.resumeCommandPrefix) '\(safeSid)'"
         guard let cwd, !cwd.isEmpty else { return resume }
@@ -317,7 +317,7 @@ final class SessionResumer {
     /// literal. Within `'…'`, the only character that can't appear is
     /// another `'`, and the idiomatic workaround is to close the quoted
     /// string, emit an escaped literal quote, and reopen it — `'\''`.
-    static func shellEscapeSingleQuoted(_ value: String) -> String {
+    nonisolated static func shellEscapeSingleQuoted(_ value: String) -> String {
         value.replacingOccurrences(of: "'", with: "'\\''")
     }
 

--- a/Lupen/Store/ProviderStore.swift
+++ b/Lupen/Store/ProviderStore.swift
@@ -770,6 +770,65 @@ extension ProviderStore: ReportsRepository {
         }
     }
 
+    /// Highest-cost sessions over the range (for `lupen top`). Matches the
+    /// sidebar's visibility rule (`visible = 1 AND superseded_by IS NULL`) so
+    /// compact-continuation replay shells don't appear — their cost is
+    /// re-homed to the canonical session anyway.
+    func topSessionCosts(from: Date?, to: Date?, limit: Int) throws -> [StoreSessionCost] {
+        try database.pool.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT r.session_id AS session_id,
+                           s.project_path AS project_path,
+                           COALESCE(s.custom_title, s.cached_title, s.first_prompt) AS title,
+                           COUNT(*) AS request_count,
+                           COALESCE(SUM(COALESCE(r.final_cost_usd, r.provisional_cost_usd, 0)), 0) AS cost_usd
+                    FROM requests r
+                    JOIN sessions s ON s.id = r.session_id
+                    WHERE r.model IS NOT NULL AND r.model != '<synthetic>'
+                      AND s.visible = 1 AND s.superseded_by IS NULL
+                      AND (? IS NULL OR r.timestamp >= ?) AND (? IS NULL OR r.timestamp <= ?)
+                    GROUP BY r.session_id
+                    ORDER BY cost_usd DESC, r.session_id
+                    LIMIT ?
+                    """,
+                arguments: [from, from, to, to, limit]
+            ).map { row in
+                StoreSessionCost(
+                    sessionId: row["session_id"],
+                    projectPath: row["project_path"],
+                    title: row["title"],
+                    requestCount: row["request_count"],
+                    costUSD: row["cost_usd"]
+                )
+            }
+        }
+    }
+
+    /// Count of the distinct sessions `topSessionCosts` ranks from — visible,
+    /// non-superseded sessions with billable activity in the window. Shares
+    /// `topSessionCosts`'s predicate exactly so `top`'s "of N" footer matches
+    /// its rows (superseded replay shells, whose cost is re-homed onto their
+    /// canonical session, are excluded — counting them would inflate N above
+    /// the rankable population).
+    func visibleSessionCount(from: Date?, to: Date?) throws -> Int {
+        try database.pool.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(DISTINCT r.session_id)
+                    FROM requests r
+                    JOIN sessions s ON s.id = r.session_id
+                    WHERE r.model IS NOT NULL AND r.model != '<synthetic>'
+                      AND s.visible = 1 AND s.superseded_by IS NULL
+                      AND (? IS NULL OR r.timestamp >= ?) AND (? IS NULL OR r.timestamp <= ?)
+                    """,
+                arguments: [from, from, to, to]
+            ) ?? 0
+        }
+    }
+
     func requestCostPoints(from: Date?, to: Date?) throws -> [StoreRequestCostPoint] {
         try database.pool.read { db in
             try Row.fetchAll(

--- a/Lupen/Store/StoreDTO.swift
+++ b/Lupen/Store/StoreDTO.swift
@@ -416,6 +416,15 @@ struct StoreSkillAggregate: Sendable, Equatable {
     let costUSD: Double
 }
 
+/// One session's cost over a range, with a human label, for `lupen top`.
+struct StoreSessionCost: Sendable, Equatable {
+    let sessionId: String
+    let projectPath: String?
+    let title: String?
+    let requestCount: Int
+    let costUSD: Double
+}
+
 /// Flat (timestamp, cost) request points — the hourly-efficiency
 /// chart's input shape.
 struct StoreRequestCostPoint: Sendable, Equatable {

--- a/Lupen/UI/Dashboard/DashboardWindow.swift
+++ b/Lupen/UI/Dashboard/DashboardWindow.swift
@@ -24,10 +24,15 @@ final class DashboardWindow: NSWindow, NSToolbarDelegate {
         titlebarAppearsTransparent = false
         center()
 
+        // The log window is a maintainer-only diagnostic; its toolbar button
+        // (the toolbar's only item) ships in DEBUG builds only. In RELEASE the
+        // window keeps a plain title bar rather than an empty toolbar strip.
+        #if DEBUG
         let toolbar = NSToolbar(identifier: "DashboardToolbar")
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
         self.toolbar = toolbar
+        #endif
     }
 
     // MARK: - NSToolbarDelegate

--- a/Lupen/main.swift
+++ b/Lupen/main.swift
@@ -10,6 +10,22 @@ if CommandLine.arguments.count >= 2,
     StatuslineTapMode.runAndExit()
 }
 
+// CLI mode. The same binary doubles as the `lupen` command-line tool: a
+// Homebrew cask (or `lupen install-cli`) symlinks
+// `Lupen.app/Contents/MacOS/Lupen` onto the PATH as `lupen`. Detected
+// before AppKit init so a CLI run never registers a Dock icon or window.
+// ArgumentParser's `main()` self-exits on the error / --help / --version
+// paths but RETURNS on a successful `run()`, so the explicit `exit(0)` is
+// load-bearing: without it a successful `lupen summary` would fall through
+// and boot the GUI. See `CLIDispatch` for the (unit-tested) branch rule.
+if CLIDispatch.mode(
+    for: CommandLine.arguments,
+    knownCommands: LupenCLI.knownCommandNames
+) == .cli {
+    LupenCLI.main()
+    exit(0)
+}
+
 // Default smoke runs validate data loading only. Keep them ahead of
 // NSApplication creation so CLI-driven validation cannot trigger AppKit
 // registration crashes or user-visible crash alerts. Set

--- a/LupenTests/CLI/BreakdownReportTests.swift
+++ b/LupenTests/CLI/BreakdownReportTests.swift
@@ -1,0 +1,106 @@
+//
+//  BreakdownReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+import ArgumentParser
+@testable import Lupen
+
+/// P7: models/projects share one breakdown report. Pin its sort/limit,
+/// totals, average, and the key-named serialization.
+@Suite("CLI breakdown report")
+struct BreakdownReportTests {
+    private func report(
+        _ rows: [(String, Int, Double)], sort: BreakdownSort = .cost, limit: Int? = nil
+    ) -> CLIBreakdownReport {
+        CLIBreakdownReport(
+            provider: .claudeCode, periodLabel: "all time",
+            keyName: "model", labelHeader: "MODEL", countHeader: "USES", countNoun: "model",
+            rows: rows.map { .init(key: $0.0, count: $0.1, costUSD: $0.2) },
+            sort: sort, limit: limit
+        )
+    }
+
+    @Test("sort modes order rows differently (with name tie-break)")
+    func sortModes() {
+        let data = [("a", 10, 100.0), ("b", 50, 5.0)]  // cost: a,b · count: b,a
+        #expect(report(data, sort: .cost).shownRows.map(\.key) == ["a", "b"])
+        #expect(report(data, sort: .count).shownRows.map(\.key) == ["b", "a"])
+        #expect(report(data, sort: .name).shownRows.map(\.key) == ["a", "b"])
+    }
+
+    @Test("limit truncates; totals reflect the full (pre-limit) set")
+    func limitAndTotals() {
+        let r = report([("a", 10, 100), ("b", 50, 5), ("c", 1, 1)], sort: .cost, limit: 1)
+        #expect(r.shownRows.map(\.key) == ["a"])
+        #expect(r.totalGroups == 3)
+        #expect(abs(r.totalCostUSD - 106) < 1e-9)
+    }
+
+    @Test("average is cost/count, zero-safe")
+    func average() {
+        #expect(report([("a", 10, 100)]).shownRows[0].avgCostUSD == 10)
+        #expect(report([("z", 0, 0)]).shownRows[0].avgCostUSD == 0)
+    }
+
+    @Test("json/csv use the configured key name")
+    func serialization() {
+        let r = report([("opus", 4, 8)])
+        #expect(JSONSerialization.isValidJSONObject(r.jsonArray))
+        #expect(r.jsonArray[0]["model"] as? String == "opus")
+        #expect(r.jsonArray[0]["count"] as? Int == 4)
+        #expect(r.jsonArray[0]["costUsd"] as? Double == 8)
+        #expect(r.jsonArray[0]["avgCostUsd"] as? Double == 2)
+
+        let lines = r.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "model,count,costUsd,avgCostUsd")
+        #expect(lines[1] == "opus,4,8.000000,2.000000")
+    }
+
+    @Test("--sort parsing")
+    func sortParsing() throws {
+        #expect(try BreakdownSort.parse("count", default: .cost) == .count)
+        #expect(try BreakdownSort.parse(nil, default: .cost) == .cost)
+        #expect(throws: ValidationError.self) { _ = try BreakdownSort.parse("bogus", default: .cost) }
+    }
+
+    @Test("empty input and limit 0 are safe; totals stay full")
+    func emptyAndZeroLimit() {
+        let empty = report([])
+        #expect(empty.shownRows.isEmpty)
+        #expect(empty.totalGroups == 0)
+        #expect(empty.totalCostUSD == 0)
+        #expect(empty.jsonArray.isEmpty)
+
+        let zero = report([("a", 1, 1), ("b", 2, 2)], sort: .cost, limit: 0)
+        #expect(zero.shownRows.isEmpty)
+        #expect(zero.totalGroups == 2)  // footer still anchors the period
+    }
+
+    @Test("displayTransform prettifies the table only — json/csv keep the raw key")
+    func transformTableOnly() {
+        let raw = "-Users-jaden-work-Lupen"
+        let r = CLIBreakdownReport(
+            provider: .claudeCode, periodLabel: "all time",
+            keyName: "project", labelHeader: "PROJECT", countHeader: "SESSIONS", countNoun: "project",
+            rows: [.init(key: raw, count: 1, costUSD: 1)], sort: .cost, limit: nil,
+            displayTransform: ProjectLabelFormatter.decode
+        )
+        #expect(r.jsonArray[0]["project"] as? String == raw)
+        // CSV keeps the raw key (the leading "'" is the formula-injection
+        // guard, since the path starts with "-"); it is NOT decoded.
+        let dataLine = r.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)[1]
+        #expect(dataLine.contains(raw))
+    }
+
+    @Test("models/projects share the row-option validation")
+    func commandOptionValidation() throws {
+        #expect(throws: (any Error).self) { _ = try ModelsCommand.parse(["--limit", "-1"]) }
+        #expect(throws: (any Error).self) { _ = try ProjectsCommand.parse(["--json", "--csv"]) }
+        _ = try ModelsCommand.parse(["--sort", "count", "--limit", "5"])
+    }
+}

--- a/LupenTests/CLI/BudgetStatuslineTests.swift
+++ b/LupenTests/CLI/BudgetStatuslineTests.swift
@@ -1,0 +1,72 @@
+//
+//  BudgetStatuslineTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P9: budget's over/under verdict and statusline's today-default period
+/// are pure — pin them.
+@Suite("CLI budget & statusline")
+struct BudgetStatuslineTests {
+    @Test("budget is over only when spend strictly exceeds the threshold")
+    func budgetThreshold() {
+        func report(_ cost: Double, _ budget: Double) -> CLIBudgetReport {
+            CLIBudgetReport(provider: .claudeCode, periodLabel: "last 7d", costUSD: cost, budgetUSD: budget)
+        }
+        #expect(report(5, 10).isOver == false)
+        #expect(report(15, 10).isOver == true)
+        #expect(report(10, 10).isOver == false)  // exactly at budget = within
+    }
+
+    @Test("budget json/csv shapes")
+    func budgetSerialization() {
+        let over = CLIBudgetReport(provider: .claudeCode, periodLabel: "last 7d", costUSD: 15, budgetUSD: 10)
+        #expect(over.jsonObject["overBudget"] as? Bool == true)
+        #expect(over.jsonObject["costUsd"] as? Double == 15)
+        #expect(over.jsonObject["budgetUsd"] as? Double == 10)
+        let lines = over.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "provider,period,costUsd,budgetUsd,overBudget")
+        #expect(lines[1] == "claudeCode,last 7d,15.000000,10.000000,true")
+    }
+
+    @Test("budget human line wording")
+    func budgetLine() {
+        func report(_ cost: Double, _ budget: Double) -> CLIBudgetReport {
+            CLIBudgetReport(provider: .claudeCode, periodLabel: "last 7d", costUSD: cost, budgetUSD: budget)
+        }
+        #expect(report(15, 10).line == "Claude Code · last 7d: $15.00 of $10.00 — OVER budget")
+        #expect(report(5, 10).line == "Claude Code · last 7d: $5.00 of $10.00 — within budget")
+    }
+
+    @Test("budget rejects negative and non-finite thresholds")
+    func budgetValidation() throws {
+        #expect(throws: (any Error).self) { _ = try BudgetCommand.parse(["--over", "-5"]) }
+        #expect(throws: (any Error).self) { _ = try BudgetCommand.parse(["--over", "nan"]) }
+        #expect(throws: (any Error).self) { _ = try BudgetCommand.parse(["--over", "inf"]) }
+        _ = try BudgetCommand.parse(["--over", "10"])  // valid
+    }
+
+    @Test("statusline defaults to today; a period flag overrides")
+    func statuslineRange() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let now = Date(timeIntervalSince1970: 1_781_785_600)
+
+        let today = try CLIStatusline.range(last: nil, month: nil, since: nil, until: nil, now: now, calendar: calendar)
+        #expect(today.from == calendar.startOfDay(for: now))
+        #expect(today.to == now)
+
+        let lastWeek = try CLIStatusline.range(last: "7d", month: nil, since: nil, until: nil, now: now, calendar: calendar)
+        #expect(lastWeek.from == calendar.date(byAdding: .day, value: -7, to: now))
+        #expect(lastWeek.to == now)
+
+        // A single period flag takes the resolved path, not the today default.
+        let month = try CLIStatusline.range(last: nil, month: "2026-06", since: nil, until: nil, now: now, calendar: calendar)
+        #expect(month.from == calendar.date(from: DateComponents(year: 2026, month: 6, day: 1)))
+    }
+}

--- a/LupenTests/CLI/CLIDateRangeTests.swift
+++ b/LupenTests/CLI/CLIDateRangeTests.swift
@@ -1,0 +1,152 @@
+//
+//  CLIDateRangeTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P1: period resolution is pure date math, so pin it against a fixed
+/// clock + UTC calendar (no wall-clock flakiness).
+@Suite("CLI date range")
+struct CLIDateRangeTests {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+    // A fixed instant (mid-2026). The exact wall-clock value is irrelevant
+    // — every expectation derives from `now` through the same calendar.
+    private let now = Date(timeIntervalSince1970: 1_781_785_600)
+
+    private func resolve(
+        since: String? = nil, until: String? = nil,
+        last: String? = nil, month: String? = nil
+    ) throws -> CLIDateRange.Resolved {
+        try CLIDateRange.resolve(
+            since: since, until: until, last: last, month: month,
+            now: now, calendar: calendar
+        )
+    }
+
+    @Test("--last Nd/Nw/Nm offsets from now, end = now")
+    func relativeWindows() throws {
+        let days = try resolve(last: "30d")
+        #expect(days.to == now)
+        #expect(days.from == calendar.date(byAdding: .day, value: -30, to: now))
+
+        let weeks = try resolve(last: "2w")
+        #expect(weeks.from == calendar.date(byAdding: .weekOfYear, value: -2, to: now))
+
+        let months = try resolve(last: "1m")
+        #expect(months.from == calendar.date(byAdding: .month, value: -1, to: now))
+    }
+
+    @Test("--month spans the full calendar month, inclusive")
+    func monthSpan() throws {
+        let resolved = try resolve(month: "2026-06")
+        let start = calendar.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+        let nextMonth = calendar.date(byAdding: .month, value: 1, to: start)!
+        #expect(resolved.from == start)
+        #expect(resolved.to == nextMonth.addingTimeInterval(-0.001))
+    }
+
+    @Test("--month December rolls the end into the next year")
+    func monthDecemberRollover() throws {
+        let resolved = try resolve(month: "2026-12")
+        let start = calendar.date(from: DateComponents(year: 2026, month: 12, day: 1))!
+        let nextYear = calendar.date(from: DateComponents(year: 2027, month: 1, day: 1))!
+        #expect(resolved.from == start)
+        #expect(resolved.to == nextYear.addingTimeInterval(-0.001))
+    }
+
+    @Test("--month February spans 29 days in a leap year")
+    func monthLeapFebruary() throws {
+        let resolved = try resolve(month: "2024-02")
+        let start = calendar.date(from: DateComponents(year: 2024, month: 2, day: 1))!
+        let march = calendar.date(from: DateComponents(year: 2024, month: 3, day: 1))!
+        #expect(resolved.from == start)
+        #expect(resolved.to == march.addingTimeInterval(-0.001))
+    }
+
+    @Test("--since/--until cover whole days, inclusive of the until day")
+    func sinceUntilDays() throws {
+        let resolved = try resolve(since: "2026-06-01", until: "2026-06-10")
+        let start = calendar.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+        let untilStart = calendar.date(from: DateComponents(year: 2026, month: 6, day: 11))!
+        #expect(resolved.from == start)
+        #expect(resolved.to == untilStart.addingTimeInterval(-0.001))
+    }
+
+    @Test("--since after --until yields an inverted (empty) window, no error")
+    func sinceAfterUntil() throws {
+        // Documents current semantics: resolution does not reorder or
+        // reject; an inverted window simply matches nothing downstream.
+        let resolved = try resolve(since: "2026-06-10", until: "2026-06-01")
+        #expect(resolved.from != nil)
+        #expect(resolved.to != nil)
+        #expect(resolved.from! > resolved.to!)
+    }
+
+    @Test("open-ended since/until and empty window")
+    func openEnded() throws {
+        let sinceOnly = try resolve(since: "2026-06-01")
+        #expect(sinceOnly.to == nil)
+        #expect(sinceOnly.from != nil)
+
+        let none = try resolve()
+        #expect(none.from == nil)
+        #expect(none.to == nil)
+    }
+
+    @Test("mixing period styles is a usage error")
+    func conflicts() {
+        #expect(throws: CLIDateRange.ResolveError.conflictingOptions) {
+            _ = try resolve(last: "7d", month: "2026-06")
+        }
+        #expect(throws: CLIDateRange.ResolveError.conflictingOptions) {
+            _ = try resolve(since: "2026-06-01", last: "7d")
+        }
+    }
+
+    @Test("malformed inputs throw the right error")
+    func malformed() {
+        #expect(throws: CLIDateRange.ResolveError.badRelative("30x")) {
+            _ = try resolve(last: "30x")
+        }
+        #expect(throws: CLIDateRange.ResolveError.badRelative("0d")) {
+            _ = try resolve(last: "0d")
+        }
+        #expect(throws: CLIDateRange.ResolveError.badDate("2026/06/01")) {
+            _ = try resolve(since: "2026/06/01")
+        }
+        #expect(throws: CLIDateRange.ResolveError.badMonth("June")) {
+            _ = try resolve(month: "June")
+        }
+        // Out-of-range month must be rejected, not rolled into next year.
+        #expect(throws: CLIDateRange.ResolveError.badMonth("2026-13")) {
+            _ = try resolve(month: "2026-13")
+        }
+        #expect(throws: CLIDateRange.ResolveError.badRelative("-5d")) {
+            _ = try resolve(last: "-5d")
+        }
+        #expect(throws: CLIDateRange.ResolveError.badRelative("d")) {
+            _ = try resolve(last: "d")
+        }
+    }
+
+    @Test("period label reads the way the user typed it")
+    func periodLabels() {
+        #expect(CLIDateRange.label(since: nil, until: nil, last: "30d", month: nil) == "last 30d")
+        #expect(CLIDateRange.label(since: nil, until: nil, last: nil, month: "2026-06") == "2026-06")
+        #expect(CLIDateRange.label(since: "2026-06-01", until: "2026-06-10", last: nil, month: nil) == "2026-06-01 → 2026-06-10")
+        #expect(CLIDateRange.label(since: "2026-06-01", until: nil, last: nil, month: nil) == "since 2026-06-01")
+        #expect(CLIDateRange.label(since: nil, until: "2026-06-10", last: nil, month: nil) == "through 2026-06-10")
+        #expect(CLIDateRange.label(since: nil, until: nil, last: nil, month: nil) == "all time")
+        // Precedence: --last wins the label when multiple are set.
+        #expect(CLIDateRange.label(since: "2026-06-01", until: nil, last: "7d", month: nil) == "last 7d")
+    }
+}

--- a/LupenTests/CLI/CLIDispatchTests.swift
+++ b/LupenTests/CLI/CLIDispatchTests.swift
@@ -1,0 +1,63 @@
+//
+//  CLIDispatchTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P1: the shared-binary CLI/GUI branch must be pure and correct so a
+/// `lupen …` invocation never launches the dashboard and a Finder launch
+/// never drops into the CLI.
+@Suite("CLI dispatch")
+struct CLIDispatchTests {
+    private let commands: Set<String> = ["summary", "skills"]
+
+    @Test("symlink name `lupen` routes to CLI even with no args")
+    func symlinkName() {
+        #expect(CLIDispatch.mode(for: ["/opt/homebrew/bin/lupen"], knownCommands: commands) == .cli)
+        #expect(CLIDispatch.mode(for: ["lupen", "skills"], knownCommands: commands) == .cli)
+    }
+
+    @Test("bundle launch (Lupen, no args) passes through to GUI")
+    func bundleLaunch() {
+        let argv0 = "/Applications/Lupen.app/Contents/MacOS/Lupen"
+        #expect(CLIDispatch.mode(for: [argv0], knownCommands: commands) == .passthrough)
+    }
+
+    @Test("known subcommand under bundle name routes to CLI")
+    func subcommandUnderBundleName() {
+        let argv0 = "/Applications/Lupen.app/Contents/MacOS/Lupen"
+        #expect(CLIDispatch.mode(for: [argv0, "summary"], knownCommands: commands) == .cli)
+    }
+
+    @Test("help/version flags route to CLI")
+    func helpVersionFlags() {
+        let argv0 = "/Applications/Lupen.app/Contents/MacOS/Lupen"
+        #expect(CLIDispatch.mode(for: [argv0, "--version"], knownCommands: commands) == .cli)
+        #expect(CLIDispatch.mode(for: [argv0, "--help"], knownCommands: commands) == .cli)
+        #expect(CLIDispatch.mode(for: [argv0, "-h"], knownCommands: commands) == .cli)
+    }
+
+    @Test("LaunchServices noise and unknown args pass through")
+    func launchServicesNoise() {
+        let argv0 = "/Applications/Lupen.app/Contents/MacOS/Lupen"
+        #expect(CLIDispatch.mode(for: [argv0, "-psn_0_123456"], knownCommands: commands) == .passthrough)
+        #expect(CLIDispatch.mode(for: [argv0, "-NSDocumentRevisionsDebugMode", "YES"], knownCommands: commands) == .passthrough)
+        #expect(CLIDispatch.mode(for: [argv0, "totally-unknown"], knownCommands: commands) == .passthrough)
+    }
+
+    @Test("empty argv passes through")
+    func emptyArgv() {
+        #expect(CLIDispatch.mode(for: [], knownCommands: commands) == .passthrough)
+    }
+
+    @Test("knownCommandNames stays in sync with registered subcommands")
+    func knownCommandNamesInSync() {
+        let registered = Set(LupenCLI.configuration.subcommands.compactMap { $0.configuration.commandName })
+        #expect(registered == LupenCLI.knownCommandNames)
+    }
+}

--- a/LupenTests/CLI/CLIEngineFreshnessTests.swift
+++ b/LupenTests/CLI/CLIEngineFreshnessTests.swift
@@ -1,0 +1,77 @@
+//
+//  CLIEngineFreshnessTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P2: the stderr freshness hint has a small branch matrix that's easy to
+/// regress (pluralization, rebuilt-vs-no-refresh wording, quiet path).
+/// `freshnessNote` is pure, so pin every branch.
+@Suite("CLI engine freshness note")
+struct CLIEngineFreshnessTests {
+    private typealias Outcome = CLIRefresher.Outcome
+
+    @Test("schema rebuild + refresh reports a reindex")
+    func rebuiltWithRefresh() {
+        let note = CLIEngine.freshnessNote(
+            bootstrap: .rebuilt(fromVersion: 14),
+            didRefresh: true,
+            outcome: Outcome(imported: 4000, failed: 0, skipped: false)
+        )
+        #expect(note == "Index rebuilt for a new version — reindexed from your logs.")
+    }
+
+    @Test("schema rebuild under --no-refresh does NOT claim a reindex")
+    func rebuiltWithoutRefresh() {
+        let note = CLIEngine.freshnessNote(
+            bootstrap: .rebuilt(fromVersion: 14),
+            didRefresh: false,
+            outcome: nil
+        )
+        #expect(note == "Index reset for a new version — run without --no-refresh to reindex.")
+    }
+
+    @Test("--no-refresh on a normal index")
+    func noRefresh() {
+        #expect(CLIEngine.freshnessNote(bootstrap: .opened, didRefresh: false, outcome: nil)
+            == "Showing the on-disk index (--no-refresh).")
+    }
+
+    @Test("refreshed but nothing changed stays quiet")
+    func refreshedNothing() {
+        #expect(CLIEngine.freshnessNote(
+            bootstrap: .opened, didRefresh: true,
+            outcome: Outcome(imported: 0, failed: 0, skipped: false)
+        ) == nil)
+        // Same for a brand-new empty index that imported nothing.
+        #expect(CLIEngine.freshnessNote(
+            bootstrap: .createdFresh, didRefresh: true,
+            outcome: Outcome(imported: 0, failed: 0, skipped: false)
+        ) == nil)
+        // And when no outcome was produced at all.
+        #expect(CLIEngine.freshnessNote(bootstrap: .opened, didRefresh: true, outcome: nil) == nil)
+    }
+
+    @Test("lock contention is surfaced")
+    func skipped() {
+        #expect(CLIEngine.freshnessNote(bootstrap: .opened, didRefresh: true, outcome: .skippedLockHeld)
+            == "Another Lupen process is indexing; showing the current index.")
+    }
+
+    @Test("import count is pluralized")
+    func importedPluralization() {
+        #expect(CLIEngine.freshnessNote(
+            bootstrap: .opened, didRefresh: true,
+            outcome: Outcome(imported: 1, failed: 0, skipped: false)
+        ) == "↻ Indexed 1 updated session.")
+        #expect(CLIEngine.freshnessNote(
+            bootstrap: .opened, didRefresh: true,
+            outcome: Outcome(imported: 2, failed: 0, skipped: false)
+        ) == "↻ Indexed 2 updated sessions.")
+    }
+}

--- a/LupenTests/CLI/CLIFormatTests.swift
+++ b/LupenTests/CLI/CLIFormatTests.swift
@@ -1,0 +1,61 @@
+//
+//  CLIFormatTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P1: number/label formatting and the `--provider` argument mapping are
+/// pure, user-facing logic — pin them so output and the CLI contract
+/// don't regress silently.
+@Suite("CLI formatting & provider argument")
+struct CLIFormatTests {
+    @Test("thousands grouping across boundaries")
+    func intGrouping() {
+        #expect(CLIFormat.int(0) == "0")
+        #expect(CLIFormat.int(7) == "7")
+        #expect(CLIFormat.int(999) == "999")
+        #expect(CLIFormat.int(1000) == "1,000")
+        #expect(CLIFormat.int(1_000_000) == "1,000,000")
+        #expect(CLIFormat.int(8_231_004) == "8,231,004")
+        #expect(CLIFormat.int(-1234) == "-1,234")
+    }
+
+    @Test("Int.min formats instead of trapping")
+    func intMinNoTrap() {
+        // `.magnitude` (not `abs()`) keeps the most-negative Int safe.
+        #expect(CLIFormat.int(Int.min) == "-9,223,372,036,854,775,808")
+    }
+
+    @Test("money is two decimal places with a dollar sign")
+    func money() {
+        #expect(CLIFormat.money(0) == "$0.00")
+        #expect(CLIFormat.money(12.4) == "$12.40")
+        #expect(CLIFormat.money(1234.5) == "$1234.50")
+        #expect(CLIFormat.money(-3.1) == "$-3.10")
+    }
+
+    @Test("--provider accepts kebab-case and aliases, rejects junk")
+    func providerArgument() {
+        #expect(ProviderKind(argument: "claude-code") == .claudeCode)
+        #expect(ProviderKind(argument: "claudeCode") == .claudeCode)
+        #expect(ProviderKind(argument: "Claude") == .claudeCode)
+        #expect(ProviderKind(argument: "cc") == .claudeCode)
+        #expect(ProviderKind(argument: "codex") == .codex)
+        #expect(ProviderKind(argument: "CODEX") == .codex)
+        #expect(ProviderKind(argument: "gpt") == nil)
+        #expect(ProviderKind(argument: "") == nil)
+    }
+
+    @Test("provider advertises kebab-case values and labels")
+    func providerAdvertisedValues() {
+        #expect(ProviderKind.allValueStrings == ["claude-code", "codex"])
+        #expect(ProviderKind.claudeCode.defaultValueDescription == "claude-code")
+        #expect(ProviderKind.claudeCode.cliLabel == "Claude Code")
+        #expect(ProviderKind.codex.cliLabel == "Codex")
+    }
+}

--- a/LupenTests/CLI/CLIProcessLockTests.swift
+++ b/LupenTests/CLI/CLIProcessLockTests.swift
@@ -1,0 +1,65 @@
+//
+//  CLIProcessLockTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P2: the cross-process refresh lock must be genuinely exclusive and
+/// release cleanly. `flock` conflicts across separate `open()`s even in
+/// one process, so exclusion is observable in-test.
+@Suite("CLI process lock")
+struct CLIProcessLockTests {
+    private func tempLockURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-lock-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("refresh.lock")
+    }
+
+    @Test("a held lock blocks a second acquire and reacquires after release")
+    func exclusionAndRelease() {
+        let url = tempLockURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let first = CLIProcessLock.acquire(at: url, timeout: 1)
+        #expect(first != nil)
+
+        // Held → a second acquire times out rather than succeeding.
+        #expect(CLIProcessLock.acquire(at: url, timeout: 0.3) == nil)
+
+        first?.release()
+
+        // Released → the lock is reacquirable.
+        let third = CLIProcessLock.acquire(at: url, timeout: 1)
+        #expect(third != nil)
+        third?.release()
+    }
+
+    @Test("acquire(timeout: 0) fast-fails when the lock is held")
+    func zeroTimeoutFastFail() {
+        let url = tempLockURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let held = CLIProcessLock.acquire(at: url, timeout: 1)
+        #expect(held != nil)
+        // No retry budget → returns immediately rather than waiting.
+        #expect(CLIProcessLock.acquire(at: url, timeout: 0) == nil)
+        held?.release()
+    }
+
+    @Test("release is idempotent")
+    func idempotentRelease() {
+        let url = tempLockURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let lock = CLIProcessLock.acquire(at: url, timeout: 1)
+        #expect(lock != nil)
+        lock?.release()
+        lock?.release()  // must not crash / double-close
+        #expect(CLIProcessLock.acquire(at: url, timeout: 1) != nil)
+    }
+}

--- a/LupenTests/CLI/CLIRefresherTests.swift
+++ b/LupenTests/CLI/CLIRefresherTests.swift
@@ -1,0 +1,76 @@
+//
+//  CLIRefresherTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P2: the CLI refresh must build a cold index from the logs and then be a
+/// cheap no-op when nothing changed — driving the same coordinator the GUI
+/// uses, so the data lands identically.
+@Suite("CLI refresher")
+struct CLIRefresherTests {
+    private func freshStore() throws -> (store: ProviderStore, cleanup: () -> Void) {
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-refresh-\(UUID().uuidString).sqlite3")
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        return (store, { try? FileManager.default.removeItem(at: dbURL) })
+    }
+
+    @Test("Claude cold refresh imports the corpus; a second pass imports nothing")
+    func claudeColdThenIncremental() throws {
+        let (corpus, cleanupCorpus) = try RefactorFixtureCorpus.materialize()
+        defer { cleanupCorpus() }
+        let (store, cleanupStore) = try freshStore()
+        defer { cleanupStore() }
+
+        let source = ProviderIndexSource.claude(projectsDirectory: corpus.projectsDir)
+
+        let first = CLIRefresher.run(source: source, store: store)
+        #expect(first.skipped == false)
+        #expect(first.failed == 0)
+        #expect(first.imported > 0)
+        #expect(try store.usageTotals(from: nil, to: nil).requestCount > 0)
+
+        // Incremental: fingerprints match → nothing re-imported.
+        let second = CLIRefresher.run(source: source, store: store)
+        #expect(second.imported == 0)
+        #expect(second.failed == 0)
+    }
+
+    @Test("Codex cold refresh imports the corpus; a second pass imports nothing")
+    func codexColdThenIncremental() throws {
+        let (corpus, cleanupCorpus) = try RefactorFixtureCorpus.materialize()
+        defer { cleanupCorpus() }
+        let (store, cleanupStore) = try freshStore()
+        defer { cleanupStore() }
+
+        let source = ProviderIndexSource.codex(codexHome: corpus.codexHome)
+
+        let first = CLIRefresher.run(source: source, store: store)
+        #expect(first.skipped == false)
+        #expect(first.failed == 0)
+        #expect(first.imported > 0)
+
+        let second = CLIRefresher.run(source: source, store: store)
+        #expect(second.imported == 0)
+    }
+
+    @Test("a missing source directory is a graceful no-op (cold first run, provider never used)")
+    func missingSource() throws {
+        let (store, cleanupStore) = try freshStore()
+        defer { cleanupStore() }
+
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-absent-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("projects")
+        let outcome = CLIRefresher.run(source: .claude(projectsDirectory: missing), store: store)
+        #expect(outcome.imported == 0)
+        #expect(outcome.failed == 0)
+        #expect(outcome.skipped == false)
+    }
+}

--- a/LupenTests/CLI/CLITableTests.swift
+++ b/LupenTests/CLI/CLITableTests.swift
@@ -1,0 +1,95 @@
+//
+//  CLITableTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P3: the shared table/CSV renderers back every report, so pin alignment,
+/// trailing-space trimming, color gating, and CSV quoting.
+@Suite("CLI table & CSV")
+struct CLITableTests {
+    @Test("columns align (left/right) with no trailing whitespace")
+    func alignment() {
+        let table = CLITable(
+            columns: [.init("A"), .init("N", align: .right)],
+            rows: [["x", "1"], ["yy", "100"]]
+        )
+        let lines = table.render(color: false).split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines.count == 3)
+        for line in lines { #expect(!line.hasSuffix(" ")) }  // trailing trimmed
+        // Right-aligned numeric column: narrow values are space-prefixed to width 3.
+        #expect(lines[1].hasSuffix("  1"))
+        #expect(lines[2].hasSuffix("100"))
+        // Left-aligned first column keeps the header letter at the start.
+        #expect(lines[0].hasPrefix("A"))
+    }
+
+    @Test("color wraps the header in ANSI bold; plain mode does not")
+    func colorHeader() {
+        let table = CLITable(columns: [.init("H")], rows: [["v"]])
+        #expect(table.render(color: true).hasPrefix("\u{001B}[1m"))
+        #expect(!table.render(color: false).contains("\u{001B}"))
+    }
+
+    @Test("CSV quotes fields with commas, quotes, or newlines")
+    func csvEscaping() {
+        #expect(CLICSV.escape("plain") == "plain")
+        #expect(CLICSV.escape("a,b") == "\"a,b\"")
+        #expect(CLICSV.escape("a\"b") == "\"a\"\"b\"")
+        #expect(CLICSV.escape("a\nb") == "\"a\nb\"")
+        #expect(CLICSV.render(header: ["x", "y"], rows: [["1", "a,b"]]) == "x,y\n1,\"a,b\"")
+    }
+
+    @Test("CSV guards spreadsheet formula-injection leads")
+    func csvFormulaGuard() {
+        #expect(CLICSV.guardingFormula("=cmd()") == "'=cmd()")
+        #expect(CLICSV.guardingFormula("+1") == "'+1")
+        #expect(CLICSV.guardingFormula("-2") == "'-2")
+        #expect(CLICSV.guardingFormula("@SUM") == "'@SUM")
+        #expect(CLICSV.guardingFormula("flow-all") == "flow-all")
+        // render routes fields through the guard then RFC quoting.
+        #expect(CLICSV.render(header: ["s"], rows: [["=danger"]]) == "s\n'=danger")
+    }
+
+    @Test("CSV sanitize strips control bytes (defusing ANSI) but keeps newlines")
+    func csvControlSanitize() {
+        #expect(CLICSV.sanitize("a\u{1B}[31mb") == "a[31mb")  // ESC byte gone → sequence inert
+        #expect(CLICSV.sanitize("a\rb\u{07}c") == "abc")       // CR + BEL stripped
+        #expect(CLICSV.sanitize("a\nb") == "a\nb")             // newline kept (RFC-4180 quotes it)
+        #expect(CLICSV.field("=a\u{1B}b") == "'=ab")           // ESC stripped, then formula-guarded
+        #expect(CLICSV.render(header: ["t"], rows: [["x\u{1B}[2Jy"]]) == "t\nx[2Jy")
+    }
+
+    @Test("table strips control characters that would inject ANSI / break alignment")
+    func controlCharSanitize() {
+        #expect(CLITable.sanitize("flow\u{1B}[31m-all") == "flow[31m-all")
+        #expect(CLITable.sanitize("a\u{07}b\u{7F}c\td") == "abcd")
+        let table = CLITable(columns: [.init("S")], rows: [["x\u{1B}[2Jy"]])
+        let out = table.render(color: false)
+        #expect(!out.contains("\u{1B}"))
+    }
+
+    @Test("ragged rows and empty rows render without trapping")
+    func raggedAndEmpty() {
+        // Row with fewer cells than columns → missing cell padded blank.
+        let ragged = CLITable(columns: [.init("A"), .init("B"), .init("C")], rows: [["1", "2"]])
+        let lines = ragged.render(color: false).split(separator: "\n", omittingEmptySubsequences: false)
+        #expect(lines.count == 2)
+        // Empty rows → header only.
+        let empty = CLITable(columns: [.init("A"), .init("B")], rows: [])
+        #expect(empty.render(color: false).split(separator: "\n", omittingEmptySubsequences: false).count == 1)
+    }
+
+    @Test("useColor honors --no-color and NO_COLOR")
+    func useColorGating() {
+        #expect(CLIStyle.useColor(disabled: true) == false)
+        setenv("NO_COLOR", "1", 1)
+        defer { unsetenv("NO_COLOR") }
+        #expect(CLIStyle.useColor(disabled: false) == false)
+    }
+}

--- a/LupenTests/CLI/InstallCLITests.swift
+++ b/LupenTests/CLI/InstallCLITests.swift
@@ -1,0 +1,83 @@
+//
+//  InstallCLITests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P10: `install-cli`'s target-directory selection and clobber-safety
+/// decision are pure (filesystem probes injected) — pin them.
+@Suite("CLI install-cli")
+struct InstallCLITests {
+    @Test("chooseDir honors an override only when writable")
+    func chooseDirOverride() {
+        #expect(CLIInstall.chooseDir(override: "/opt/x", candidates: [],
+            isWritableDir: { $0 == "/opt/x" }, ensureDir: { _ in false }) == "/opt/x")
+        #expect(CLIInstall.chooseDir(override: "/opt/x", candidates: [],
+            isWritableDir: { _ in false }, ensureDir: { _ in false }) == nil)
+        let home = NSHomeDirectory()
+        #expect(CLIInstall.chooseDir(override: "~/bin", candidates: [],
+            isWritableDir: { $0 == home + "/bin" }, ensureDir: { _ in false }) == home + "/bin")
+    }
+
+    @Test("chooseDir picks the first writable candidate, else creates the ~ fallback")
+    func chooseDirCandidates() {
+        let candidates = ["/opt/homebrew/bin", "/usr/local/bin", "~/.local/bin"]
+        #expect(CLIInstall.chooseDir(override: nil, candidates: candidates,
+            isWritableDir: { $0 == "/usr/local/bin" }, ensureDir: { _ in false }) == "/usr/local/bin")
+
+        let local = NSHomeDirectory() + "/.local/bin"
+        var created = false
+        let dir = CLIInstall.chooseDir(override: nil, candidates: candidates,
+            isWritableDir: { $0 == local && created }, ensureDir: { _ in created = true; return true })
+        #expect(dir == local)
+
+        #expect(CLIInstall.chooseDir(override: nil, candidates: candidates,
+            isWritableDir: { _ in false }, ensureDir: { _ in false }) == nil)
+    }
+
+    @Test("decide: symlink → replace, real file → refuse, nothing → create (dangling links too)")
+    func decide() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-install-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let real = dir.appendingPathComponent("realfile")
+        try Data().write(to: real)
+        let symlink = dir.appendingPathComponent("sym")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: real)
+        let dangling = dir.appendingPathComponent("dang")
+        try FileManager.default.createSymbolicLink(at: dangling, withDestinationURL: dir.appendingPathComponent("gone"))
+        let missing = dir.appendingPathComponent("nope")
+
+        #expect(CLIInstall.decide(at: symlink.path) == .replaceSymlink)
+        #expect(CLIInstall.decide(at: dangling.path) == .replaceSymlink)
+        #expect(CLIInstall.decide(at: real.path) == .refuseExistingFile)
+        #expect(CLIInstall.decide(at: missing.path) == .create)
+    }
+
+    @Test("refresh message surfaces imported and failed counts")
+    func refreshMessage() {
+        typealias Outcome = CLIRefresher.Outcome
+        #expect(CLIRefreshMessage.text(for: nil) == "Index already up to date.")
+        #expect(CLIRefreshMessage.text(for: Outcome(imported: 0, failed: 0, skipped: false)) == "Index already up to date.")
+        #expect(CLIRefreshMessage.text(for: .skippedLockHeld) == "Another Lupen process is indexing; skipped.")
+        #expect(CLIRefreshMessage.text(for: Outcome(imported: 3, failed: 0, skipped: false)) == "Indexed 3 updated session(s).")
+        #expect(CLIRefreshMessage.text(for: Outcome(imported: 0, failed: 2, skipped: false)) == "2 session(s) failed (retried next run).")
+        #expect(CLIRefreshMessage.text(for: Outcome(imported: 3, failed: 2, skipped: false))
+            == "Indexed 3 updated session(s). 2 session(s) failed (retried next run).")
+    }
+
+    @Test("config field keys are a stable ordered contract")
+    func configFields() {
+        let keys = ConfigCommand.fields(provider: .claudeCode).map(\.0)
+        #expect(keys == ["version", "schema", "provider", "sourceDir", "indexDb", "appSupport"])
+        let providerValue = ConfigCommand.fields(provider: .codex).first { $0.0 == "provider" }?.1
+        #expect(providerValue == "codex")
+    }
+}

--- a/LupenTests/CLI/SearchResumeTests.swift
+++ b/LupenTests/CLI/SearchResumeTests.swift
@@ -1,0 +1,94 @@
+//
+//  SearchResumeTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P8: `search` groups FTS hits by session; `resume` resolves a cwd and
+/// builds the provider's resume command. Both pure cores are pinned here.
+@Suite("CLI search & resume")
+struct SearchResumeTests {
+    private func hit(_ session: String, _ snippet: String) -> StoreSearchHit {
+        StoreSearchHit(sessionId: session, turnId: nil, stepUuid: nil, kind: "prompt", snippet: snippet)
+    }
+
+    @Test("search groups hits by session in rank order, counts, keeps first snippet")
+    func grouping() {
+        let hits = [hit("s1", "a"), hit("s1", "b"), hit("s2", "c"), hit("s1", "d"), hit("s3", "e")]
+        let rows = CLISearchReport.group(hits: hits, limit: 10)
+        #expect(rows.map(\.sessionId) == ["s1", "s2", "s3"])  // first-seen order
+        #expect(rows[0].hits == 3)
+        #expect(rows[0].snippet == "a")  // first snippet retained
+        #expect(rows[1].hits == 1)
+    }
+
+    @Test("search limit caps the session count")
+    func groupingLimit() {
+        let hits = [hit("s1", "a"), hit("s2", "b"), hit("s3", "c")]
+        #expect(CLISearchReport.group(hits: hits, limit: 2).map(\.sessionId) == ["s1", "s2"])
+        #expect(CLISearchReport.group(hits: [], limit: 10).isEmpty)
+    }
+
+    @Test("resume cwd: codex uses the path if it exists, else nil")
+    func resumeCwdCodex() {
+        #expect(CLIResume.resolveCwd(provider: .codex, projectPath: "/tmp/x", directoryExists: { _ in true }) == "/tmp/x")
+        #expect(CLIResume.resolveCwd(provider: .codex, projectPath: "/tmp/x", directoryExists: { _ in false }) == nil)
+        #expect(CLIResume.resolveCwd(provider: .codex, projectPath: nil, directoryExists: { _ in true }) == nil)
+        #expect(CLIResume.resolveCwd(provider: .codex, projectPath: "", directoryExists: { _ in true }) == nil)
+    }
+
+    @Test("resume cwd: claude decodes the munged path, gated on existence")
+    func resumeCwdClaude() {
+        let encoded = "-Users-jaden-work-Lupen"
+        #expect(CLIResume.resolveCwd(provider: .claudeCode, projectPath: encoded, directoryExists: { _ in true }) != nil)
+        #expect(CLIResume.resolveCwd(provider: .claudeCode, projectPath: encoded, directoryExists: { _ in false }) == nil)
+    }
+
+    @Test("resume command shape matches the provider; ids are shell-escaped")
+    func resumeCommand() {
+        #expect(SessionResumer.buildShellCommand(provider: .claudeCode, cwd: "/p", sessionId: "abc")
+            == "cd '/p' && claude --resume 'abc'")
+        #expect(SessionResumer.buildShellCommand(provider: .codex, cwd: nil, sessionId: "abc")
+            == "codex resume 'abc'")
+        // A single quote in the id can't break out of the single-quoted literal.
+        #expect(SessionResumer.buildShellCommand(provider: .codex, cwd: nil, sessionId: "a'b")
+            == "codex resume 'a'\\''b'")
+    }
+
+    @Test("search report json/csv shape")
+    func serialization() {
+        let report = CLISearchReport(
+            provider: .claudeCode, query: "q",
+            rows: [.init(sessionId: "s1", hits: 3, snippet: "hello [world]")]
+        )
+        #expect(report.jsonArray[0]["sessionId"] as? String == "s1")
+        #expect(report.jsonArray[0]["hits"] as? Int == 3)
+        #expect(report.jsonArray[0]["snippet"] as? String == "hello [world]")
+        let lines = report.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "sessionId,hits,snippet")
+        #expect(lines[1] == "s1,3,hello [world]")
+    }
+
+    @Test("FTS search returns hits over the corpus (headless path)")
+    func searchOverCorpus() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-search-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .claude(projectsDirectory: corpus.projectsDir), store: store)
+
+        let match = ProviderStore.ftsPrefixQuery(from: "prompt")
+        #expect(match != nil)
+        let hits = try store.search(matching: match ?? "", limit: 100)
+        #expect(!hits.isEmpty)
+        #expect(!CLISearchReport.group(hits: hits, limit: 20).isEmpty)
+    }
+}

--- a/LupenTests/CLI/SkillsReportTests.swift
+++ b/LupenTests/CLI/SkillsReportTests.swift
@@ -1,0 +1,159 @@
+//
+//  SkillsReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+import ArgumentParser
+@testable import Lupen
+
+/// P3: the skills report's assembly (top-model join, sort, limit, average)
+/// is pure — pin it independent of the store.
+@Suite("CLI skills report")
+struct SkillsReportTests {
+    // alpha: few runs / high cost; beta: many runs / low cost — so cost and
+    // count orderings differ, distinguishing the sort modes.
+    private let aggregates = [
+        StoreSkillAggregate(skillName: "alpha", invocationCount: 10, costUSD: 100),
+        StoreSkillAggregate(skillName: "beta", invocationCount: 50, costUSD: 5),
+        StoreSkillAggregate(skillName: "gamma", invocationCount: 2, costUSD: 1),
+    ]
+    private let modelCosts = [
+        StoreGroupedModelCost(groupKey: "alpha", model: "sonnet", costUSD: 60),
+        StoreGroupedModelCost(groupKey: "alpha", model: "opus", costUSD: 40),
+        StoreGroupedModelCost(groupKey: "beta", model: "opus", costUSD: 5),
+        // gamma has no model-cost row → topModel nil.
+    ]
+
+    @Test("top model is the highest-cost model per skill; missing → nil")
+    func topModel() {
+        let map = CLISkillsReport.topModelBySkill(modelCosts)
+        #expect(map["alpha"] == "sonnet")
+        #expect(map["beta"] == "opus")
+        #expect(map["gamma"] == nil)
+    }
+
+    @Test("sort modes order rows differently")
+    func sorting() {
+        let byCost = CLISkillsReport.build(aggregates: aggregates, modelCosts: modelCosts, sort: .cost, limit: nil)
+        #expect(byCost.map(\.skill) == ["alpha", "beta", "gamma"])
+
+        let byCount = CLISkillsReport.build(aggregates: aggregates, modelCosts: modelCosts, sort: .count, limit: nil)
+        #expect(byCount.map(\.skill) == ["beta", "alpha", "gamma"])
+
+        let byName = CLISkillsReport.build(aggregates: aggregates, modelCosts: modelCosts, sort: .name, limit: nil)
+        #expect(byName.map(\.skill) == ["alpha", "beta", "gamma"])
+    }
+
+    @Test("limit truncates after sorting; topModel + average flow through")
+    func limitAndDerived() {
+        let rows = CLISkillsReport.build(aggregates: aggregates, modelCosts: modelCosts, sort: .cost, limit: 1)
+        #expect(rows.count == 1)
+        #expect(rows[0].skill == "alpha")
+        #expect(rows[0].topModel == "sonnet")
+        #expect(abs(rows[0].avgCostUSD - 10.0) < 1e-9)  // 100 / 10
+    }
+
+    @Test("zero-run row reports a zero average without dividing by zero")
+    func zeroRunsAverage() {
+        let rows = CLISkillsReport.build(
+            aggregates: [StoreSkillAggregate(skillName: "x", invocationCount: 0, costUSD: 0)],
+            modelCosts: [], sort: .cost, limit: nil
+        )
+        #expect(rows[0].avgCostUSD == 0)
+    }
+
+    @Test("--sort parsing accepts the three modes, rejects junk, defaults")
+    func sortParsing() throws {
+        #expect(try SkillSort.parse("count", default: .cost) == .count)
+        #expect(try SkillSort.parse("NAME", default: .cost) == .name)
+        #expect(try SkillSort.parse(nil, default: .cost) == .cost)
+        #expect(throws: ValidationError.self) {
+            _ = try SkillSort.parse("bogus", default: .cost)
+        }
+    }
+
+    @Test("equal-cost rows break ties by skill name (reproducible)")
+    func costTieDeterminism() {
+        let tied = [
+            StoreSkillAggregate(skillName: "zeta", invocationCount: 1, costUSD: 5),
+            StoreSkillAggregate(skillName: "alpha", invocationCount: 1, costUSD: 5),
+        ]
+        let rows = CLISkillsReport.build(aggregates: tied, modelCosts: [], sort: .cost, limit: nil)
+        #expect(rows.map(\.skill) == ["alpha", "zeta"])
+    }
+
+    @Test("top-model cost ties break on the smaller model name (order-independent)")
+    func topModelTie() {
+        let forward = [
+            StoreGroupedModelCost(groupKey: "s", model: "opus", costUSD: 10),
+            StoreGroupedModelCost(groupKey: "s", model: "haiku", costUSD: 10),
+        ]
+        let reverse = Array(forward.reversed())
+        #expect(CLISkillsReport.topModelBySkill(forward)["s"] == "haiku")
+        #expect(CLISkillsReport.topModelBySkill(reverse)["s"] == "haiku")
+    }
+
+    @Test("jsonArray emits the scripting contract (keys, Int runs, null topModel)")
+    func jsonShape() {
+        let report = CLISkillsReport(
+            provider: .claudeCode, periodLabel: "all time",
+            rows: [
+                .init(skill: "a", runs: 4, costUSD: 8, topModel: "opus"),
+                .init(skill: "b", runs: 1, costUSD: 1, topModel: nil),
+            ],
+            totalSkills: 2, totalRuns: 5, totalCostUSD: 9
+        )
+        let array = report.jsonArray
+        #expect(JSONSerialization.isValidJSONObject(array))
+        #expect(array[0]["skill"] as? String == "a")
+        #expect(array[0]["runs"] as? Int == 4)
+        #expect(array[0]["costUsd"] as? Double == 8)
+        #expect(array[0]["avgCostUsd"] as? Double == 2)
+        #expect(array[0]["topModel"] as? String == "opus")
+        #expect(array[1]["topModel"] is NSNull)
+    }
+
+    @Test("csv emits header + rows; null topModel is an empty field")
+    func csvShape() {
+        let report = CLISkillsReport(
+            provider: .claudeCode, periodLabel: "all time",
+            rows: [
+                .init(skill: "a", runs: 4, costUSD: 8, topModel: "opus"),
+                .init(skill: "b", runs: 1, costUSD: 1, topModel: nil),
+            ],
+            totalSkills: 2, totalRuns: 5, totalCostUSD: 9
+        )
+        let lines = report.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "skill,runs,costUsd,avgCostUsd,topModel")
+        #expect(lines[1] == "a,4,8.000000,2.000000,opus")
+        #expect(lines[2] == "b,1,1.000000,1.000000,")
+    }
+
+    @Test("TOTAL reflects all skills and flags a truncated top-N")
+    func totalLine() {
+        let full = CLISkillsReport(
+            provider: .claudeCode, periodLabel: "all time",
+            rows: [.init(skill: "a", runs: 1, costUSD: 1, topModel: nil)],
+            totalSkills: 1, totalRuns: 1, totalCostUSD: 1
+        )
+        #expect(full.totalLine == "TOTAL  1 skill(s) · 1 run(s) · $1.00")
+
+        let truncated = CLISkillsReport(
+            provider: .claudeCode, periodLabel: "all time",
+            rows: [.init(skill: "a", runs: 10, costUSD: 100, topModel: nil)],
+            totalSkills: 5, totalRuns: 200, totalCostUSD: 900.13
+        )
+        #expect(truncated.totalLine == "TOTAL  top 1 of 5 skills · 200 run(s) · $900.13")
+    }
+
+    @Test("--json + --csv is rejected; negative --limit is rejected")
+    func optionValidation() throws {
+        #expect(throws: (any Error).self) { _ = try SkillsCommand.parse(["--json", "--csv"]) }
+        #expect(throws: (any Error).self) { _ = try SkillsCommand.parse(["--limit", "-1"]) }
+        _ = try SkillsCommand.parse(["--limit", "5", "--sort", "count"])  // valid: must not throw
+    }
+}

--- a/LupenTests/CLI/SummaryReportTests.swift
+++ b/LupenTests/CLI/SummaryReportTests.swift
@@ -1,0 +1,83 @@
+//
+//  SummaryReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// `lupen summary` is the default command and the most-piped one, so its
+/// JSON/CSV contract and the bounded-vs-unbounded period serialization are
+/// pinned here — a renamed key or a swapped token field would otherwise ship
+/// silently and break every `lupen | jq` / `--csv` consumer.
+@Suite("CLI summary report")
+struct SummaryReportTests {
+    private func totals() -> StoreUsageTotals {
+        StoreUsageTotals(
+            requestCount: 7, inputTokens: 100, outputTokens: 200,
+            reasoningOutputTokens: 50, cacheCreationInputTokens: 10,
+            cacheReadInputTokens: 20, costUSD: 12.5
+        )
+        // contextTokens == 100 + 200 + 50 + 10 + 20 == 380
+    }
+
+    private func report(from: Date?, to: Date?) -> CLISummaryReport {
+        CLISummaryReport(
+            provider: .claudeCode, periodLabel: "last 7 days",
+            range: .init(from: from, to: to),
+            totals: totals(), sessionCount: 3, turnCount: 9
+        )
+    }
+
+    @Test("jsonObject keys, nesting, and token mapping are the stable contract")
+    func jsonShape() {
+        let json = report(from: Date(timeIntervalSince1970: 0), to: Date(timeIntervalSince1970: 86_400)).jsonObject
+        #expect(JSONSerialization.isValidJSONObject(json))
+        #expect(json["provider"] as? String == ProviderKind.claudeCode.rawValue)
+        #expect(json["costUsd"] as? Double == 12.5)
+        #expect(json["sessions"] as? Int == 3)
+        #expect(json["turns"] as? Int == 9)
+        #expect(json["requests"] as? Int == 7)
+
+        let period = json["period"] as? [String: Any]
+        #expect(period?["label"] as? String == "last 7 days")
+
+        let tokens = json["tokens"] as? [String: Any]
+        #expect(tokens?["input"] as? Int == 100)
+        #expect(tokens?["output"] as? Int == 200)
+        #expect(tokens?["reasoning"] as? Int == 50)
+        #expect(tokens?["cacheCreation"] as? Int == 10)
+        #expect(tokens?["cacheRead"] as? Int == 20)
+        #expect(tokens?["context"] as? Int == 380)
+    }
+
+    @Test("period bounds serialize as ISO-8601 strings, or null when unbounded")
+    func periodBounds() {
+        let bounded = report(from: Date(timeIntervalSince1970: 0), to: Date(timeIntervalSince1970: 86_400)).jsonObject
+        let p = bounded["period"] as? [String: Any]
+        let fromStr = p?["from"] as? String
+        #expect(fromStr == "1970-01-01T00:00:00Z")
+        #expect((p?["to"] as? String)?.contains("1970-01-02") == true)
+
+        let unbounded = report(from: nil, to: nil).jsonObject
+        let pu = unbounded["period"] as? [String: Any]
+        #expect(pu?["from"] is NSNull)
+        #expect(pu?["to"] is NSNull)
+    }
+
+    @Test("csv is a metric/value table with the full token breakdown")
+    func csvShape() {
+        let lines = report(from: nil, to: nil).csv.split(separator: "\n").map(String.init)
+        #expect(lines.first == "metric,value")
+        #expect(lines.count == 13)  // header + 12 metric rows
+        #expect(lines.contains("costUsd,12.500000"))
+        #expect(lines.contains("sessions,3"))
+        #expect(lines.contains("turns,9"))
+        #expect(lines.contains("requests,7"))
+        #expect(lines.contains("contextTokens,380"))
+        #expect(lines.contains("provider,\(ProviderKind.claudeCode.rawValue)"))
+    }
+}

--- a/LupenTests/CLI/TimeReportTests.swift
+++ b/LupenTests/CLI/TimeReportTests.swift
@@ -1,0 +1,142 @@
+//
+//  TimeReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+import ArgumentParser
+@testable import Lupen
+
+/// P4: daily/weekly/monthly roll the store's per-day buckets up in pure
+/// code — pin the rollup keys, sort, limit, and serialization.
+@Suite("CLI time reports")
+struct TimeReportTests {
+    private func bucket(_ key: String, cost: Double, req: Int = 1, tok: Int = 100) -> StoreUsageBucket {
+        StoreUsageBucket(bucketKey: key, costUSD: cost, requestCount: req, tokenCount: tok)
+    }
+
+    @Test("day granularity passes through and sorts chronologically")
+    func dailyPassthrough() {
+        let daily = [bucket("2026-06-16", cost: 2), bucket("2026-06-15", cost: 1)]
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: .day, sort: .date, limit: nil)
+        #expect(rows.map(\.label) == ["2026-06-15", "2026-06-16"])
+        #expect(rows[0].costUSD == 1)
+    }
+
+    @Test("month granularity rolls days into YYYY-MM and sums")
+    func monthlyRollup() {
+        let daily = [
+            bucket("2026-05-30", cost: 1, req: 1, tok: 10),
+            bucket("2026-06-01", cost: 2, req: 2, tok: 20),
+            bucket("2026-06-15", cost: 3, req: 3, tok: 30),
+        ]
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: .month, sort: .date, limit: nil)
+        #expect(rows.map(\.label) == ["2026-05", "2026-06"])
+        #expect(rows[1].costUSD == 5)
+        #expect(rows[1].requests == 5)
+        #expect(rows[1].tokens == 50)
+    }
+
+    @Test("week granularity groups by the ISO Monday")
+    func weeklyRollup() {
+        // 2026-06-15 is a Monday; 16 and 21(Sun) share its week; 22 starts the next.
+        #expect(CLITimeReport.weekStart(forDay: "2026-06-16") == "2026-06-15")
+        #expect(CLITimeReport.weekStart(forDay: "2026-06-21") == "2026-06-15")
+        #expect(CLITimeReport.weekStart(forDay: "2026-06-22") == "2026-06-22")
+
+        let daily = [
+            bucket("2026-06-15", cost: 1), bucket("2026-06-16", cost: 2), bucket("2026-06-22", cost: 4),
+        ]
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: .week, sort: .date, limit: nil)
+        #expect(rows.map(\.label) == ["2026-06-15", "2026-06-22"])
+        #expect(rows[0].costUSD == 3)  // 1 + 2
+    }
+
+    @Test("sort by cost (desc, name tie-break) and limit")
+    func sortAndLimit() {
+        let daily = [bucket("2026-06-15", cost: 1), bucket("2026-06-16", cost: 9), bucket("2026-06-17", cost: 5)]
+        let byCost = CLITimeReport.build(dailyBuckets: daily, granularity: .day, sort: .cost, limit: nil)
+        #expect(byCost.map(\.label) == ["2026-06-16", "2026-06-17", "2026-06-15"])
+        let limited = CLITimeReport.build(dailyBuckets: daily, granularity: .day, sort: .cost, limit: 2)
+        #expect(limited.map(\.label) == ["2026-06-16", "2026-06-17"])
+    }
+
+    @Test("distinctBucketCount counts rolled buckets pre-limit")
+    func distinctCount() {
+        let daily = [bucket("2026-06-01", cost: 1), bucket("2026-06-15", cost: 1), bucket("2026-05-01", cost: 1)]
+        #expect(CLITimeReport.distinctBucketCount(dailyBuckets: daily, granularity: .month) == 2)
+        #expect(CLITimeReport.distinctBucketCount(dailyBuckets: daily, granularity: .day) == 3)
+    }
+
+    @Test("TOTAL reflects the whole period and flags truncation")
+    func totalLine() {
+        let full = CLITimeReport(
+            provider: .claudeCode, periodLabel: "all time", granularity: .day,
+            rows: [.init(label: "2026-06-15", costUSD: 5, requests: 3, tokens: 100)],
+            totalPeriods: 1, totalCostUSD: 5, totalRequests: 3, totalTokens: 100
+        )
+        #expect(full.totalLine == "TOTAL  1 day(s) · $5.00 · 3 req · 100 tok")
+
+        let truncated = CLITimeReport(
+            provider: .claudeCode, periodLabel: "all time", granularity: .month,
+            rows: [.init(label: "2026-06", costUSD: 5, requests: 3, tokens: 100)],
+            totalPeriods: 4, totalCostUSD: 20, totalRequests: 12, totalTokens: 400
+        )
+        #expect(truncated.totalLine == "TOTAL  showing 1 of 4 months · $20.00 · 12 req · 400 tok")
+    }
+
+    @Test("ISO week start crosses the year boundary correctly")
+    func weekYearBoundary() {
+        // 2027-01-01 is a Friday → its ISO week starts Mon 2026-12-28.
+        #expect(CLITimeReport.weekStart(forDay: "2027-01-01") == "2026-12-28")
+        #expect(CLITimeReport.weekStart(forDay: "2026-12-31") == "2026-12-28")
+        #expect(CLITimeReport.weekStart(forDay: "2027-01-04") == "2027-01-04")  // first Monday in Jan
+    }
+
+    @Test("date sort + limit keeps the most recent N (chronological tail)")
+    func dateLimitKeepsRecent() {
+        let daily = [bucket("2026-06-15", cost: 1), bucket("2026-06-16", cost: 2), bucket("2026-06-17", cost: 3)]
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: .day, sort: .date, limit: 2)
+        #expect(rows.map(\.label) == ["2026-06-16", "2026-06-17"])  // recent 2, still ascending
+    }
+
+    @Test("month rollup crosses the year boundary")
+    func monthCrossYear() {
+        let daily = [bucket("2026-12-31", cost: 1), bucket("2027-01-01", cost: 2)]
+        let rows = CLITimeReport.build(dailyBuckets: daily, granularity: .month, sort: .date, limit: nil)
+        #expect(rows.map(\.label) == ["2026-12", "2027-01"])
+    }
+
+    @Test("empty buckets and malformed keys degrade gracefully")
+    func emptyAndMalformed() {
+        #expect(CLITimeReport.build(dailyBuckets: [], granularity: .day, sort: .date, limit: nil).isEmpty)
+        #expect(CLITimeReport.distinctBucketCount(dailyBuckets: [], granularity: .month) == 0)
+        #expect(CLITimeReport.weekStart(forDay: "not-a-date") == nil)
+        #expect(CLITimeReport.key(forDay: "garbage", granularity: .week) == "garbage")
+    }
+
+    @Test("json and csv shapes")
+    func serialization() {
+        let report = CLITimeReport(
+            provider: .claudeCode, periodLabel: "all time", granularity: .day,
+            rows: [.init(label: "2026-06-15", costUSD: 1.5, requests: 2, tokens: 30)],
+            totalPeriods: 1, totalCostUSD: 1.5, totalRequests: 2, totalTokens: 30
+        )
+        #expect(JSONSerialization.isValidJSONObject(report.jsonArray))
+        #expect(report.jsonArray[0]["period"] as? String == "2026-06-15")
+        #expect(report.jsonArray[0]["requests"] as? Int == 2)
+        let lines = report.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "period,costUsd,requests,tokens")
+        #expect(lines[1] == "2026-06-15,1.500000,2,30")
+    }
+
+    @Test("--sort parsing for time reports")
+    func sortParsing() throws {
+        #expect(try TimeSort.parse(nil, default: .date) == .date)
+        #expect(try TimeSort.parse("cost", default: .date) == .cost)
+        #expect(throws: ValidationError.self) { _ = try TimeSort.parse("name", default: .date) }
+    }
+}

--- a/LupenTests/CLI/TopReportTests.swift
+++ b/LupenTests/CLI/TopReportTests.swift
@@ -1,0 +1,164 @@
+//
+//  TopReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P5: `lupen top` ranks the costliest sessions/days. Pure helpers are
+/// pinned directly; the new top-sessions SQL is exercised against the
+/// fixture corpus so a column-name slip can't slip through.
+@Suite("CLI top report")
+struct TopReportTests {
+    @Test("topDays ranks by cost desc (date tie-break) and limits")
+    func topDays() {
+        let buckets = [
+            StoreUsageBucket(bucketKey: "2026-06-15", costUSD: 1, requestCount: 1, tokenCount: 10),
+            StoreUsageBucket(bucketKey: "2026-06-16", costUSD: 9, requestCount: 2, tokenCount: 20),
+            StoreUsageBucket(bucketKey: "2026-06-17", costUSD: 5, requestCount: 3, tokenCount: 30),
+        ]
+        let rows = CLITopReport.topDays(buckets, limit: 2)
+        #expect(rows.map(\.key) == ["2026-06-16", "2026-06-17"])
+        #expect(rows[0].costUSD == 9)
+        #expect(rows[0].requests == 2)
+    }
+
+    @Test("shortID and truncate")
+    func displayHelpers() {
+        #expect(CLITopReport.shortID("0123456789abcdef") == "01234567")
+        #expect(CLITopReport.shortID("short") == "short")
+        #expect(CLITopReport.truncate("abcdefghij", 5) == "abcd…")
+        #expect(CLITopReport.truncate("abc", 5) == "abc")
+    }
+
+    @Test("--by parses sessions/days, rejects junk")
+    func dimensionParsing() {
+        #expect(TopDimension(argument: "sessions") == .sessions)
+        #expect(TopDimension(argument: "days") == .days)
+        #expect(TopDimension(argument: "turns") == nil)
+    }
+
+    @Test("json/csv shapes differ by dimension")
+    func serialization() {
+        let sessions = CLITopReport(
+            provider: .claudeCode, periodLabel: "all time", dimension: .sessions,
+            rows: [
+                .init(key: "sid-1", project: "/p", title: "hello", costUSD: 5, requests: 3),
+                .init(key: "sid-2", project: nil, title: nil, costUSD: 1, requests: 1),
+            ],
+            totalCount: 2, periodCostUSD: 6
+        )
+        let array = sessions.jsonArray
+        #expect(JSONSerialization.isValidJSONObject(array))
+        #expect(array[0]["sessionId"] as? String == "sid-1")
+        #expect(array[0]["costUsd"] as? Double == 5)
+        #expect(array[1]["title"] is NSNull)
+        #expect(sessions.csv.split(separator: "\n").first.map(String.init) == "sessionId,project,title,costUsd,requests")
+
+        let days = CLITopReport(
+            provider: .claudeCode, periodLabel: "all time", dimension: .days,
+            rows: [.init(key: "2026-06-15", project: nil, title: nil, costUSD: 2, requests: 1)],
+            totalCount: 1, periodCostUSD: 2
+        )
+        #expect(days.jsonArray[0]["day"] as? String == "2026-06-15")
+        #expect(days.csv.split(separator: "\n").first.map(String.init) == "day,costUsd,requests")
+    }
+
+    @Test("TOTAL footer anchors against the period and flags truncation")
+    func totalLine() {
+        let full = CLITopReport(
+            provider: .claudeCode, periodLabel: "all time", dimension: .sessions,
+            rows: [.init(key: "a", project: nil, title: nil, costUSD: 5, requests: 1)],
+            totalCount: 1, periodCostUSD: 5
+        )
+        #expect(full.totalLine == "TOTAL  1 session(s) · $5.00 period total")
+
+        let truncated = CLITopReport(
+            provider: .claudeCode, periodLabel: "all time", dimension: .sessions,
+            rows: [.init(key: "a", project: nil, title: nil, costUSD: 90, requests: 1)],
+            totalCount: 12, periodCostUSD: 123.45
+        )
+        #expect(truncated.totalLine == "TOTAL  top 1 of 12 sessions · $123.45 period total")
+    }
+
+    @Test("--limit < 0 is rejected; a valid limit parses")
+    func limitValidation() throws {
+        #expect(throws: (any Error).self) { _ = try TopCommand.parse(["--limit", "-1"]) }
+        _ = try TopCommand.parse(["--by", "days", "--limit", "5"])
+    }
+
+    @Test("topSessionCosts honors the date window and the row limit (corpus)")
+    func sessionsDateAndLimit() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-topwin-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .claude(projectsDirectory: corpus.projectsDir), store: store)
+
+        let all = try store.topSessionCosts(from: nil, to: nil, limit: 100)
+        #expect(all.count > 1)
+
+        // Row limit caps the result.
+        let capped = try store.topSessionCosts(from: nil, to: nil, limit: 1)
+        #expect(capped.count == 1)
+
+        // A window after the corpus's activity returns nothing.
+        let future = Date(timeIntervalSince1970: 4_000_000_000)  // year ~2096
+        let empty = try store.topSessionCosts(from: future, to: nil, limit: 100)
+        #expect(empty.isEmpty)
+    }
+
+    @Test("top-sessions SQL runs against the corpus, sorted by cost desc")
+    func topSessionsFromCorpus() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-top-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .claude(projectsDirectory: corpus.projectsDir), store: store)
+
+        let top = try store.topSessionCosts(from: nil, to: nil, limit: 5)
+        #expect(top.count > 0)
+        #expect(top.count <= 5)
+        for index in 1..<top.count {
+            #expect(top[index - 1].costUSD >= top[index].costUSD)
+        }
+    }
+
+    @Test("visibleSessionCount equals the topSessionCosts row population (corpus)")
+    func visibleSessionCountMatchesRows() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-topcount-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .claude(projectsDirectory: corpus.projectsDir), store: store)
+
+        // The footer denominator must count exactly the sessions the rows are
+        // drawn from — one GROUP BY row per visible, non-superseded session.
+        let rows = try store.topSessionCosts(from: nil, to: nil, limit: 100_000)
+        let count = try store.visibleSessionCount(from: nil, to: nil)
+        #expect(count > 0)
+        #expect(count == rows.count)
+    }
+
+    @Test("topDays guards a non-positive limit instead of trapping")
+    func topDaysNonPositiveLimit() {
+        let buckets = [
+            StoreUsageBucket(bucketKey: "2026-06-15", costUSD: 1, requestCount: 1, tokenCount: 10),
+        ]
+        #expect(CLITopReport.topDays(buckets, limit: 0).isEmpty)
+        #expect(CLITopReport.topDays(buckets, limit: -3).isEmpty)
+    }
+}

--- a/LupenTests/CLI/VerifyReportTests.swift
+++ b/LupenTests/CLI/VerifyReportTests.swift
@@ -1,0 +1,125 @@
+//
+//  VerifyReportTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/18.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// P6: `lupen verify` groups the verifier's divergences into per-session
+/// mismatch rows. The grouping is pure; the end-to-end recompute-vs-index
+/// agreement is exercised against the fixture corpus.
+@Suite("CLI verify report")
+struct VerifyReportTests {
+    private typealias Divergence = GroundTruthVerifier.Divergence
+
+    @Test("divergences group by session; cost pair extracted; sorted by |delta|")
+    func build() {
+        let divergences = [
+            Divergence(sessionId: "s1", kind: .costMismatch(viewUSD: 5, truthUSD: 4)),
+            Divergence(sessionId: "s1", kind: .outputTokenMismatch(view: 10, truth: 8)),
+            Divergence(sessionId: "s2", kind: .requestCountMismatch(view: 3, truth: 2)),
+        ]
+        let rows = CLIVerifyReport.build(divergences: divergences)
+        #expect(rows.count == 2)
+        // s1 has a cost delta of 1; s2 has no cost pair (delta nil → 0) → s1 first.
+        #expect(rows[0].sessionId == "s1")
+        #expect(rows[0].viewCostUSD == 5)
+        #expect(rows[0].truthCostUSD == 4)
+        #expect(rows[0].delta == 1)
+        #expect(rows[0].kinds == ["cost", "output"])  // sorted, deduped
+        #expect(rows[1].sessionId == "s2")
+        #expect(rows[1].delta == nil)
+        #expect(rows[1].kinds == ["requestCount"])
+    }
+
+    @Test("hasDrift and json/csv shapes")
+    func serialization() {
+        let clean = CLIVerifyReport(provider: .claudeCode, verifiedSessionCount: 5, rows: [], pendingCount: 0, issueCount: 0)
+        #expect(clean.hasDrift == false)
+        #expect(clean.jsonObject["drift"] as? Bool == false)
+
+        let drift = CLIVerifyReport(
+            provider: .claudeCode, verifiedSessionCount: 3,
+            rows: [.init(sessionId: "s1", viewCostUSD: 5, truthCostUSD: 4, kinds: ["cost"])],
+            pendingCount: 1, issueCount: 2
+        )
+        #expect(drift.hasDrift)
+        let json = drift.jsonObject
+        #expect(JSONSerialization.isValidJSONObject(json))
+        #expect(json["drift"] as? Bool == true)
+        #expect(json["verifiedSessions"] as? Int == 3)
+        #expect(json["pending"] as? Int == 1)
+        let mismatches = json["mismatches"] as? [[String: Any]]
+        #expect(mismatches?.count == 1)
+        #expect(mismatches?[0]["sessionId"] as? String == "s1")
+        #expect(mismatches?[0]["costDelta"] as? Double == 1)
+
+        let lines = drift.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "sessionId,viewCostUsd,truthCostUsd,costDelta,kinds")
+        #expect(lines[1] == "s1,5.000000,4.000000,1.000000,cost")
+    }
+
+    @Test("a session with only token/count divergences yields a nil-cost row")
+    func tokenOnlyRow() {
+        let divergences = [
+            Divergence(sessionId: "s", kind: .outputTokenMismatch(view: 10, truth: 8)),
+            Divergence(sessionId: "s", kind: .requestCountMismatch(view: 3, truth: 2)),
+        ]
+        let rows = CLIVerifyReport.build(divergences: divergences)
+        #expect(rows.count == 1)
+        #expect(rows[0].viewCostUSD == nil)
+        #expect(rows[0].truthCostUSD == nil)
+        #expect(rows[0].delta == nil)
+        #expect(rows[0].kinds == ["output", "requestCount"])
+    }
+
+    @Test("csv renders nil cost cells as empty fields")
+    func csvNilCells() {
+        let report = CLIVerifyReport(
+            provider: .claudeCode, verifiedSessionCount: 1,
+            rows: [.init(sessionId: "s", viewCostUSD: nil, truthCostUSD: nil, kinds: ["output", "requestCount"])],
+            pendingCount: 0, issueCount: 0
+        )
+        let lines = report.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[1] == "s,,,,output;requestCount")
+    }
+
+    @Test("mismatchSummary keeps short lists, truncates long ones")
+    func mismatchSummary() {
+        #expect(CLIVerifyReport.mismatchSummary(["cost"]) == "cost")
+        #expect(CLIVerifyReport.mismatchSummary(["a", "b", "c"]) == "a, b, c")
+        #expect(CLIVerifyReport.mismatchSummary(["a", "b", "c", "d", "e"]) == "a, b, c +2 more")
+    }
+
+    @Test("kindLabel covers the divergence kinds used in output")
+    func kindLabels() {
+        #expect(CLIVerifyReport.kindLabel(.costMismatch(viewUSD: 1, truthUSD: 0)) == "cost")
+        #expect(CLIVerifyReport.kindLabel(.unknownPricing(model: "x")) == "unknownPricing")
+        #expect(CLIVerifyReport.kindLabel(.sessionMissingInView(sessionId: "x")) == "missingInView")
+    }
+
+    @Test("a freshly built index verifies clean against the independent recompute (corpus)")
+    func freshIndexVerifiesClean() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-verify-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .claude(projectsDirectory: corpus.projectsDir), store: store)
+
+        let verifier = ClaudeUsageVerifier()
+        let files = try store.allSourceFiles().map { URL(fileURLWithPath: $0.path) }
+        let report = verifier.computeReport(files: files)
+        let verification = verifier.verify(report: report, againstSQLite: store)
+
+        // The importer and the independent verifier must agree on the
+        // equivalence corpus — that agreement IS the Verify Costs promise.
+        #expect(verification.divergences.isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Lupen breaks the number down and recomputes each cost from the raw tokens.
 - **Sub-agent cost rollup** — When a Turn spawns sub-agents, their cost rolls up into the parent in the outline but stays separately attributable in the detail pane. The aggregate and the per-agent figures come from the same source, so they stay consistent.
 - **Origin-tagged attachment tracking** — File paths, image bytes, and URLs are classified by where they entered the conversation (inline prompt, tool input, tool output, reply, …) so you can see what's filling the context window.
 - **5-hour limit tracking** — A Bayesian estimate of `$ per 1 % of limit consumed` across your last 7 days, surfaced in the menu-bar icon's ring tint (yellow at 70 %, orange at 90 %, red at 100 %).
+- **Scriptable `lupen` CLI** — The same app binary is a command line over the same local index: every report as a table, `--json`, or `--csv`, plus `verify` / `budget` exit-code gates for a CI step or commit hook. See [Command line](#command-line).
 - **Zero network** — Lupen only reads local Claude Code and Codex files on disk. No API keys, no telemetry, no cloud sync.
 
 ## Install
@@ -93,6 +94,41 @@ cp Config/Local.xcconfig.example Config/Local.xcconfig  # set DEVELOPMENT_TEAM
 xcodebuild build -project Lupen.xcodeproj -scheme Lupen -destination 'platform=macOS'
 open ~/Library/Developer/Xcode/DerivedData/Lupen-*/Build/Products/Debug/Lupen.app
 ```
+
+## Command line
+
+The app binary doubles as a `lupen` CLI — same local index the menu-bar app
+builds, every report scriptable and local:
+
+<p align="center">
+  <img src="docs/branding/lupen-cli.svg" alt="lupen skills --last 30d — a per-skill cost table with RUNS, COST, $/run, and top model columns" width="620">
+</p>
+
+```bash
+lupen skills --last 30d            # per-skill cost, $/run, top model
+lupen top --by sessions --limit 5  # the costliest sessions
+lupen budget --over 20 --last 7d   # exit 4 if this week ran over $20
+lupen verify                       # exit 4 if any cost drifts from the recomputed truth
+lupen daily --json | jq            # any report as JSON / CSV
+```
+
+The full command set, grouped:
+
+| | Commands |
+|---|---|
+| **Spend** | `summary` (default) · `daily` / `weekly` / `monthly` |
+| **Breakdowns** | `skills` · `models` · `projects` · `top` |
+| **Find & resume** | `search <text>` · `resume <session-id>` |
+| **Guards** (exit-code gates for CI) | `verify` · `budget --over <usd>` · `statusline` |
+| **Index & setup** | `refresh` · `config` · `install-cli` |
+
+Every reporting command takes `--provider`, a period (`--last 30d` / `--month
+2026-06` / `--since … --until …`), and `--json` / `--csv` — except `verify`,
+which audits the whole corpus and ignores the period.
+
+Once a release ships the CLI, Homebrew puts `lupen` on your PATH automatically;
+on a DMG or source build, run `lupen install-cli` once. Full reference — every
+flag and exit code: [docs/CLI.md](docs/CLI.md).
 
 ## Why I built this
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,108 @@
+# `lupen` — command line
+
+Lupen ships a CLI in the same binary as the app: scriptable, local, and
+reading the very same index the menu-bar app maintains. Every report the
+dashboard shows is available as a table, `--json`, or `--csv`.
+
+```
+lupen skills --last 30d
+lupen top --by sessions --limit 5
+lupen verify            # exit 4 if any cost drifts from the recomputed truth
+```
+
+## Install
+
+The CLI is the app's own executable exposed on your `PATH` as `lupen`.
+
+- **Homebrew** (once a release with the CLI ships): `brew install --cask momoraul/lupen/lupen` symlinks `lupen` automatically.
+- **DMG / build from source**: run `lupen install-cli` once — it symlinks
+  `lupen` into the first writable PATH directory (`/opt/homebrew/bin`,
+  `/usr/local/bin`, or `~/.local/bin`). Or symlink it yourself:
+
+  ```
+  ln -s /Applications/Lupen.app/Contents/MacOS/Lupen /opt/homebrew/bin/lupen
+  ```
+
+`lupen` reads from disk only — no network, no API keys (the same promise as
+the app). The index is a cache of `~/.claude` / `~/.codex`; the CLI builds it
+itself on first run, so the app need not have been opened.
+
+## Global options
+
+Available on every reporting command:
+
+| Option | Meaning |
+|---|---|
+| `--provider claude-code\|codex` | Which provider to report on (default: `claude-code`). |
+| `--last <Nd\|Nw\|Nm>` | Relative window ending now, e.g. `30d`, `4w`, `1m`. |
+| `--month <YYYY-MM>` | A calendar month. |
+| `--since <YYYY-MM-DD> --until <YYYY-MM-DD>` | Explicit inclusive range. |
+| `--json` / `--csv` | Machine-readable output (mutually exclusive). |
+| `--no-color` | Disable ANSI color in tables. |
+| `--refresh` / `--no-refresh` | Update the index from the logs first (default: on). |
+
+`--last`, `--month`, and `--since/--until` are mutually exclusive; with none,
+all recorded usage is included.
+
+Row reports (`skills`, `daily`, `weekly`, `monthly`, `models`, `projects`)
+also take `--limit <N>` and `--sort`.
+
+## Commands
+
+### Spend overview
+- **`summary`** (default) — totals for the period: cost, sessions, turns, requests, tokens.
+- **`daily`** / **`weekly`** / **`monthly`** — cost & usage per day / ISO week / month. `--sort date` (default) or `cost`; `--limit` keeps the most recent N (or costliest under `--sort cost`).
+
+### Breakdowns
+- **`skills`** — per-skill invocations, cost, $/run, and top model. `--sort cost` (default), `count`, or `name`.
+- **`models`** — per-model uses + cost.
+- **`projects`** — per-project sessions + cost.
+- **`top`** — the most expensive `--by sessions` (default) or `--by days`. `--limit` (default 10).
+
+### Find & resume
+- **`search <text>`** — full-text search across every prompt, grouped by session (with a snippet). `--limit` (default 20).
+- **`resume <session-id>`** — print (or `--run`) the command to reopen a session in its CLI (`claude --resume` / `codex resume`). Pass a full id from `search`/`top --json`.
+
+### Trust & guards
+- **`verify`** — recompute every session's cost from the raw logs and diff it against the index. **Exits 4 on any drift** — a CI / pre-commit gate. Audits the whole corpus (period flags don't apply).
+- **`budget --over <usd>`** — **exits 4** when spend over the period exceeds the threshold. Scope it with `--last`/`--month`.
+- **`statusline`** — a compact one-line spend figure (`$X.XX`, today by default) for a shell prompt or Claude Code `statusLine`. Never refreshes (instant); emits nothing on stderr.
+
+### Index & setup
+- **`refresh`** — index new/changed logs now, no report. (Pre-warm for `statusline`/cron.)
+- **`config`** — the paths and versions Lupen uses for the current provider.
+- **`install-cli`** — symlink `lupen` onto your PATH (DMG installs).
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. On an empty index reports still exit 0 — `summary` prints zero totals; the row/breakdown reports print a "No usage…" line. |
+| `3` | Nothing to act on: `verify` found no logs to audit, or `install-cli` found no writable PATH directory. |
+| `4` | A gate failed: `verify` found drift, or `budget` is over. |
+| `64` | Usage error (bad flags / arguments) — ArgumentParser's `EX_USAGE`. |
+
+## Examples
+
+```bash
+# This month's spend, by skill, as JSON for jq
+lupen skills --month 2026-06 --json | jq '.[0]'
+
+# The five costliest sessions in the last week
+lupen top --by sessions --last 7d --limit 5
+
+# Fail CI if this week cost more than $20
+lupen budget --over 20 --last 7d
+
+# Gate a commit on cost accuracy
+lupen verify || echo "cost drift detected"
+
+# Find a past session and resume it
+lupen search "rate limiter" --json | jq -r '.[0].sessionId' | xargs lupen resume
+
+# Today's Claude Code spend in your shell prompt
+PROMPT="$(lupen statusline) \$ "
+```
+
+JSON keys are stable camelCase (`costUsd`, `avgCostUsd`, …); CSV is RFC-4180
+with spreadsheet-formula-injection guarding. Both are safe to pipe.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,6 +73,20 @@ asset** (large binaries don't belong in Pages) and point each appcast
 Existing users get the update via Sparkle; new users download the DMG or
 `brew install --cask`.
 
+### Exposing the `lupen` CLI (one-time, with the first CLI release)
+
+The app binary doubles as the `lupen` command line. To put it on a brew
+user's PATH automatically, add a `binary` stanza to the cask **once the
+shipped DMG actually contains the CLI** (do NOT add it before then — it
+would symlink a CLI-less binary and `lupen` would just open the GUI):
+
+```ruby
+binary "#{appdir}/Lupen.app/Contents/MacOS/Lupen", target: "lupen"
+```
+
+DMG-only users run `lupen install-cli` instead. The CLI updates with the app
+(same bundle), so there's nothing extra to ship per release after this.
+
 ## Packaging gotchas
 - **Hardened Runtime** + `--timestamp` are required for notarization (the
   script sets them).

--- a/docs/branding/lupen-cli.svg
+++ b/docs/branding/lupen-cli.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 548 350" width="548" height="350" role="img" aria-label="Terminal showing: lupen skills --last 30d — a per-skill cost table with RUNS, COST, dollars per run, and TOP MODEL columns, totalling 91 runs and $291.07. Synthetic demo data.">
+  <!-- window -->
+  <rect x="0.5" y="0.5" width="547" height="349" rx="12" fill="#0b1020" stroke="#233059"/>
+  <!-- title bar -->
+  <path d="M0 12 A12 12 0 0 1 12 0 H536 A12 12 0 0 1 548 12 V40 H0 Z" fill="#141b33"/>
+  <line x1="0" y1="40.5" x2="548" y2="40.5" stroke="#233059"/>
+  <circle cx="22" cy="20" r="6" fill="#ff5f56"/>
+  <circle cx="42" cy="20" r="6" fill="#febc2e"/>
+  <circle cx="62" cy="20" r="6" fill="#28c840"/>
+  <text x="274" y="24.5" text-anchor="middle" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" font-size="12" fill="#6b7aa8">lupen — zsh</text>
+  <!-- body: columns positioned by explicit x (numeric columns right-anchored) so
+       alignment never depends on whitespace collapsing -->
+  <g font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" font-size="14">
+    <!-- command -->
+    <text y="76"><tspan x="24" fill="#3ddc97">$</tspan><tspan fill="#e8ecff"> lupen skills --last 30d</tspan></text>
+    <!-- provider · period -->
+    <text x="24" y="116" fill="#8aa2ff">Claude Code · last 30d</text>
+    <!-- header -->
+    <text y="156" fill="#6f7cb0"><tspan x="24">SKILL</tspan><tspan x="185" text-anchor="end">RUNS</tspan><tspan x="278" text-anchor="end">COST</tspan><tspan x="356" text-anchor="end">$/RUN</tspan><tspan x="376">TOP MODEL</tspan></text>
+    <!-- rows -->
+    <text y="180" fill="#cdd6ff"><tspan x="24">refactor</tspan><tspan x="185" text-anchor="end">16</tspan><tspan x="278" text-anchor="end">$182.40</tspan><tspan x="356" text-anchor="end">$11.40</tspan><tspan x="376">claude-fable-5</tspan></text>
+    <text y="204" fill="#cdd6ff"><tspan x="24">code-review</tspan><tspan x="185" text-anchor="end">30</tspan><tspan x="278" text-anchor="end">$63.00</tspan><tspan x="356" text-anchor="end">$2.10</tspan><tspan x="376">claude-opus-4-8</tspan></text>
+    <text y="228" fill="#cdd6ff"><tspan x="24">write-tests</tspan><tspan x="185" text-anchor="end">24</tspan><tspan x="278" text-anchor="end">$32.40</tspan><tspan x="356" text-anchor="end">$1.35</tspan><tspan x="376">claude-sonnet-4-6</tspan></text>
+    <text y="252" fill="#cdd6ff"><tspan x="24">doc-sync</tspan><tspan x="185" text-anchor="end">13</tspan><tspan x="278" text-anchor="end">$9.75</tspan><tspan x="356" text-anchor="end">$0.75</tspan><tspan x="376">claude-sonnet-4-6</tspan></text>
+    <text y="276" fill="#cdd6ff"><tspan x="24">changelog</tspan><tspan x="185" text-anchor="end">8</tspan><tspan x="278" text-anchor="end">$3.52</tspan><tspan x="356" text-anchor="end">$0.44</tspan><tspan x="376">claude-haiku-4-5</tspan></text>
+    <!-- total -->
+    <text y="314" fill="#9bb0ff"><tspan x="24">TOTAL</tspan><tspan x="82">5 skill(s) · 91 run(s) · $291.07</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
- **Add the swift-argument-parser dependency**
- **Add headless store/domain support for the lupen CLI**
- **Add the `lupen` CLI: shared-binary dispatch, reports, and guards**
- **Add CLI unit tests**
- **Gate the log window behind DEBUG builds**
- **Document the `lupen` CLI**
