### PR TITLE
Release 0.4.1

### DIFF
--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -12,8 +12,8 @@ INFOPLIST_KEY_NSHumanReadableCopyright = Copyright © 2026 jaden (@momoraul). MI
 // Bump MARKETING_VERSION for user-visible releases, CURRENT_PROJECT_VERSION
 // for every build that ships (TestFlight / Developer ID notarization).
 
-MARKETING_VERSION = 0.4.0
-CURRENT_PROJECT_VERSION = 2
+MARKETING_VERSION = 0.4.1
+CURRENT_PROJECT_VERSION = 3
 
 // --- Activation policy ------------------------------------------------------
 // We run as a regular app (Dock icon + global menu bar always visible)

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -2555,7 +2555,7 @@ final class SessionCellView: NSTableCellView {
         requestCount: Int,
         totalTokens: Int
     ) -> String? {
-        var lines = [
+        let lines = [
             "Requests: \(formatCount(requestCount))",
             "Tokens: \(formatCount(totalTokens))",
         ]

--- a/LupenTests/UI/Animation/AppearanceDiffEngineTests.swift
+++ b/LupenTests/UI/Animation/AppearanceDiffEngineTests.swift
@@ -245,7 +245,7 @@ struct AppearanceDiffEngineTests {
         // 12 new items + 5 reordered items in one cycle, default cap.
         // Spec §3 prefers letting newcomers through; reorders are a
         // less-urgent signal and can wait for a quieter cycle.
-        var prevIds = ["a", "b", "c", "d", "e"]
+        let prevIds = ["a", "b", "c", "d", "e"]
         var currIds: [String] = []
         for i in 0..<12 { currIds.append("new-\(i)") }
         currIds.append(contentsOf: prevIds.reversed())   // reorder all 5 originals

--- a/LupenTests/UI/Dashboard/SessionCostLabelTests.swift
+++ b/LupenTests/UI/Dashboard/SessionCostLabelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import AppKit
 @testable import Lupen
 
+@MainActor
 final class SessionCostLabelTests: XCTestCase {
     private func makeCell() -> SessionCellView {
         SessionCellView(frame: .init(x: 0, y: 0, width: 300, height: 56))

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ OpenAI**; it only reads local log files written to your machine.
 
 ## Changelog
 
+### v0.4.1 — _2026-06-20_
+
+Maintenance release — cost-accuracy fixes and a clearer cost in the sidebar.
+
+- Per-session cost now has a dedicated, compression-resistant sidebar label —
+  the title truncates first so the cost stays visible, with the same confidence
+  tinting as the turn rows.
+- Codex: sessions backed by valid rollout JSONL now appear in the sidebar even
+  when they're missing from `session_index.jsonl`, matching the local Codex view.
+- Verify Costs: `usage` blocks that omit input/output tokens are kept (coerced
+  to 0) instead of silently dropping the line — fixes an undercount versus the
+  ground-truth scan.
+- Codex usage verifier: fold `last`-only token events into the running total so
+  the verifier matches the importer.
+- Codex: bound memory when importing/verifying oversized single-piece rollouts,
+  preventing an out-of-memory spike on very large sessions.
+
 ### v0.4.0 — _2026-06-18_
 
 First release of the `lupen` command line — the app binary doubles as a


### PR DESCRIPTION
Maintenance release bundling everything merged since 0.4.0 (#3, #4, #5, #7, #8), plus the version bump, changelog, and a build-warning cleanup.

## Changelog (v0.4.1)
- Per-session cost as a dedicated, compression-resistant sidebar label (#7)
- Codex: surface sessions backed by rollout JSONL even when missing from the title index (#3)
- Verify Costs: keep `usage` blocks that omit input/output tokens instead of dropping the line — fixes an undercount (#4)
- Codex usage verifier: fold `last`-only token events into the running total to match the importer (#5)
- Codex: bound memory for oversized single-piece rollouts (prevents OOM) (#8)

## This PR
- Version 0.4.0 → 0.4.1 (build 2 → 3), README changelog entry
- Build-warning cleanup (`@MainActor` + `var`→`let`; no behavior change)

## Verified
- Full test suite: 1,858 passed / 0 failed
- Release clean build: SUCCEEDED, 0 code warnings