### PR TITLE
fix(codex): bound single-piece import/verify memory for oversized rollouts

### DIFF
--- a/Lupen/Domain/Codex/CodexConversationAssembler.swift
+++ b/Lupen/Domain/Codex/CodexConversationAssembler.swift
@@ -372,6 +372,17 @@ enum CodexConversationAssembler {
     }
 }
 
+extension CodexConversationAssembler {
+    /// Canonical Codex user-message predicate. Shared (internal) with
+    /// `CodexEntry.lightweightProjection` so the projection's preserved
+    /// set is defined by the SAME rule the aggregator/trimmer/assembler
+    /// match on — it cannot silently drift.
+    static func isUserMessage(_ entry: CodexEntry, _ payload: CodexEntry.Payload) -> Bool {
+        (entry.type == "response_item" && payload.type == "message" && payload.role == "user")
+            || (entry.type == "event_msg" && payload.type == "user_message")
+    }
+}
+
 private extension CodexConversationAssembler {
     struct TurnDraft {
         let key: String
@@ -407,11 +418,6 @@ private extension CodexConversationAssembler {
 
     static func isTurnContext(_ entry: CodexEntry, _ payload: CodexEntry.Payload) -> Bool {
         entry.type == "turn_context" || payload.type == "turn_context"
-    }
-
-    static func isUserMessage(_ entry: CodexEntry, _ payload: CodexEntry.Payload) -> Bool {
-        (entry.type == "response_item" && payload.type == "message" && payload.role == "user")
-            || (entry.type == "event_msg" && payload.type == "user_message")
     }
 
     static func isAssistantMessage(_ entry: CodexEntry, _ payload: CodexEntry.Payload) -> Bool {

--- a/Lupen/Domain/Codex/CodexEntryProjection.swift
+++ b/Lupen/Domain/Codex/CodexEntryProjection.swift
@@ -1,0 +1,94 @@
+//
+//  CodexEntryProjection.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/19.
+//
+
+import Foundation
+
+extension CodexEntry {
+    /// Memory-bounded projection for an oversized rollout piece (see
+    /// `CodexDetailImporter.importPiece`). Clips the non-user
+    /// conversation BODY (assistant replies, tool output/args) to
+    /// `textCap` characters and drops the large display-only structured
+    /// JSON, so the per-piece working set tracks line count × cap instead
+    /// of file bytes.
+    ///
+    /// **User-prompt text is preserved VERBATIM.** It is the matching
+    /// basis for everything load-bearing: the subagent replay trim and
+    /// the same-raw dedup match prompt text; skill detection, prompt
+    /// preview, search content, and first-prompt all derive from it.
+    /// Leaving it untouched is what makes the projection usage-/turn-/
+    /// skill-/link-equivalent to the full path for any non-duplicated
+    /// piece — including a parent whose prompts seed its children's trim.
+    /// `info` (token usage), `type`/`role`/`turnId`/`model`/`cwd`, and the
+    /// `name`/`call_id` link fields are likewise preserved; `output`
+    /// (spawn `agent_id` JSON) is small and survives the clip.
+    ///
+    /// The importer still excludes DUPLICATED chains, whose same-raw
+    /// dedup keys on assistant text — that is the only cross-piece
+    /// matcher that reads non-user body. Pinned by the equivalence tests.
+    ///
+    /// Known display-only limitation: clipping non-user body can make the
+    /// assembler's intra-piece mirror dedup (`isMatchingResponseMirror`,
+    /// which compares normalized assistant text) miss a match when the
+    /// SAME reply is a single string on the `event_msg` mirror side but
+    /// multi-block `content` on the `response_item` side and exceeds the
+    /// cap — leaving a duplicate assistant step (`StoreTurnRow.stepCount`
+    /// +1). No usage/cost/turn/skill/link/search number is affected, and
+    /// it only arises in a >=threshold (degraded) session.
+    func lightweightProjection(textCap: Int) -> CodexEntry {
+        guard let payload else { return self }
+
+        // Reuse the ONE canonical user-message predicate (shared with the
+        // aggregator, subagent trimmer, and assembler) so the preserved
+        // set can never drift from what the matchers read.
+        let isUserMessage = CodexConversationAssembler.isUserMessage(self, payload)
+
+        func clip(_ value: String?) -> String? {
+            // `utf8.count` is O(1) (String is UTF-8 backed) and a necessary
+            // precondition for `count > textCap`, so an already-short field
+            // skips the O(n) grapheme walk entirely; only a genuine over-cap
+            // candidate pays for the grapheme count + prefix.
+            guard let value, value.utf8.count > textCap else { return value }
+            return value.count > textCap ? String(value.prefix(textCap)) : value
+        }
+        func clip(_ blocks: [ContentBlock]) -> [ContentBlock] {
+            blocks.map { ContentBlock(type: $0.type, text: clip($0.text)) }
+        }
+
+        let projected = Payload(
+            type: payload.type,
+            timestamp: payload.timestamp,
+            turnId: payload.turnId,
+            model: payload.model,
+            cwd: payload.cwd,
+            info: payload.info,
+            role: payload.role,
+            // Preserve user-prompt text; clip only non-user body.
+            message: isUserMessage ? payload.message : clip(payload.message),
+            text: isUserMessage ? payload.text : clip(payload.text),
+            content: isUserMessage ? payload.content : clip(payload.content),
+            summary: isUserMessage ? payload.summary : clip(payload.summary),
+            name: payload.name,
+            arguments: clip(payload.arguments),
+            input: clip(payload.input),
+            output: clip(payload.output),
+            callId: payload.callId,
+            id: payload.id,
+            status: payload.status,
+            changes: nil,
+            tools: nil,
+            invocation: nil,
+            action: nil,
+            result: nil,
+            duration: nil,
+            execution: clip(payload.execution),
+            query: clip(payload.query),
+            revisedPrompt: clip(payload.revisedPrompt),
+            numTurns: payload.numTurns
+        )
+        return CodexEntry(type: type, timestamp: timestamp, payload: projected)
+    }
+}

--- a/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
+++ b/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
@@ -44,6 +44,13 @@ struct ClaudeUsageVerifier: ProviderUsageVerifier {
 /// those carry their own test suites.
 struct CodexUsageVerifier: ProviderUsageVerifier {
     let provider: ProviderKind = .codex
+    /// Oversized non-duplicated pieces are read via the importer's
+    /// memory-bounded projection so the verify/ground-truth path doesn't
+    /// OOM on the same giant rollouts the importer now bounds. Usage is
+    /// projection-invariant (user prompts + token events preserved), so
+    /// the ground-truth numbers — and thus the divergence verdict — are
+    /// unchanged. Injectable so tests can force the path on small fixtures.
+    var oversizedPieceByteThreshold: Int64 = CodexDetailImporter.defaultOversizedPieceByteThreshold
 
     func computeReport(files: [URL]) -> GroundTruth.Report {
         var usageLines: [GroundTruth.UsageLine] = []
@@ -120,9 +127,18 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
                 var chainTracker = CodexSubagentReplayTrimmer.ParentSummary()
 
                 for piece in pieces {
+                    // Mirror the importer gate: bound non-duplicated
+                    // oversized pieces (dup chains key on body text, so
+                    // they read full — and never reach here projected).
+                    let lightweight = CodexDetailImporter.usesLightweightProjection(
+                        pieceByteSize: Self.fileByteSize(piece.url),
+                        usesDiscriminator: usesDiscriminator,
+                        threshold: oversizedPieceByteThreshold
+                    )
                     let decoded = Self.readDecodedLines(
                         from: piece.url,
                         sessionId: groupSessionId,
+                        lightweight: lightweight,
                         issues: &issues
                     )
 
@@ -179,16 +195,31 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
 
     // MARK: - Line reading
 
+    private static func fileByteSize(_ url: URL) -> Int64 {
+        Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+    }
+
     private static func readDecodedLines(
         from url: URL,
         sessionId: String,
+        lightweight: Bool,
         issues: inout [GroundTruth.ReportIssue]
     ) -> [CodexLineReader.DecodedLine] {
         var decodedLines: [CodexLineReader.DecodedLine] = []
         _ = CodexLineReader.streamEntries(from: url) { streamed in
             switch streamed {
             case .decoded(let line):
-                decodedLines.append(line)
+                let entry = lightweight
+                    ? line.entry.lightweightProjection(textCap: CodexDetailImporter.lightweightTextCap)
+                    : line.entry
+                // Drop raw bytes — the usage fold consumes entries and
+                // diagnostics use the locator, so retaining rawData only
+                // bloated the verify path (worse than the importer, which
+                // already dropped it). When oversized, also clip non-user
+                // body like the importer.
+                decodedLines.append(CodexLineReader.DecodedLine(
+                    entry: entry, rawData: Data(), rawLocator: line.rawLocator
+                ))
             case .rejected(_, let lineOrdinal, _):
                 issues.append(GroundTruth.ReportIssue(
                     sessionId: sessionId,

--- a/Lupen/Store/CodexDetailImporter.swift
+++ b/Lupen/Store/CodexDetailImporter.swift
@@ -74,8 +74,44 @@ struct CodexDetailImporter: Sendable {
         /// Rows per write transaction inside `replaceSource` — bounds
         /// journal growth and gives cancellation its batch boundaries.
         var writeBatchRowLimit: Int = 2_000
+        /// A non-duplicated rollout piece whose file is at least this
+        /// large is imported via a memory-bounded projection
+        /// (`CodexEntry.lightweightProjection`): user-prompt text is kept
+        /// verbatim and only the non-user conversation body is clipped,
+        /// so usage/cost/turn/skill/link numbers stay identical. This
+        /// bounds the SINGLE-PIECE peak that 3.8a's group streaming left
+        /// unbounded — a lone multi-hundred-MB rollout (standalone,
+        /// subagent, or parent) would otherwise materialize whole and
+        /// could OOM on low-memory machines. DUPLICATED chains are
+        /// excluded (their same-raw dedup keys on assistant body text).
+        /// `.max` disables it (used to pin full-vs-light equivalence).
+        var oversizedPieceByteThreshold: Int64 = CodexDetailImporter.defaultOversizedPieceByteThreshold
         init() {}
     }
+
+    /// Default oversized-piece byte threshold (192 MiB). One source of
+    /// truth shared by the importer `Configuration`, the GUI/CLI index
+    /// coordinator, and the Codex verifier so they all agree on what
+    /// counts as "oversized".
+    static let defaultOversizedPieceByteThreshold: Int64 = 192 << 20
+
+    /// The ONE projection-eligibility rule, shared by the importer and the
+    /// verifier so the two paths cannot drift: a piece is projected iff it
+    /// is at least `threshold` AND not part of a duplicated chain (whose
+    /// same-raw dedup keys on the assistant body text the projection clips,
+    /// so those must always be read in full).
+    static func usesLightweightProjection(
+        pieceByteSize: Int64, usesDiscriminator: Bool, threshold: Int64
+    ) -> Bool {
+        pieceByteSize >= threshold && !usesDiscriminator
+    }
+
+    /// Character cap applied to the NON-USER conversation body (assistant
+    /// replies, tool output) of an oversized piece's lines (see
+    /// `Configuration.oversizedPieceByteThreshold`). User-prompt text is
+    /// never clipped, so prompt preview, search, skill detection, and
+    /// replay matching are unaffected; only long bodies clip.
+    static let lightweightTextCap = 2_000
 
     struct Outcome: Equatable, Sendable {
         var importedSources = 0
@@ -391,13 +427,32 @@ struct CodexDetailImporter: Sendable {
         // 1. Stream-read this rollout. Raw line bytes are dropped at
         //    collection — the assembler and aggregator consume locators
         //    only; rejected lines keep their bytes out-of-band counts.
+        //
+        //    Oversized pieces take a memory-bounded projection that
+        //    preserves user-prompt text verbatim and clips only non-user
+        //    body, so usage/cost/turn/skill/link numbers stay identical
+        //    while the per-piece working set tracks line count, not file
+        //    bytes. Only DUPLICATED chains (`usesDiscriminator`) are
+        //    excluded — their same-raw dedup is the one cross-piece
+        //    matcher that keys on assistant body text. Standalone,
+        //    subagent, and parent pieces are all eligible: the subagent
+        //    trim and a parent's `ParentSummary` seeding match on prompts,
+        //    which the projection preserves.
+        let useLightweightProjection = Self.usesLightweightProjection(
+            pieceByteSize: piece.byteSize,
+            usesDiscriminator: chain.usesDiscriminator,
+            threshold: configuration.oversizedPieceByteThreshold
+        )
         var decodedLines: [CodexLineReader.DecodedLine] = []
         var rejected: [(line: CodexLineReader.RejectedLine, ordinal: Int, offset: UInt64)] = []
         CodexLineReader.streamEntries(from: piece.url) { streamed in
             switch streamed {
             case .decoded(let line):
+                let entry = useLightweightProjection
+                    ? line.entry.lightweightProjection(textCap: Self.lightweightTextCap)
+                    : line.entry
                 decodedLines.append(CodexLineReader.DecodedLine(
-                    entry: line.entry, rawData: Data(), rawLocator: line.rawLocator
+                    entry: entry, rawData: Data(), rawLocator: line.rawLocator
                 ))
             case .rejected(let line, let ordinal, let offset):
                 rejected.append((line, ordinal, offset))
@@ -606,6 +661,22 @@ struct CodexDetailImporter: Sendable {
             ))
         }
         outcome.diagnosticRows += payload.diagnostics.count
+
+        // The body trim is a benign, expected memory optimization, not a
+        // parse problem — so it is a developer-facing log breadcrumb, NOT
+        // a persisted diagnostic row (those are reserved for warning/error
+        // and would otherwise surface as a spurious warning in the
+        // Diagnostics window). A user-facing "body trimmed" notice on the
+        // conversation tab is deferred to the Phase 2 UX work.
+        if useLightweightProjection {
+            LoggerService.shared.logFromAnyThread(
+                .info,
+                "Codex oversized piece \(piece.path) (\(piece.byteSize >> 20) MB) imported with a "
+                    + "lightweight projection: conversation body clipped to bound memory; "
+                    + "usage and cost are unaffected.",
+                context: "Import"
+            )
+        }
 
         // 11. Shell rides along (partial; widening upsert).
         payload.sessions = [plan.sessionShell(

--- a/Lupen/Store/ProviderIndexCoordinator.swift
+++ b/Lupen/Store/ProviderIndexCoordinator.swift
@@ -66,6 +66,11 @@ final class ProviderIndexCoordinator: @unchecked Sendable {
         /// for its whole import (the 109 GB jumbo group measured in
         /// the wild held "7 of 383" for tens of minutes).
         var largeUnitDemoteBytes: Int64 = 1 << 30   // 1 GiB
+        /// Forwarded to the Codex detail importer: a non-duplicated piece
+        /// at least this large imports via the memory-bounded projection
+        /// (user prompts kept, non-user body clipped). Overridable so the
+        /// safety floor can be tuned per environment rather than baked in.
+        var oversizedPieceByteThreshold: Int64 = CodexDetailImporter.defaultOversizedPieceByteThreshold
         init() {}
     }
 
@@ -388,6 +393,7 @@ final class ProviderIndexCoordinator: @unchecked Sendable {
             case .codex(let codexHome):
                 var importerConfiguration = CodexDetailImporter.Configuration()
                 importerConfiguration.writeBatchRowLimit = configuration.writeBatchRowLimit
+                importerConfiguration.oversizedPieceByteThreshold = configuration.oversizedPieceByteThreshold
                 let importer = CodexDetailImporter(
                     writer: store, configuration: importerConfiguration
                 )

--- a/LupenTests/Store/CodexOversizedPieceMemoryTests.swift
+++ b/LupenTests/Store/CodexOversizedPieceMemoryTests.swift
@@ -1,0 +1,253 @@
+//
+//  CodexOversizedPieceMemoryTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/19.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// Single-piece memory gate: 3.8a bounded a GROUP to its largest piece,
+/// but a lone multi-hundred-MB rollout still materialized whole. The
+/// lightweight projection must bound that — importing one large
+/// standalone rollout with the projection on must peak FAR below the
+/// file size (and below the full path), with usage still exact.
+@Suite("Codex oversized single-piece memory bound", .serialized)
+struct CodexOversizedPieceMemoryTests {
+
+    private static let turns = 16
+    /// Body bytes per turn — sized so the single file (~64 MB) towers
+    /// over allocator/page-cache noise, making "peak ≪ file" decisive.
+    private static let bodyChars = 4_000_000
+
+    private final class PeakSampler: @unchecked Sendable {
+        private let lock = NSLock()
+        private var peakBytes: UInt64 = 0
+        private var running = true
+
+        func start() {
+            let thread = Thread { [weak self] in
+                while true {
+                    guard let self else { return }
+                    self.lock.lock()
+                    let stillRunning = self.running
+                    if let footprint = MemoryFootprint.current()?.physicalFootprintBytes,
+                       footprint > self.peakBytes {
+                        self.peakBytes = footprint
+                    }
+                    self.lock.unlock()
+                    if !stillRunning { return }
+                    Thread.sleep(forTimeInterval: 0.02)
+                }
+            }
+            thread.qualityOfService = .userInitiated
+            thread.start()
+        }
+
+        func stop() -> UInt64 {
+            lock.lock(); defer { lock.unlock() }
+            running = false
+            return peakBytes
+        }
+    }
+
+    private func makeBigStandalone() throws -> (home: URL, fileBytes: Int, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-mem-\(UUID().uuidString)")
+        let day = home.appendingPathComponent("sessions/2026/06/01")
+        try FileManager.default.createDirectory(at: day, withIntermediateDirectories: true)
+
+        func stamp(_ m: Int, _ s: Int) -> String { String(format: "2026-06-01T10:%02d:%02dZ", m, s) }
+        let body = String(repeating: "x", count: Self.bodyChars)
+        var lines = [
+            #"{"type":"session_meta","timestamp":"\#(stamp(0,0))","payload":{"id":"big-solo","timestamp":"\#(stamp(0,0))","cwd":"/Users/example/Big","originator":"codex_cli_rs","model":"gpt-5.3-codex"}}"#
+        ]
+        for i in 0..<Self.turns {
+            let ts = stamp(1 + i, 0)
+            lines.append(#"{"type":"turn_context","timestamp":"\#(ts)","payload":{"type":"turn_context","turn_id":"t-\#(i)","model":"gpt-5.3-codex"}}"#)
+            lines.append(#"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"work \#(i)"}]}}"#)
+            lines.append(#"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\#(body)"}]}}"#)
+            lines.append(#"{"type":"event_msg","timestamp":"\#(ts)","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110}}}}"#)
+        }
+        let file = day.appendingPathComponent("rollout-2026-06-01T10-00-00-big-solo.jsonl")
+        try (lines.joined(separator: "\n") + "\n").write(to: file, atomically: true, encoding: .utf8)
+        let bytes = (try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        return (home, bytes, { try? FileManager.default.removeItem(at: home) })
+    }
+
+    /// One large subagent group: a tiny parent that spawns one big
+    /// subagent child carrying the bulk. The child is a subagent (non-dup)
+    /// → eligible for projection under the redesigned gate.
+    private func makeBigSubagentGroup() throws -> (home: URL, childBytes: Int, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-mem-sub-\(UUID().uuidString)")
+        let day = home.appendingPathComponent("sessions/2026/06/01")
+        try FileManager.default.createDirectory(at: day, withIntermediateDirectories: true)
+
+        func stamp(_ m: Int, _ s: Int) -> String { String(format: "2026-06-01T10:%02d:%02dZ", m, s) }
+        let body = String(repeating: "x", count: Self.bodyChars)
+
+        // Parent (small): spawns one child, one usage event.
+        let parent = [
+            #"{"type":"session_meta","timestamp":"\#(stamp(0,0))","payload":{"id":"p-root","timestamp":"\#(stamp(0,0))","cwd":"/Users/example/Big","originator":"codex_cli_rs","model":"gpt-5.3-codex"}}"#,
+            #"{"type":"turn_context","timestamp":"\#(stamp(0,1))","payload":{"type":"turn_context","turn_id":"t-root","model":"gpt-5.3-codex"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0,1))","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"spawn"}]}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0,1))","payload":{"type":"function_call","name":"spawn_agent","call_id":"call-1","arguments":"{\"task\":\"work\"}"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0,1))","payload":{"type":"function_call_output","call_id":"call-1","output":"{\"agent_id\":\"child-1\",\"nickname\":\"Worker\"}"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0,2))","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"dispatched"}]}}"#,
+            #"{"type":"event_msg","timestamp":"\#(stamp(0,2))","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":55}}}}"#
+        ]
+        try (parent.joined(separator: "\n") + "\n")
+            .write(to: day.appendingPathComponent("rollout-2026-06-01T10-00-00-p-root.jsonl"),
+                   atomically: true, encoding: .utf8)
+
+        // Child (BIG): replays the parent prompt (trimmed), then novel
+        // turns with big assistant bodies.
+        var child = [
+            #"{"type":"session_meta","timestamp":"\#(stamp(1,0))","payload":{"id":"child-1","timestamp":"\#(stamp(1,0))","cwd":"/Users/example/Big","originator":"codex_cli_rs","model":"gpt-5.3-codex","source":{"subagent":{"thread_spawn":{"parent_thread_id":"p-root","agent_nickname":"Worker"}}}}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(1,0))","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"spawn"}]}}"#,
+            #"{"type":"event_msg","timestamp":"\#(stamp(1,0))","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":55}}}}"#
+        ]
+        for i in 0..<Self.turns {
+            let ts = stamp(2 + i, 0)
+            child.append(#"{"type":"turn_context","timestamp":"\#(ts)","payload":{"type":"turn_context","turn_id":"t-c\#(i)","model":"gpt-5.3-codex"}}"#)
+            child.append(#"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"work \#(i)"}]}}"#)
+            child.append(#"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\#(body)"}]}}"#)
+            child.append(#"{"type":"event_msg","timestamp":"\#(ts)","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110}}}}"#)
+        }
+        let childFile = day.appendingPathComponent("rollout-2026-06-01T10-01-00-child-1.jsonl")
+        try (child.joined(separator: "\n") + "\n").write(to: childFile, atomically: true, encoding: .utf8)
+        let childBytes = (try? childFile.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        return (home, childBytes, { try? FileManager.default.removeItem(at: home) })
+    }
+
+    private func importPeakDelta(
+        home: URL, threshold: Int64, rawId: String = "big-solo"
+    ) throws -> (peakMB: Double, inputTokens: Int, outputTokens: Int) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-mem-db-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let database = try ProviderDatabase.open(at: dir.appendingPathComponent("index.sqlite3"))
+        let store = ProviderStore(database: database)
+        defer { try? database.close() }
+        try CodexMetadataScanner(writer: store).scan(codexHome: home)
+        var config = CodexDetailImporter.Configuration()
+        config.oversizedPieceByteThreshold = threshold
+        let importer = CodexDetailImporter(writer: store, configuration: config)
+        let unit = CodexImportUnit.unit(
+            forSessionRawId: rawId, codexHome: home, sources: try store.allSourceFiles()
+        )
+        let baseline = MemoryFootprint.current()?.physicalFootprintBytes ?? 0
+        let sampler = PeakSampler()
+        sampler.start()
+        try importer.importUnit(unit)
+        let peak = sampler.stop()
+        let sessionId = ProviderScopedID(provider: .codex, rawSessionId: rawId).value
+        let aggregate = try #require(
+            try store.sessionUsageAggregates().first { $0.sessionId == sessionId }
+        )
+        let peakMB = Double(peak > baseline ? peak - baseline : 0) / 1_048_576.0
+        return (peakMB, aggregate.inputTokens, aggregate.outputTokens)
+    }
+
+    @Test("lightweight projection bounds a lone large rollout's peak far below its size, numbers exact")
+    func loneLargePieceBounded() throws {
+        try CorpusHeavyTestGate.withExclusiveAccess {
+            let fixture = try makeBigStandalone()
+            defer { fixture.cleanup() }
+            let fileMB = Double(fixture.fileBytes) / 1_048_576.0
+
+            // Full path: WORST (max) of two runs, so the contrast
+            // assertion isn't defeated by a single low-noise sample.
+            var fullPeakMB = 0.0
+            for _ in 0..<2 {
+                let full = try importPeakDelta(home: fixture.home, threshold: .max)
+                fullPeakMB = max(fullPeakMB, full.peakMB)
+                #expect(full.inputTokens == Self.turns * 100)
+                #expect(full.outputTokens == Self.turns * 10)
+            }
+
+            // Lightweight: best (cleanest) of three, process-wide sampling
+            // is noisy (same lesson as the 3.8a jumbo gate).
+            var lightBest = Double.greatestFiniteMagnitude
+            var lightInput = 0, lightOutput = 0
+            for attempt in 0..<3 {
+                if attempt > 0 { Thread.sleep(forTimeInterval: 1.0) }
+                let light = try importPeakDelta(home: fixture.home, threshold: 1 << 20)
+                lightBest = min(lightBest, light.peakMB)
+                lightInput = light.inputTokens
+                lightOutput = light.outputTokens
+                if lightBest < fileMB / 4 { break }
+            }
+
+            FileHandle.standardError.write(Data(String(
+                format: "[oversized-mem] file=%.1fMB fullPeak=%.1fMB lightBest=%.1fMB\n",
+                fileMB, fullPeakMB, lightBest
+            ).utf8))
+
+            // Numbers are identical to the full path.
+            #expect(lightInput == Self.turns * 100)
+            #expect(lightOutput == Self.turns * 10)
+
+            // The whole point: peak tracks the projection, not file bytes.
+            #expect(
+                lightBest < fileMB / 4,
+                "lightweight peak \(lightBest)MB not bounded well below file \(fileMB)MB"
+            )
+            // And demonstrably lower than materializing the whole piece.
+            #expect(
+                lightBest < fullPeakMB,
+                "lightweight peak \(lightBest)MB should be below full-path peak \(fullPeakMB)MB"
+            )
+        }
+    }
+
+    @Test("lightweight projection bounds a large SUBAGENT child's peak too, numbers exact")
+    func loneLargeSubagentBounded() throws {
+        try CorpusHeavyTestGate.withExclusiveAccess {
+            let fixture = try makeBigSubagentGroup()
+            defer { fixture.cleanup() }
+            let childMB = Double(fixture.childBytes) / 1_048_576.0
+
+            // Full path once (baseline / contrast).
+            let full = try importPeakDelta(home: fixture.home, threshold: .max, rawId: "p-root")
+            // Parent 50/5 + child novel turns × (100/10); replayed 50/5 trimmed.
+            let expectedInput = 50 + Self.turns * 100
+            let expectedOutput = 5 + Self.turns * 10
+            #expect(full.inputTokens == expectedInput)
+            #expect(full.outputTokens == expectedOutput)
+
+            var lightBest = Double.greatestFiniteMagnitude
+            var lightInput = 0, lightOutput = 0
+            for attempt in 0..<3 {
+                if attempt > 0 { Thread.sleep(forTimeInterval: 1.0) }
+                let light = try importPeakDelta(home: fixture.home, threshold: 1 << 20, rawId: "p-root")
+                lightBest = min(lightBest, light.peakMB)
+                lightInput = light.inputTokens
+                lightOutput = light.outputTokens
+                if lightBest < childMB / 4 { break }
+            }
+
+            FileHandle.standardError.write(Data(String(
+                format: "[oversized-mem-subagent] child=%.1fMB fullPeak=%.1fMB lightBest=%.1fMB\n",
+                childMB, full.peakMB, lightBest
+            ).utf8))
+
+            // Usage identical to the full path (replay trimmed, novel counted).
+            #expect(lightInput == expectedInput)
+            #expect(lightOutput == expectedOutput)
+            // Peak tracks the projection, not the child's bytes.
+            #expect(
+                lightBest < childMB / 4,
+                "subagent lightweight peak \(lightBest)MB not bounded below child \(childMB)MB"
+            )
+            #expect(
+                lightBest < full.peakMB,
+                "subagent lightweight peak \(lightBest)MB should be below full-path peak \(full.peakMB)MB"
+            )
+        }
+    }
+}

--- a/LupenTests/Store/CodexOversizedPieceTests.swift
+++ b/LupenTests/Store/CodexOversizedPieceTests.swift
@@ -1,0 +1,770 @@
+//
+//  CodexOversizedPieceTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/19.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// Single-piece memory safety (oversized standalone rollout): the
+/// importer's lightweight projection must leave usage/cost/turn/skill/
+/// link numbers IDENTICAL to the full path — only the conversation body
+/// beyond the cap is clipped — and must NEVER engage where replay
+/// trimming is load-bearing (subagent / duplicated chains).
+@Suite("Codex oversized single-piece projection")
+struct CodexOversizedPieceTests {
+
+    // MARK: - Fixture builders
+
+    private func makeHome() throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent("sessions/2026/06/01"),
+            withIntermediateDirectories: true
+        )
+        return home
+    }
+
+    private func dayDir(_ home: URL) -> URL {
+        home.appendingPathComponent("sessions/2026/06/01")
+    }
+
+    private func meta(_ id: String, ts: String, parent: String? = nil) -> String {
+        let source = parent.map {
+            #","source":{"subagent":{"thread_spawn":{"parent_thread_id":"\#($0)","agent_nickname":"Worker"}}}"#
+        } ?? ""
+        return #"{"type":"session_meta","timestamp":"\#(ts)","payload":{"id":"\#(id)","timestamp":"\#(ts)","cwd":"/Users/example/Solo","originator":"codex_cli_rs","model":"gpt-5.3-codex"\#(source)}}"#
+    }
+    private func turnContext(_ turnId: String, ts: String) -> String {
+        #"{"type":"turn_context","timestamp":"\#(ts)","payload":{"type":"turn_context","turn_id":"\#(turnId)","model":"gpt-5.3-codex"}}"#
+    }
+    private func user(_ text: String, ts: String) -> String {
+        #"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"\#(text)"}]}}"#
+    }
+    private func assistant(_ text: String, ts: String) -> String {
+        #"{"type":"response_item","timestamp":"\#(ts)","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\#(text)"}]}}"#
+    }
+    private func tokensLast(input: Int, output: Int, ts: String) -> String {
+        #"{"type":"event_msg","timestamp":"\#(ts)","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":\#(input),"cached_input_tokens":0,"output_tokens":\#(output),"reasoning_output_tokens":0,"total_tokens":\#(input + output)}}}}"#
+    }
+    private func tokensTotal(input: Int, output: Int, ts: String) -> String {
+        #"{"type":"event_msg","timestamp":"\#(ts)","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":\#(input),"cached_input_tokens":0,"output_tokens":\#(output),"reasoning_output_tokens":0,"total_tokens":\#(input + output)}}}}"#
+    }
+    private func stamp(_ minute: Int, _ second: Int) -> String {
+        String(format: "2026-06-01T10:%02d:%02dZ", minute, second)
+    }
+
+    private func write(_ lines: [String], to url: URL) throws {
+        try (lines.joined(separator: "\n") + "\n")
+            .write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// One standalone session (non-subagent, single file → no trim).
+    @discardableResult
+    private func writeStandalone(
+        _ home: URL, id: String, turns: Int, bodyChars: Int, prompt: String = "do work"
+    ) throws -> URL {
+        var lines = [meta(id, ts: stamp(0, 0))]
+        let body = String(repeating: "x", count: bodyChars)
+        for i in 0..<turns {
+            let ts = stamp(1 + i, 0)
+            lines.append(turnContext("t-\(i)", ts: ts))
+            lines.append(user("\(prompt) \(i)", ts: ts))
+            lines.append(assistant(body, ts: ts))
+            lines.append(tokensLast(input: 100, output: 10, ts: ts))
+        }
+        let url = dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-\(id).jsonl")
+        try write(lines, to: url)
+        return url
+    }
+
+    // MARK: - Import harness
+
+    private struct Imported {
+        let store: ProviderStore
+        let sessionId: String
+        let cleanup: () -> Void
+    }
+
+    private func importGroup(
+        home: URL, rawId: String, threshold: Int64
+    ) throws -> Imported {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-db-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let database = try ProviderDatabase.open(at: dir.appendingPathComponent("index.sqlite3"))
+        let store = ProviderStore(database: database)
+        try CodexMetadataScanner(writer: store).scan(codexHome: home)
+        var config = CodexDetailImporter.Configuration()
+        config.oversizedPieceByteThreshold = threshold
+        let importer = CodexDetailImporter(writer: store, configuration: config)
+        let unit = CodexImportUnit.unit(
+            forSessionRawId: rawId, codexHome: home, sources: try store.allSourceFiles()
+        )
+        try importer.importUnit(unit)
+        return Imported(
+            store: store,
+            sessionId: ProviderScopedID(provider: .codex, rawSessionId: rawId).value,
+            cleanup: {
+                try? database.close()
+                try? FileManager.default.removeItem(at: dir)
+            }
+        )
+    }
+
+    private func maxBodyLength(_ imported: Imported, turns: [StoreTurnRow]) throws -> Int {
+        var maxLen = 0
+        for turn in turns {
+            for step in try imported.store.steps(sessionId: imported.sessionId, turnId: turn.id) {
+                maxLen = max(maxLen, step.text?.count ?? 0)
+            }
+        }
+        return maxLen
+    }
+
+    // MARK: - Pure projection
+
+    @Test("lightweightProjection clips body text, drops display JSON, preserves load-bearing fields")
+    func projectionClipsAndPreserves() {
+        let big = String(repeating: "a", count: 5_000)
+        let usage = CodexTokenUsage(
+            inputTokens: 100, cachedInputTokens: 5, outputTokens: 10,
+            reasoningOutputTokens: 2, totalTokens: 115
+        )
+        let entry = CodexEntry(
+            type: "response_item",
+            timestamp: "2026-06-01T10:00:00Z",
+            payload: CodexEntry.Payload(
+                type: "message", timestamp: "2026-06-01T10:00:00Z", turnId: "t1",
+                model: "gpt-5.3-codex", cwd: "/x",
+                info: CodexEntry.Info(
+                    model: "gpt-5.3-codex", lastTokenUsage: usage,
+                    totalTokenUsage: nil, modelContextWindow: 272_000
+                ),
+                role: "assistant", message: big, text: big,
+                content: [CodexEntry.ContentBlock(type: "output_text", text: big)],
+                summary: [], name: "spawn_agent", arguments: "{\"task\":\"x\"}",
+                input: nil, output: "{\"agent_id\":\"a1\"}", callId: "c1", id: "i1",
+                status: "completed",
+                changes: .object(["k": .string(big)]),
+                tools: .array([.string("t")]),
+                invocation: .string("inv"), action: .string("act"),
+                result: .string(big), duration: .number(1),
+                execution: big, query: big, revisedPrompt: big, numTurns: 3
+            )
+        )
+
+        let projected = entry.lightweightProjection(textCap: 2_000)
+        let p = try! #require(projected.payload)
+
+        // Body text clipped to the cap.
+        #expect(p.message?.count == 2_000)
+        #expect(p.text?.count == 2_000)
+        #expect(p.content.first?.text?.count == 2_000)
+        #expect(p.execution?.count == 2_000)
+        #expect(p.query?.count == 2_000)
+        #expect(p.revisedPrompt?.count == 2_000)
+
+        // Large display-only structured JSON dropped.
+        #expect(p.changes == nil)
+        #expect(p.tools == nil)
+        #expect(p.invocation == nil)
+        #expect(p.action == nil)
+        #expect(p.result == nil)
+        #expect(p.duration == nil)
+
+        // Load-bearing fields untouched: usage / identity / link fields.
+        #expect(p.info?.lastTokenUsage == usage)
+        #expect(p.info?.modelContextWindow == 272_000)
+        #expect(p.type == "message")
+        #expect(p.role == "assistant")
+        #expect(p.turnId == "t1")
+        #expect(p.model == "gpt-5.3-codex")
+        #expect(p.cwd == "/x")
+        #expect(p.numTurns == 3)
+        // Small link fields (below cap) survive byte-for-byte.
+        #expect(p.name == "spawn_agent")
+        #expect(p.arguments == "{\"task\":\"x\"}")
+        #expect(p.output == "{\"agent_id\":\"a1\"}")
+        #expect(p.callId == "c1")
+        #expect(p.id == "i1")
+        #expect(p.status == "completed")
+        // Envelope preserved.
+        #expect(projected.type == "response_item")
+        #expect(projected.timestamp == "2026-06-01T10:00:00Z")
+    }
+
+    @Test("short fields below the cap survive unchanged (skill marker / spawn id intact)")
+    func projectionShortFieldsUnchanged() {
+        let prompt = "/flow-all run the whole pipeline"
+        let entry = CodexEntry(
+            type: "response_item", timestamp: nil,
+            payload: CodexEntry.Payload(
+                type: "message", timestamp: nil, turnId: nil, model: nil, cwd: nil,
+                info: nil, role: "user", message: prompt,
+                content: [CodexEntry.ContentBlock(type: "input_text", text: prompt)]
+            )
+        )
+        let projected = entry.lightweightProjection(textCap: 2_000)
+        #expect(projected.payload?.message == prompt)
+        #expect(projected.payload?.content.first?.text == prompt)
+        // messageText (used for prompt preview + skill detection) intact.
+        #expect(projected.payload?.messageText == prompt)
+    }
+
+    // MARK: - Full vs lightweight equivalence (standalone)
+
+    @Test("oversized standalone: lightweight path matches full path exactly, only body clipped")
+    func standaloneEquivalence() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        // 3 turns, each with a 5000-char assistant body (> 2000 cap),
+        // skill-invoking prompts. Single file → non-sub, non-dup.
+        try writeStandalone(home, id: "solo", turns: 3, bodyChars: 5_000, prompt: "/flow-all step")
+
+        let full = try importGroup(home: home, rawId: "solo", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "solo", threshold: 0)
+        defer { light.cleanup() }
+
+        // (1) Usage aggregates identical (input/output/reasoning/cache/cost).
+        let fullAgg = try #require(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+        )
+        let lightAgg = try #require(
+            try light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        #expect(fullAgg == lightAgg)
+        #expect(fullAgg.inputTokens == 300)   // 3 × 100
+        #expect(fullAgg.outputTokens == 30)   // 3 × 10
+
+        // (2) Turn rows identical on every load-bearing column.
+        let fullTurns = try full.store.turnPage(sessionId: full.sessionId, limit: 100, afterOrdinal: nil)
+        let lightTurns = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(fullTurns.count == 3)
+        #expect(lightTurns.count == fullTurns.count)
+        for (a, b) in zip(fullTurns, lightTurns) {
+            #expect(a.ordinal == b.ordinal)
+            #expect(a.aggTokens == b.aggTokens)
+            #expect(a.aggCost.totalCostUSD == b.aggCost.totalCostUSD)
+            #expect(a.promptPreview == b.promptPreview)   // preview cap < text cap → identical
+            #expect(a.stepCount == b.stepCount)
+            #expect(a.sidechainOnly == b.sidechainOnly)
+            #expect(a.aggComplete == b.aggComplete)
+        }
+
+        // (3) Skill + link projections identical (prompt < cap → same extraction).
+        #expect(
+            try full.store.skillAggregates(from: nil, to: nil)
+            == light.store.skillAggregates(from: nil, to: nil)
+        )
+        #expect(
+            try full.store.subagentLinks(sessionId: full.sessionId).count
+            == light.store.subagentLinks(sessionId: light.sessionId).count
+        )
+
+        // (4) The ONLY difference: the conversation body is clipped in the
+        //     lightweight store and full in the other.
+        #expect(try maxBodyLength(full, turns: fullTurns) == 5_000)
+        let lightMax = try maxBodyLength(light, turns: lightTurns)
+        #expect(lightMax <= 2_000)
+        #expect(lightMax > 0)   // a readable preview survives
+
+        // (5) The lightweight import still completes (detailState complete
+        //     → never re-queued) and persists NO diagnostic row: the body
+        //     trim is a benign log breadcrumb, and info rows are silent by
+        //     the importer contract.
+        #expect(try #require(try light.store.session(id: light.sessionId)).detailState == .complete)
+        #expect(try light.store.severityCounts().info == 0)
+    }
+
+    // MARK: - Safety boundary: never lightweight a duplicated chain
+
+    @Test("duplicated chain keeps the full path even below threshold (no replay regression)")
+    func duplicatedChainExcludedFromProjection() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let big = String(repeating: "x", count: 5_000)
+        // Two files, same raw id "dup" → usesDiscriminator → replay trim
+        // is load-bearing → projection MUST NOT engage.
+        try write([
+            meta("dup", ts: stamp(0, 0)),
+            turnContext("t1", ts: stamp(0, 1)),
+            user("first prompt", ts: stamp(0, 1)),
+            assistant(big, ts: stamp(0, 2)),
+            tokensTotal(input: 100, output: 6, ts: stamp(0, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-dup.jsonl"))
+        try write([
+            meta("dup", ts: stamp(5, 0)),
+            tokensTotal(input: 100, output: 6, ts: stamp(5, 0)),   // replay of cumulative → skipped
+            turnContext("t2", ts: stamp(5, 1)),
+            user("second prompt", ts: stamp(5, 1)),
+            assistant("small", ts: stamp(5, 2)),
+            tokensTotal(input: 190, output: 16, ts: stamp(5, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-05-00-dup.jsonl"))
+
+        let full = try importGroup(home: home, rawId: "dup", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "dup", threshold: 0)
+        defer { light.cleanup() }
+
+        // Usage identical regardless of threshold (dup excluded → same path).
+        let fullAgg = try #require(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+        )
+        let lightAgg = try #require(
+            try light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        #expect(fullAgg == lightAgg)
+        #expect(fullAgg.inputTokens == 190)   // 100 + 90 (replay deduped)
+        #expect(fullAgg.outputTokens == 16)
+
+        // Decisive: even with threshold 0, the dup piece's body is NOT
+        // clipped — proves the gate excluded the duplicated chain.
+        let lightTurns = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(try maxBodyLength(light, turns: lightTurns) == 5_000)
+    }
+
+    // MARK: - Subagent group IS projected (safely) — user text preserved
+
+    @Test("oversized parent + subagent are both projected; long replayed prompt still trims (usage exact)")
+    func subagentGroupProjectedKeepsUsageExact() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        // A replayed prompt LONGER than the cap. Because the projection
+        // preserves USER-prompt text verbatim, the child's full-length
+        // replay still matches the parent summary and is trimmed — usage
+        // stays identical even though BOTH parent and child are projected
+        // (their assistant body is clipped). Clipping user text instead
+        // would break the match and double-count (the old C1 failure mode,
+        // now structurally impossible).
+        let longPrompt = "spawn worker " + String(repeating: "Z", count: 3_000)
+        let big = String(repeating: "y", count: 5_000)
+        try write([
+            meta("p-root", ts: stamp(0, 0)),
+            turnContext("t-root", ts: stamp(0, 1)),
+            user(longPrompt, ts: stamp(0, 1)),
+            #"{"type":"response_item","timestamp":"\#(stamp(0, 1))","payload":{"type":"function_call","name":"spawn_agent","call_id":"call-1","arguments":"{\"task\":\"work\"}"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0, 1))","payload":{"type":"function_call_output","call_id":"call-1","output":"{\"agent_id\":\"child-1\",\"nickname\":\"Worker\"}"}}"#,
+            assistant("dispatched", ts: stamp(0, 2)),
+            tokensLast(input: 50, output: 5, ts: stamp(0, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-p-root.jsonl"))
+        try write([
+            meta("child-1", ts: stamp(2, 0), parent: "p-root"),
+            user(longPrompt, ts: stamp(2, 0)),                      // replayed parent prompt (trimmed)
+            tokensTotal(input: 50, output: 5, ts: stamp(2, 0)),
+            turnContext("t-child", ts: stamp(2, 1)),
+            user("child novel work", ts: stamp(2, 1)),
+            assistant(big, ts: stamp(2, 2)),                        // child assistant body (clipped)
+            tokensLast(input: 30, output: 3, ts: stamp(2, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-02-00-child-1.jsonl"))
+
+        let full = try importGroup(home: home, rawId: "p-root", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "p-root", threshold: 0)
+        defer { light.cleanup() }
+
+        let fullAgg = try #require(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+        )
+        let lightAgg = try #require(
+            try light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        // Decisive: identical usage even though BOTH pieces are projected
+        // — the replayed prompt matched (user text preserved) and trimmed.
+        // Clipping user text would read 130/13 here (replay kept).
+        #expect(fullAgg == lightAgg)
+        #expect(fullAgg.inputTokens == 80)   // parent 50 + child novel 30
+        #expect(fullAgg.outputTokens == 8)   // parent 5 + child novel 3
+
+        // Full path keeps the 5000-char assistant body; the projected
+        // store clips it but PRESERVES the 3013-char user prompt verbatim
+        // → its longest stored body is exactly that prompt, never 5000.
+        let fullTurns = try full.store.turnPage(sessionId: full.sessionId, limit: 100, afterOrdinal: nil)
+        let lightTurns = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(try maxBodyLength(full, turns: fullTurns) == 5_000)
+        #expect(longPrompt.count > 2_000)
+        #expect(try maxBodyLength(light, turns: lightTurns) == longPrompt.count)
+        #expect(try light.store.subagentLinks(sessionId: light.sessionId).count == 1)
+    }
+
+    // MARK: - Threshold boundary (the `>=` gate itself)
+
+    @Test("gate is inclusive: byteSize == threshold projects, threshold + 1 does not")
+    func thresholdBoundaryGate() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let url = try writeStandalone(home, id: "edge", turns: 2, bodyChars: 5_000)
+        let size = Int64(try #require(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize))
+
+        let atThreshold = try importGroup(home: home, rawId: "edge", threshold: size)
+        defer { atThreshold.cleanup() }
+        let above = try importGroup(home: home, rawId: "edge", threshold: size + 1)
+        defer { above.cleanup() }
+
+        let atTurns = try atThreshold.store.turnPage(sessionId: atThreshold.sessionId, limit: 100, afterOrdinal: nil)
+        let aboveTurns = try above.store.turnPage(sessionId: above.sessionId, limit: 100, afterOrdinal: nil)
+        // byteSize == threshold → projected (body clipped).
+        #expect(try maxBodyLength(atThreshold, turns: atTurns) <= 2_000)
+        // byteSize < threshold (threshold = size + 1) → full path.
+        #expect(try maxBodyLength(above, turns: aboveTurns) == 5_000)
+        // Usage identical regardless of which side of the boundary.
+        #expect(
+            try atThreshold.store.sessionUsageAggregates().first { $0.sessionId == atThreshold.sessionId }
+            == above.store.sessionUsageAggregates().first { $0.sessionId == above.sessionId }
+        )
+    }
+
+    // MARK: - User skill prompt is preserved by the projection
+
+    @Test("the projection preserves a >cap Codex skill prompt verbatim (skill detection unaffected)")
+    func skillPromptPreservedByProjection() {
+        let known: Set<String> = ["flow-all"]
+        let prompt = "$flow-all " + String(repeating: "x", count: 5_000)
+        // A user message whose prompt runs well past the cap.
+        let userEntry = CodexEntry(
+            type: "response_item", timestamp: nil,
+            payload: CodexEntry.Payload(
+                type: "message", timestamp: nil, turnId: nil, model: nil, cwd: nil,
+                info: nil, role: "user",
+                content: [CodexEntry.ContentBlock(type: "input_text", text: prompt)]
+            )
+        )
+        let projected = userEntry.lightweightProjection(textCap: 2_000)
+        // User-prompt text is preserved VERBATIM (not clipped to 2000) →
+        // the marker and full prompt survive, so detection is identical.
+        #expect(projected.payload?.messageText == prompt)
+        #expect((projected.payload?.content.first?.text?.count ?? 0) == prompt.count)
+        let full = CostAnalyzer.extractSkillName(
+            from: prompt, provider: .codex, knownCodexSkillNames: known
+        )
+        let proj = CostAnalyzer.extractSkillName(
+            from: projected.payload?.messageText, provider: .codex, knownCodexSkillNames: known
+        )
+        #expect(full == "flow-all")   // detection fires (non-vacuous)
+        #expect(proj == full)          // preserved by the projection
+    }
+
+    // MARK: - Projected piece re-imports idempotently
+
+    @Test("a projected piece re-imports idempotently — stable usage, complete, no spurious rows")
+    func projectedPieceReimportsIdempotently() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try writeStandalone(home, id: "idem", turns: 3, bodyChars: 5_000)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-oversized-idem-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let database = try ProviderDatabase.open(at: dir.appendingPathComponent("index.sqlite3"))
+        let store = ProviderStore(database: database)
+        defer {
+            try? database.close()
+            try? FileManager.default.removeItem(at: dir)
+        }
+        try CodexMetadataScanner(writer: store).scan(codexHome: home)
+        var config = CodexDetailImporter.Configuration()
+        config.oversizedPieceByteThreshold = 0   // force the lightweight path
+        let importer = CodexDetailImporter(writer: store, configuration: config)
+        let sessionId = ProviderScopedID(provider: .codex, rawSessionId: "idem").value
+
+        func runImport() throws -> StoreSessionUsageAggregate {
+            let unit = CodexImportUnit.unit(
+                forSessionRawId: "idem", codexHome: home, sources: try store.allSourceFiles()
+            )
+            try importer.importUnit(unit)
+            return try #require(
+                try store.sessionUsageAggregates().first { $0.sessionId == sessionId }
+            )
+        }
+
+        let first = try runImport()
+        let second = try runImport()
+        #expect(first == second)            // re-import is idempotent
+        #expect(first.inputTokens == 300)   // 3 × 100
+        #expect(try #require(try store.session(id: sessionId)).detailState == .complete)
+        #expect(try store.severityCounts().info == 0)   // no spurious/duplicated rows
+    }
+
+    // MARK: - Standalone with a >cap user prompt (end-to-end)
+
+    @Test("standalone: a >cap user prompt is preserved verbatim while the assistant body clips (usage exact)")
+    func standaloneLongPromptPreserved() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let longPrompt = "analyze this: " + String(repeating: "Q", count: 4_000)   // > 2000 cap
+        try write([
+            meta("solo2", ts: stamp(0, 0)),
+            turnContext("t0", ts: stamp(1, 0)),
+            user(longPrompt, ts: stamp(1, 0)),
+            assistant(String(repeating: "x", count: 5_000), ts: stamp(1, 0)),
+            tokensLast(input: 100, output: 10, ts: stamp(1, 0))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-solo2.jsonl"))
+
+        let full = try importGroup(home: home, rawId: "solo2", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "solo2", threshold: 0)
+        defer { light.cleanup() }
+
+        // Usage identical despite the assistant body being clipped.
+        #expect(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+            == light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        // The >cap user prompt survives verbatim; the assistant body is
+        // clipped → the longest stored body equals the prompt, never 5000.
+        let fullTurns = try full.store.turnPage(sessionId: full.sessionId, limit: 100, afterOrdinal: nil)
+        let lightTurns = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(try maxBodyLength(full, turns: fullTurns) == 5_000)
+        #expect(longPrompt.count > 2_000)
+        #expect(try maxBodyLength(light, turns: lightTurns) == longPrompt.count)
+    }
+
+    // MARK: - Pure projection: degenerate / boundary / field-precedence
+
+    private func assistantEntry(content: String? = nil, message: String? = nil, text: String? = nil) -> CodexEntry {
+        CodexEntry(type: "response_item", timestamp: nil, payload: CodexEntry.Payload(
+            type: "message", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil,
+            role: "assistant", message: message, text: text,
+            content: content.map { [CodexEntry.ContentBlock(type: "output_text", text: $0)] } ?? []
+        ))
+    }
+
+    @Test("projection returns self unchanged when payload is nil")
+    func projectionNilPayload() {
+        let entry = CodexEntry(type: "event_msg", timestamp: "ts", payload: nil)
+        let projected = entry.lightweightProjection(textCap: 2_000)
+        #expect(projected.payload == nil)
+        #expect(projected.type == "event_msg")
+        #expect(projected.timestamp == "ts")
+    }
+
+    @Test("projection clip boundary: count == cap kept, cap+1 clipped, cap-1 kept")
+    func projectionCapBoundary() {
+        func len(_ n: Int) -> Int? {
+            assistantEntry(content: String(repeating: "a", count: n))
+                .lightweightProjection(textCap: 2_000).payload?.content.first?.text?.count
+        }
+        #expect(len(2_000) == 2_000)   // == cap → not clipped (guard is strictly >)
+        #expect(len(2_001) == 2_000)   // cap+1 → clipped to cap
+        #expect(len(1_999) == 1_999)   // below cap → untouched
+    }
+
+    @Test("projection leaves nil/empty body fields as-is (never fabricates strings)")
+    func projectionEmptyAndNilFields() {
+        let entry = CodexEntry(type: "response_item", timestamp: nil, payload: CodexEntry.Payload(
+            type: "message", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil,
+            role: "assistant", message: nil, text: nil,
+            content: [CodexEntry.ContentBlock(type: "output_text", text: nil)], summary: []
+        ))
+        let p = entry.lightweightProjection(textCap: 2_000).payload
+        #expect(p?.message == nil)
+        #expect(p?.text == nil)
+        #expect(p?.summary.isEmpty == true)
+        #expect(p?.content.first?.text == nil)
+    }
+
+    @Test("projection preserves user text in any field (content/text/summary/message); clips assistant body")
+    func projectionUserFieldPrecedence() {
+        let big = String(repeating: "U", count: 5_000)
+        func userVia(content: Bool, text: Bool, summary: Bool) -> CodexEntry.Payload? {
+            CodexEntry(type: "response_item", timestamp: nil, payload: CodexEntry.Payload(
+                type: "message", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil,
+                role: "user", text: text ? big : nil,
+                content: content ? [CodexEntry.ContentBlock(type: "input_text", text: big)] : [],
+                summary: summary ? [CodexEntry.ContentBlock(type: "summary_text", text: big)] : []
+            )).lightweightProjection(textCap: 2_000).payload
+        }
+        #expect(userVia(content: true, text: false, summary: false)?.content.first?.text?.count == 5_000)
+        #expect(userVia(content: false, text: true, summary: false)?.text?.count == 5_000)
+        #expect(userVia(content: false, text: false, summary: true)?.summary.first?.text?.count == 5_000)
+        // The OTHER user shape — event_msg/user_message — is preserved too.
+        let evUser = CodexEntry(type: "event_msg", timestamp: nil, payload: CodexEntry.Payload(
+            type: "user_message", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil, message: big))
+        #expect(evUser.lightweightProjection(textCap: 2_000).payload?.message?.count == 5_000)
+        // An assistant body carried in message/text (not content) IS clipped.
+        let asst = assistantEntry(message: big, text: big).lightweightProjection(textCap: 2_000).payload
+        #expect(asst?.message?.count == 2_000)
+        #expect(asst?.text?.count == 2_000)
+    }
+
+    @Test("projection clips a huge non-spawn tool output but leaves a small spawn output intact")
+    func projectionToolOutputClipping() {
+        let bigOut = String(repeating: "o", count: 5_000)
+        let toolOut = CodexEntry(type: "response_item", timestamp: nil, payload: CodexEntry.Payload(
+            type: "function_call_output", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil,
+            output: bigOut, callId: "c9"))
+        #expect(toolOut.lightweightProjection(textCap: 2_000).payload?.output?.count == 2_000)
+        let spawn = "{\"agent_id\":\"a1\",\"nickname\":\"W\"}"
+        let spawnOut = CodexEntry(type: "response_item", timestamp: nil, payload: CodexEntry.Payload(
+            type: "function_call_output", timestamp: nil, turnId: nil, model: nil, cwd: nil, info: nil,
+            output: spawn, callId: "c1"))
+        #expect(spawnOut.lightweightProjection(textCap: 2_000).payload?.output == spawn)
+    }
+
+    @Test("projection caps on Characters, not bytes: wide graphemes clip by count and short-but-wide survive")
+    func projectionMultiByteBoundary() {
+        let wide5k = String(repeating: "😀", count: 5_000)   // count 5000, utf8 ~20000
+        #expect(assistantEntry(content: wide5k).lightweightProjection(textCap: 2_000).payload?.content.first?.text?.count == 2_000)
+        let wide1k = String(repeating: "😀", count: 1_000)   // utf8 > cap but count < cap → preserved
+        #expect(assistantEntry(content: wide1k).lightweightProjection(textCap: 2_000).payload?.content.first?.text?.count == 1_000)
+    }
+
+    // MARK: - Importer equivalence: more shapes
+
+    @Test("piece with NO user message: projected, usage identical, body clipped")
+    func noUserMessageEquivalence() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let big = String(repeating: "x", count: 5_000)
+        try write([
+            meta("nouser", ts: stamp(0, 0)),
+            turnContext("t0", ts: stamp(1, 0)),
+            assistant(big, ts: stamp(1, 0)),
+            tokensLast(input: 100, output: 10, ts: stamp(1, 0))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-nouser.jsonl"))
+        let full = try importGroup(home: home, rawId: "nouser", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "nouser", threshold: 0)
+        defer { light.cleanup() }
+        #expect(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+            == light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        let lt = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(try maxBodyLength(light, turns: lt) <= 2_000)
+    }
+
+    @Test("mixed token shapes (last-only + cumulative total) stay identical under projection")
+    func tokenShapeEquivalence() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let big = String(repeating: "x", count: 5_000)
+        try write([
+            meta("toks", ts: stamp(0, 0)),
+            turnContext("t0", ts: stamp(1, 0)),
+            user("hi", ts: stamp(1, 0)),
+            assistant(big, ts: stamp(1, 0)),
+            tokensLast(input: 100, output: 10, ts: stamp(1, 0)),
+            turnContext("t1", ts: stamp(2, 0)),
+            user("more", ts: stamp(2, 0)),
+            assistant(big, ts: stamp(2, 0)),
+            tokensTotal(input: 250, output: 25, ts: stamp(2, 0))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-toks.jsonl"))
+        let full = try importGroup(home: home, rawId: "toks", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "toks", threshold: 0)
+        defer { light.cleanup() }
+        #expect(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+            == light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+    }
+
+    @Test("multi-block assistant mirror > cap: usage/cost/turn aggregates identical (stepCount may differ)")
+    func multiBlockMirrorUsageInvariant() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        // event_msg agent_message (single string) mirrors a response_item
+        // assistant whose SAME text is split across two content blocks; the
+        // joined text exceeds the cap. Per-block vs single-string clipping
+        // can make the assembler's mirror dedup miss → stepCount +1. The
+        // load-bearing numbers (usage/cost/turn aggregates) must still match.
+        let a = String(repeating: "A", count: 1_500)
+        let b = String(repeating: "B", count: 1_500)
+        try write([
+            meta("mirror", ts: stamp(0, 0)),
+            turnContext("t0", ts: stamp(1, 0)),
+            user("go", ts: stamp(1, 0)),
+            #"{"type":"event_msg","timestamp":"\#(stamp(1, 1))","payload":{"type":"agent_message","message":"\#(a) \#(b)"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(1, 1))","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\#(a)"},{"type":"output_text","text":"\#(b)"}]}}"#,
+            tokensLast(input: 100, output: 10, ts: stamp(1, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-mirror.jsonl"))
+        let full = try importGroup(home: home, rawId: "mirror", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "mirror", threshold: 0)
+        defer { light.cleanup() }
+        #expect(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+            == light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        let ft = try full.store.turnPage(sessionId: full.sessionId, limit: 100, afterOrdinal: nil)
+        let lt = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(ft.count == lt.count)
+        #expect(zip(ft, lt).allSatisfy { $0.aggTokens == $1.aggTokens })
+        #expect(zip(ft, lt).allSatisfy { $0.aggCost.totalCostUSD == $1.aggCost.totalCostUSD })
+    }
+
+    @Test("a subagent thread that is ALSO a duplicated chain is NOT projected (dup wins)")
+    func dupSubagentComboExcluded() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let big = String(repeating: "x", count: 5_000)
+        // Root parent + a child whose raw id appears in TWO files (dup chain)
+        // AND is a subagent. usesDiscriminator wins → never projected.
+        try write([
+            meta("droot", ts: stamp(0, 0)),
+            turnContext("t-r", ts: stamp(0, 1)),
+            user("spawn", ts: stamp(0, 1)),
+            #"{"type":"response_item","timestamp":"\#(stamp(0, 1))","payload":{"type":"function_call","name":"spawn_agent","call_id":"c1","arguments":"{\"task\":\"w\"}"}}"#,
+            #"{"type":"response_item","timestamp":"\#(stamp(0, 1))","payload":{"type":"function_call_output","call_id":"c1","output":"{\"agent_id\":\"dchild\"}"}}"#,
+            tokensLast(input: 40, output: 4, ts: stamp(0, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-00-00-droot.jsonl"))
+        try write([
+            meta("dchild", ts: stamp(1, 0), parent: "droot"),
+            turnContext("t-c1", ts: stamp(1, 1)),
+            user("child work one", ts: stamp(1, 1)),
+            assistant(big, ts: stamp(1, 2)),
+            tokensTotal(input: 100, output: 10, ts: stamp(1, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-01-00-dchild.jsonl"))
+        try write([
+            meta("dchild", ts: stamp(2, 0), parent: "droot"),
+            tokensTotal(input: 100, output: 10, ts: stamp(2, 0)),   // replay cumulative → skipped
+            turnContext("t-c2", ts: stamp(2, 1)),
+            user("child work two", ts: stamp(2, 1)),
+            assistant(big, ts: stamp(2, 2)),
+            tokensTotal(input: 160, output: 16, ts: stamp(2, 2))
+        ], to: dayDir(home).appendingPathComponent("rollout-2026-06-01T10-02-00-dchild.jsonl"))
+
+        let full = try importGroup(home: home, rawId: "droot", threshold: .max)
+        defer { full.cleanup() }
+        let light = try importGroup(home: home, rawId: "droot", threshold: 0)
+        defer { light.cleanup() }
+        // Usage identical (dup chain takes the full path in both).
+        #expect(
+            try full.store.sessionUsageAggregates().first { $0.sessionId == full.sessionId }
+            == light.store.sessionUsageAggregates().first { $0.sessionId == light.sessionId }
+        )
+        // Decisive: the dup-subagent body is NOT clipped even at threshold 0.
+        let lt = try light.store.turnPage(sessionId: light.sessionId, limit: 100, afterOrdinal: nil)
+        #expect(try maxBodyLength(light, turns: lt) == 5_000)
+    }
+
+    // MARK: - Verify (ground-truth) path is bounded + equivalent
+
+    @Test("verify path: projecting an oversized piece yields identical ground-truth usage")
+    func verifyPathProjectionEquivalence() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let file = try writeStandalone(home, id: "vsolo", turns: 3, bodyChars: 5_000)
+
+        var fullV = CodexUsageVerifier()
+        fullV.oversizedPieceByteThreshold = .max     // never projects
+        var lightV = CodexUsageVerifier()
+        lightV.oversizedPieceByteThreshold = 0       // always projects (non-dup)
+
+        let sid = ProviderScopedID(provider: .codex, rawSessionId: "vsolo").value
+        let f = try #require(fullV.computeReport(files: [file]).perSession[sid])
+        let l = try #require(lightV.computeReport(files: [file]).perSession[sid])
+        #expect(f.dedupedInputTokens == l.dedupedInputTokens)
+        #expect(f.dedupedCacheReadInputTokens == l.dedupedCacheReadInputTokens)
+        #expect(f.dedupedReasoningOutputTokens == l.dedupedReasoningOutputTokens)
+        #expect(f.dedupedLineCount == l.dedupedLineCount)
+    }
+}


### PR DESCRIPTION
## What & why
A user with a large `~/.codex` (≈11 GB; individual rollouts up to ~660 MB) hit
repeated crashes. The 3.8a streaming importer bounds a session *group* to its
largest *piece*, but a single multi-hundred-MB rollout was still materialized
whole on import — and the Verify Costs path materialized it *with* raw bytes,
OOM-ing harder. This bounds the single piece on both paths.

## Approach
`CodexEntry.lightweightProjection` preserves user-prompt text verbatim and clips
only the non-user conversation body (assistant/tool), dropping large
display-only structured JSON. Applied per line when a piece is ≥ a configurable
threshold (default 192 MiB) and is NOT part of a duplicated chain.
- Eligible: standalone, subagent, and parent pieces.
- Excluded: duplicated (same-raw) chains — their dedup keys on assistant body text.
- One shared `usesLightweightProjection` rule drives both the importer and the
  verifier so the two paths cannot drift.

## Guarantees
- **No value regression**: usage/cost/turn/skill/link numbers are byte-identical
  to the full path (user prompts + token events preserved; the only assistant-body
  matcher, same-raw dedup, runs solely on the excluded duplicated chains).
- **Normal sessions unchanged**: sub-threshold pieces take the exact prior code path.
- **Memory**: peak tracks line count × cap, not file bytes (RSS-sampling tests).
- **Verify path** bounded too, and no longer retains raw line bytes.

## Tests
Pure projection (nil/empty/boundary/field-precedence/multi-byte/tool-output),
full-vs-light equivalence (standalone, >cap prompt, subagent group, mixed token
shapes, multi-block mirror, dup+subagent exclusion, threshold boundary,
idempotent re-import, skill preservation), verify-path equivalence, and
standalone + subagent memory-bound gates. All green; existing importer / loader /
equivalence / streaming suites unaffected.

## Known limitations (documented, rare, value-invariant)
- A single multi-hundred-MB *line* still materializes transiently (most rollouts
  are many-line; the reporting user's files are).
- A piece dominated by one huge *user* prompt stays full (preserving user text is
  required for correct replay matching).
- Conversation *display* for projected giant sessions is truncated (full text is
  in the Raw tab); some tool/patch display fields are dropped.
- A spawn output exceeding the cap could drop a subagent link (spawn outputs are
  tiny in practice).

None of these affect cost/usage analytics; tracked as Phase 2.