### PR TITLE
fix: fold last-only Codex token events in the usage verifier

### DIFF
--- a/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
+++ b/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
@@ -374,6 +374,17 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
         let usage: CodexTokenUsage?
         if let last = info.lastTokenUsage {
             usage = last
+            // Mirror CodexUsageAggregator.resolveUsage: a `last`-only event
+            // (no `total`) must still advance the running total, otherwise a
+            // later total-bearing event's delta is computed against a stale
+            // baseline and the verifier diverges from the importer.
+            if info.totalTokenUsage == nil {
+                if let totalBeforeLast = previousTotal {
+                    previousTotal = totalBeforeLast.adding(last)
+                } else {
+                    previousTotal = last
+                }
+            }
         } else if let total = info.totalTokenUsage {
             if let previousTotal {
                 usage = total.delta(from: previousTotal)

--- a/LupenTests/Domain/Codex/CodexUsageVerifierTests.swift
+++ b/LupenTests/Domain/Codex/CodexUsageVerifierTests.swift
@@ -241,4 +241,24 @@ struct CodexUsageVerifierTests {
         }
     }
 
+    @Test("last-only token_count event folds into the running total (verifier matches importer)")
+    func lastOnlyEventFoldsIntoTotal() throws {
+        try withTempCodexHome { home in
+            let file = try writeCodexSession(home: home, lines: [
+                // `last_token_usage` only (no `total`): must fold into the running
+                // total so the next total event deltas against (previous + last).
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:02Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex","last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":6,"reasoning_output_tokens":0,"total_tokens":106}}}}"#,
+                // `total_token_usage` only (cumulative).
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:03Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex","total_token_usage":{"input_tokens":150,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":160}}}}"#
+            ])
+
+            let result = try verifiedStore(home: home, files: [file])
+
+            // Without the fold the verifier double-counts the second event
+            // (250 input vs the importer's 150) and diverges. With it they agree.
+            #expect(result.divergences.isEmpty)
+            #expect(result.report.perSession["codex:verify-codex"]?.dedupedInputTokens == 150)
+        }
+    }
+
 }


### PR DESCRIPTION
ProviderUsageVerifier.resolveUsage skipped advancing previousTotal on a `last`-only token_count event (no `total`), while the importer (CodexUsageAggregator.resolveUsage) folds it. A later total event then deltas against a stale baseline and the verifier diverges from the stored view. Mirror the aggregator exactly; guarded by `total == nil` so total-bearing events (all current data) are unchanged. Adds a same-piece last-only→total fixture that diverges before the fix.
