### PR TITLE
chore: clear build warnings

### DIFF
--- a/Lupen.xcodeproj/project.pbxproj
+++ b/Lupen.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2650;
 			};
 			buildConfigurationList = CL0000000000000000000001 /* Build configuration list for PBXProject "Lupen" */;
 			developmentRegion = en;
@@ -351,7 +351,6 @@
 			baseConfigurationReference = RF0000000000000000000011 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -369,7 +368,6 @@
 			baseConfigurationReference = RF0000000000000000000012 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Lupen/Store/DiagnosticsProjection.swift
+++ b/Lupen/Store/DiagnosticsProjection.swift
@@ -24,7 +24,7 @@ enum DiagnosticsProjection {
         // Ring-buffer semantics: newest LAST (the view reverses).
         let samples = rows.reversed().map { row in
             ParseDiagnostics.Sample(
-                at: row.createdAt ?? Date(),
+                at: row.createdAt,
                 fileURL: nil,
                 byteOffset: (row.byteOffset).map(Int.init),
                 rejection: rejection(category: row.category),

--- a/Lupen/Store/ProviderStore.swift
+++ b/Lupen/Store/ProviderStore.swift
@@ -1188,7 +1188,7 @@ extension ProviderStore: ImportWriting {
         var imported = source
         imported.parseState = .imported
         imported.importedAt = Date()
-        try database.pool.write { db in
+        _ = try database.pool.write { db in
             try Self.upsertSourceFile(imported, db: db)
         }
         return true

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -503,11 +503,8 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         // The legacy Codex load-summary panel died with the in-memory
         // loader (5.3) — the view stays in the layout chain as a
         // permanently hidden zero-height spacer.
-        let shouldShow = false
-        codexLoadSummaryView.isHidden = !shouldShow
-        codexLoadSummaryHeightConstraint?.constant = shouldShow
-            ? SidebarMetrics.statusStripHeight
-            : 0
+        codexLoadSummaryView.isHidden = true
+        codexLoadSummaryHeightConstraint?.constant = 0
     }
 
     /// Refresh the filter button's icon to reflect whether any

--- a/Lupen/UI/Reports/TimelineOverviewView.swift
+++ b/Lupen/UI/Reports/TimelineOverviewView.swift
@@ -430,13 +430,13 @@ struct TimelineOverviewView: View {
         }
     }
 
-    nonisolated(unsafe) private static let hoverDayFormatter: DateFormatter = {
+    private static let hoverDayFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .medium
         f.timeStyle = .none
         return f
     }()
-    nonisolated(unsafe) private static let hoverHourFormatter: DateFormatter = {
+    private static let hoverHourFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d, HH:00"
         return f


### PR DESCRIPTION
AccentColor (drop dangling asset-catalog setting), dead ?? Date() coalesce, unused write result, unreachable ternary branch, redundant nonisolated(unsafe) on Sendable DateFormatters.
