### PR TITLE
test: cover title-index-free sessions in top report

### DIFF
--- a/Lupen/Domain/Codex/CodexSessionMetadata.swift
+++ b/Lupen/Domain/Codex/CodexSessionMetadata.swift
@@ -126,12 +126,4 @@ struct CodexSessionTitleIndex: Equatable, Sendable {
         }
         return title
     }
-
-    var isEmpty: Bool {
-        entriesById.isEmpty
-    }
-
-    func contains(sessionId: String) -> Bool {
-        entriesById[sessionId] != nil
-    }
 }

--- a/Lupen/Domain/Codex/CodexUsageSessionLoader.swift
+++ b/Lupen/Domain/Codex/CodexUsageSessionLoader.swift
@@ -362,7 +362,7 @@ enum CodexUsageSessionLoader {
             )
         }
 
-        let merged = mergeSessionPieces(pieces, titleIndex: titleIndex)
+        let merged = mergeSessionPieces(pieces)
 
         let result = CodexUsageSessionLoadResult(
             codexHome: discovery.codexHome,
@@ -1019,10 +1019,7 @@ enum CodexUsageSessionLoader {
         return decodedLines.isEmpty ? nil : decodedLines
     }
 
-    static func mergeSessionPieces(
-        _ pieces: [LoadedSessionPiece],
-        titleIndex: CodexSessionTitleIndex
-    ) -> MergedSessions {
+    static func mergeSessionPieces(_ pieces: [LoadedSessionPiece]) -> MergedSessions {
         guard !pieces.isEmpty else {
             return MergedSessions(
                 sessions: [],

--- a/LupenTests/CLI/TopReportTests.swift
+++ b/LupenTests/CLI/TopReportTests.swift
@@ -153,6 +153,29 @@ struct TopReportTests {
         #expect(count == rows.count)
     }
 
+    @Test("Codex top sessions include rollout-backed sessions missing from title index")
+    func codexTopSessionsIncludeUnindexedRollouts() throws {
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let dbURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lupen-top-codex-\(UUID().uuidString).sqlite3")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let store = ProviderStore(database: try ProviderDatabase.open(at: dbURL))
+        _ = CLIRefresher.run(source: .codex(codexHome: corpus.codexHome), store: store)
+
+        let rows = try store.topSessionCosts(from: nil, to: nil, limit: 100_000)
+        let count = try store.visibleSessionCount(from: nil, to: nil)
+
+        #expect(rows.contains {
+            $0.sessionId == ProviderScopedID(
+                provider: .codex,
+                rawSessionId: RefactorFixtureCorpus.codexForkRawId
+            ).value
+        })
+        #expect(count == rows.count)
+    }
+
     @Test("topDays guards a non-positive limit instead of trapping")
     func topDaysNonPositiveLimit() {
         let buckets = [


### PR DESCRIPTION
## What this changes

Addresses the optional follow-up items from #3:

- Removes the now-dead `mergeSessionPieces` title-index parameter.
- Removes unused `CodexSessionTitleIndex.isEmpty` and `contains(sessionId:)` helpers.
- Adds a Codex `lupen top` regression test proving a rollout-backed session missing from `session_index.jsonl` appears in `topSessionCosts` and is counted by `visibleSessionCount`.

## How it was verified

- [x] `xcodebuild test -project Lupen.xcodeproj -scheme Lupen -destination 'platform=macOS' -only-testing:LupenTests/TopReportTests`
- [x] `xcodebuild test -project Lupen.xcodeproj -scheme Lupen -destination 'platform=macOS' -only-testing:LupenTests/CodexUsageSessionLoaderTests/keepsUnindexedRolloutsVisibleFromRolloutJSONL`
- [x] `git diff --check`

Notes:

- One initial parallel test run hit Xcode's shared DerivedData build database lock. The affected test was rerun sequentially and passed.
- No UI layout changed, so no screenshot or screen recording is attached.

## Checklist

- [x] `xcodebuild test` passes locally
- [x] UI changes include a screenshot or screen recording
  - N/A: no UI changes
- [x] New features add tests (domain) or list a manual-verification procedure (UI)
- [x] Vocabulary matches [`docs/CONVERSATION-MODEL.md`](../docs/CONVERSATION-MODEL.md)
- [x] Cost-affecting changes are checked against Window → Verify Costs…
  - N/A: cleanup plus reporting regression coverage only; no pricing or token accounting changes.
- [x] No hard-coded `/Users/<name>/…` paths or other personal data

## Related issues

Follow-up to #3 review comments.
