### PR TITLE
Sidebar: Codex first-prompt titles, zero-cost hiding, cost recoloring

### DIFF
--- a/Lupen/Data/Models/Session.swift
+++ b/Lupen/Data/Models/Session.swift
@@ -59,6 +59,16 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
     /// when `requests` is empty so the sidebar branch row renders.
     var shellGitBranch: String? = nil
 
+    /// Importer-extracted `sessions.first_prompt` (the cleaned first user
+    /// message) carried by the shell projection. Unlike `slug` /
+    /// `lastGitBranch` there is no request-level source for it, so it is
+    /// surfaced directly through the `firstPrompt` computed property and
+    /// consumed by `SessionTitleResolver` as the sidebar title fallback
+    /// below `slug`. This lets Codex sessions that have no
+    /// `session_index.jsonl` thread name show their first prompt instead
+    /// of the raw id prefix; Claude sessions keep their `slug` ordering.
+    var shellFirstPrompt: String? = nil
+
     var scopedId: String {
         ProviderScopedID(provider: provider, rawSessionId: rawSessionId).value
     }
@@ -75,7 +85,8 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
         shellStartTime: Date? = nil,
         shellEndTime: Date? = nil,
         shellSlug: String? = nil,
-        shellGitBranch: String? = nil
+        shellGitBranch: String? = nil,
+        shellFirstPrompt: String? = nil
     ) {
         let parsed = ProviderScopedID(value: id)
         self.id = id
@@ -90,6 +101,7 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
         self.shellEndTime = shellEndTime
         self.shellSlug = shellSlug
         self.shellGitBranch = shellGitBranch
+        self.shellFirstPrompt = shellFirstPrompt
     }
 
     init(from decoder: Decoder) throws {
@@ -112,11 +124,12 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
         self.shellEndTime = try c.decodeIfPresent(Date.self, forKey: .shellEndTime)
         self.shellSlug = try c.decodeIfPresent(String.self, forKey: .shellSlug)
         self.shellGitBranch = try c.decodeIfPresent(String.self, forKey: .shellGitBranch)
+        self.shellFirstPrompt = try c.decodeIfPresent(String.self, forKey: .shellFirstPrompt)
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, provider, rawSessionId, requests, projectPath, isVisibleInSessionList, cachedTitle, customTitle
-        case shellStartTime, shellEndTime, shellSlug, shellGitBranch
+        case shellStartTime, shellEndTime, shellSlug, shellGitBranch, shellFirstPrompt
     }
 
     var startTime: Date? { requests.first?.timestamp ?? shellStartTime }
@@ -138,6 +151,12 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
     var slug: String? {
         requests.first(where: { $0.slug != nil })?.slug ?? shellSlug
     }
+
+    /// The cleaned first user prompt for this session, carried by the
+    /// SQLite-first shell projection. No request-level source exists, so
+    /// this simply exposes `shellFirstPrompt`; legacy in-memory sessions
+    /// leave it nil. Used only as a sidebar title fallback below `slug`.
+    var firstPrompt: String? { shellFirstPrompt }
 
     func withProviderScopedIdentity() -> Session {
         let provider = ProviderScopedID(value: id)?.provider ?? self.provider
@@ -165,7 +184,8 @@ struct Session: Sendable, Codable, Identifiable, Equatable {
             shellStartTime: shellStartTime,
             shellEndTime: shellEndTime,
             shellSlug: shellSlug,
-            shellGitBranch: shellGitBranch
+            shellGitBranch: shellGitBranch,
+            shellFirstPrompt: shellFirstPrompt
         )
     }
 }

--- a/Lupen/Domain/SessionListHiddenPartition.swift
+++ b/Lupen/Domain/SessionListHiddenPartition.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Splits a project group's sessions into "shown" and "hidden" buckets for
+/// the sidebar. A session is hidden when it is *low-signal* — its cost
+/// aggregate is present and non-positive (Codex `codex-auto-review`
+/// assessment threads, empty `/clear` sessions, etc.): nothing billable
+/// happened, so it is noise in the list. Framework-free so the rules stay
+/// unit-testable (same philosophy as `SessionPagination` / `SessionGrouping`).
+///
+/// The cost lookup itself is injected as `isLowSignal` so the aggregate
+/// availability gate — never hide on a *missing* aggregate, which would blank
+/// the sidebar during a cold load before costs are imported — lives with the
+/// view controller, and tests can stub the predicate directly.
+enum SessionListHiddenPartition {
+
+    struct Result: Equatable {
+        let shown: [Session]
+        let hidden: [Session]
+    }
+
+    /// - Parameters:
+    ///   - sessions: group sessions already in display order (endTime DESC).
+    ///   - hidingEnabled: when false (e.g. an active search/filter), nothing
+    ///     is hidden — the user is looking for something and must see all.
+    ///   - keepShown: session ids that must never be hidden even when
+    ///     low-signal (typically the current selection, so a reload never
+    ///     drops the row the user is viewing).
+    ///   - isLowSignal: returns true when a session is a hide candidate.
+    static func partition(
+        sessions: [Session],
+        hidingEnabled: Bool,
+        keepShown: Set<String>,
+        isLowSignal: (Session) -> Bool
+    ) -> Result {
+        guard hidingEnabled else {
+            return Result(shown: sessions, hidden: [])
+        }
+        var shown: [Session] = []
+        var hidden: [Session] = []
+        for session in sessions {
+            if isLowSignal(session) && !keepShown.contains(session.id) {
+                hidden.append(session)
+            } else {
+                shown.append(session)
+            }
+        }
+        return Result(shown: shown, hidden: hidden)
+    }
+}

--- a/Lupen/Domain/SessionListHiddenPartition.swift
+++ b/Lupen/Domain/SessionListHiddenPartition.swift
@@ -46,4 +46,20 @@ enum SessionListHiddenPartition {
         }
         return Result(shown: shown, hidden: hidden)
     }
+
+    /// Whether a session is a "low-signal" hide candidate: it incurred no
+    /// billable cost (cost present and `<= 0`) AND is not currently active.
+    ///
+    /// - `costUSD == nil` means the cost aggregate is absent — a cold load
+    ///   before costs import, or a session with no requests at all (e.g. an
+    ///   empty `/clear` shell). Never hidden: hiding on absence would blank
+    ///   the sidebar mid-import, and an empty shell has nothing to aggregate.
+    /// - An `isActive` session is never hidden even at zero cost: it is the
+    ///   one the user is most likely watching and simply hasn't been billed
+    ///   yet. `isActive` already feeds the render fingerprint, so a session
+    ///   flips shown↔hidden automatically when it goes idle.
+    static func isLowSignal(costUSD: Double?, isActive: Bool) -> Bool {
+        guard let costUSD, !isActive else { return false }
+        return costUSD <= 0
+    }
 }

--- a/Lupen/Store/SQLiteFirstStartup.swift
+++ b/Lupen/Store/SQLiteFirstStartup.swift
@@ -42,7 +42,8 @@ enum SessionShellProjection {
                 shellStartTime: row.startTime,
                 shellEndTime: row.endTime,
                 shellSlug: row.slug,
-                shellGitBranch: row.lastGitBranch
+                shellGitBranch: row.lastGitBranch,
+                shellFirstPrompt: row.firstPrompt
             )
         }
     }

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -802,7 +802,8 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// detail pane even though nothing was actually deleted.
     private func buildGroupedTree(
         from sessions: [Session],
-        previousSelectionId: String?
+        previousSelectionId: String?,
+        now: Date
     ) -> TreeBuild {
         let groups = SessionGrouping.groupByProject(sessions)
 
@@ -821,7 +822,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                 sessions: group.sessions,
                 hidingEnabled: hidingEnabled,
                 keepShown: keepShown,
-                isLowSignal: { self.isLowSignalSession($0) }
+                isLowSignal: { self.isLowSignalSession($0, now: now) }
             )
             let hiddenCount = partition.hidden.count
             let expanded = expandedHiddenByProject.contains(projectKey)
@@ -1092,7 +1093,8 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         case .grouped:
             let built = buildGroupedTree(
                 from: sessionsForGrouping,
-                previousSelectionId: selectionToRestore
+                previousSelectionId: selectionToRestore,
+                now: now
             )
             newRoots = built.roots
             newSessionNodes = built.nodesById
@@ -1470,18 +1472,18 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         reloadData()
     }
 
-    /// A session is a "low-signal" hide candidate when its cost aggregate is
-    /// present and non-positive — Codex auto-review assessment threads, empty
-    /// `/clear` sessions, etc., where nothing billable happened. A *missing*
-    /// aggregate (not yet imported) is deliberately NOT hidden: during a cold
-    /// load every aggregate is absent, and hiding on absence would blank the
-    /// sidebar. `costUSD` already feeds the render fingerprint, so a session
-    /// flips between shown/hidden automatically once its cost lands.
-    private func isLowSignalSession(_ session: Session) -> Bool {
-        guard let aggregate = store.sessionListAggregates[session.id] else {
-            return false
-        }
-        return aggregate.costUSD <= 0
+    /// Store-backed wrapper over `SessionListHiddenPartition.isLowSignal` —
+    /// supplies the session's cost aggregate and active state. Only sessions
+    /// that ran requests with no billable cost (Codex auto-review threads,
+    /// unpriced models) and are idle get hidden; active sessions and sessions
+    /// with no aggregate (cold load / no requests, e.g. empty `/clear` shells)
+    /// stay visible. `now` is the reload's shared timestamp so this active
+    /// check matches the render fingerprint's `isActive` exactly.
+    private func isLowSignalSession(_ session: Session, now: Date) -> Bool {
+        SessionListHiddenPartition.isLowSignal(
+            costUSD: store.sessionListAggregates[session.id]?.costUSD,
+            isActive: store.isSessionActive(session, now: now)
+        )
     }
 
     /// Flip this group's hidden (zero-cost) bucket open/closed and rebuild.
@@ -2784,8 +2786,12 @@ private final class SessionListGroupHeaderView: NSTableCellView {
         guard !hiddenToggle.isHidden else { return false }
         // Convert the toggle's bounds into cell coordinates (it lives inside
         // `rightStack`), plus a few points of horizontal grace.
-        let rect = convert(hiddenToggle.bounds, from: hiddenToggle)
-        return point.x >= rect.minX - 4 && point.x <= rect.maxX + 4
+        // Accept a click inside the toggle's bounds (in cell coordinates;
+        // it lives inside `rightStack`) plus a small grace margin on both
+        // axes, so the compact pill is comfortable to hit without claiming
+        // the full-height header band the way an x-only test did.
+        let rect = convert(hiddenToggle.bounds, from: hiddenToggle).insetBy(dx: -4, dy: -4)
+        return rect.contains(point)
     }
 }
 

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -2377,7 +2377,8 @@ final class SessionCellView: NSTableCellView {
         costLabel.alignment = .right
         costLabel.lineBreakMode = .byClipping
         costLabel.maximumNumberOfLines = 1
-        // 비용은 핵심 지표 — 절대 안 잘리고 폭도 안 늘어남. 제목이 먼저 …로 양보.
+        // Cost is the key metric — never clipped, never grows the column; the
+        // title yields to a … truncation first.
         costLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         costLabel.setContentHuggingPriority(.required, for: .horizontal)
 
@@ -2554,7 +2555,8 @@ final class SessionCellView: NSTableCellView {
         costLabel.stringValue = costDisplay.text
         costBaseColor = costDisplay.color
         applyCostLabelColor()
-        // Codex 신뢰도 설명 툴팁은 비용 라벨로 이동(이전엔 metaLabel에 붙였음).
+        // The Codex confidence tooltip now lives on the cost label (it was on
+        // metaLabel before).
         costLabel.toolTip = Self.costTooltip(provider: provider, confidence: costConfidence)
 
         // Format numbers tersely. "·" is a middle-dot separator — more compact

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -587,7 +587,14 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     private static func providerModeAccentColor(for kind: ProviderKind) -> NSColor {
         switch kind {
         case .claudeCode:
-            return NSColor(srgbRed: 0.98, green: 0.74, blue: 0.38, alpha: 1.0)
+            return NSColor(name: "ClaudeProviderAccent") { appearance in
+                let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                // Dark keeps the bright amber; light deepens it so the tinted
+                // background / border / icon don't wash out on a white sidebar.
+                return isDark
+                    ? NSColor(srgbRed: 0.98, green: 0.74, blue: 0.38, alpha: 1.0)
+                    : NSColor(srgbRed: 0.812, green: 0.478, blue: 0.071, alpha: 1.0)
+            }
         case .codex:
             return NSColor(srgbRed: 0.22, green: 0.78, blue: 0.58, alpha: 1.0)
         }

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -127,6 +127,11 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// the value; we intentionally keep the window after a collapse so the
     /// user's explicit expand isn't silently thrown away.
     private var visibleCountByProject: [String: Int] = [:]
+    /// Per-project "is the zero-cost hidden bucket currently expanded".
+    /// Missing ⇒ collapsed (default). In-memory only: hidden sessions start
+    /// collapsed on every launch, mirroring the pagination window's first
+    /// page. Part of `RenderSnapshot` so a toggle invalidates the guard.
+    private var expandedHiddenByProject: Set<String> = []
     /// Page size for the per-group paginated list. Five keeps the sidebar
     /// compact — a "heavy" project day (50+ sessions) doesn't dominate the
     /// pane just because one group got unlucky activity bursts.
@@ -171,6 +176,10 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         /// Pagination window per project key. Required so "Show N more"
         /// clicks invalidate the snapshot automatically.
         var visibleCounts: [String: Int]
+        /// Per-project "is the zero-cost hidden bucket expanded". Must be in
+        /// the fingerprint so toggling it invalidates the guard and rebuilds
+        /// the tree (otherwise the show/hide click would silently no-op).
+        var hiddenExpanded: Set<String>
         /// Current filter applied to the session list. Must be in the
         /// fingerprint so a query change (or any other filter tweak)
         /// automatically invalidates the guard and forces a rebuild.
@@ -225,6 +234,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     private var lastRenderSnapshot: RenderSnapshot = RenderSnapshot(
         sessionFingerprints: [],
         visibleCounts: [:],
+        hiddenExpanded: [],
         filter: SessionFilter(),
         layoutMode: .grouped,
         activeProvider: .claudeCode,
@@ -279,6 +289,9 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         }
         outlineView.onShowLessClicked = { [weak self] projectKey in
             self?.collapseToFirstPage(for: projectKey)
+        }
+        outlineView.onHiddenToggleClicked = { [weak self] projectKey in
+            self?.toggleHiddenSessions(for: projectKey)
         }
         // Context menu on session rows: the outline view subclass handles
         // locating the row under the cursor; we build the menu here so all
@@ -793,30 +806,53 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     ) -> TreeBuild {
         let groups = SessionGrouping.groupByProject(sessions)
 
-        if let prevId = previousSelectionId {
-            for group in groups {
-                if let idx = group.sessions.firstIndex(where: { $0.id == prevId }) {
-                    let projectKey = providerProjectKey(group.key)
-                    let current = visibleCountByProject[projectKey] ?? Self.pageSize
-                    if idx >= current {
-                        // Round up to the next page boundary so the window
-                        // doesn't settle on an awkward "off-by-one" size.
-                        let needed = idx + 1
-                        let rounded = ((needed + Self.pageSize - 1) / Self.pageSize) * Self.pageSize
-                        visibleCountByProject[projectKey] = rounded
-                    }
-                    break
-                }
-            }
-        }
+        // Hiding is suppressed while a search/filter is active — the user is
+        // looking for something and must see every match. The current
+        // selection is always kept visible so a reload never drops the row
+        // being viewed (it stays in the `shown` bucket via `keepShown`).
+        let hidingEnabled = currentFilter.isEmpty
+        let keepShown: Set<String> = previousSelectionId.map { [$0] } ?? []
 
         var roots: [SessionListNode] = []
         var nodesById: [String: SessionListNode] = [:]
         for group in groups {
             let projectKey = providerProjectKey(group.key)
+            let partition = SessionListHiddenPartition.partition(
+                sessions: group.sessions,
+                hidingEnabled: hidingEnabled,
+                keepShown: keepShown,
+                isLowSignal: { self.isLowSignalSession($0) }
+            )
+            let hiddenCount = partition.hidden.count
+            let expanded = expandedHiddenByProject.contains(projectKey)
+
+            // Collapsed → only the non-hidden sessions. Expanded → low-signal
+            // sessions rejoin the list in their natural endTime order (mixed
+            // back in, not a separate section). Either way pagination applies
+            // to the resulting list.
+            let displaySessions = (hiddenCount == 0 || expanded)
+                ? group.sessions
+                : partition.shown
+
+            // Pagination window auto-grow: if the previously selected session
+            // is in this group's displayed list but past the visible window
+            // (a few fresh sessions streamed in while the user was idle),
+            // bump the window so the selection stays in view.
+            if let prevId = previousSelectionId,
+               let idx = displaySessions.firstIndex(where: { $0.id == prevId }) {
+                let current = visibleCountByProject[projectKey] ?? Self.pageSize
+                if idx >= current {
+                    // Round up to the next page boundary so the window
+                    // doesn't settle on an awkward "off-by-one" size.
+                    let needed = idx + 1
+                    let rounded = ((needed + Self.pageSize - 1) / Self.pageSize) * Self.pageSize
+                    visibleCountByProject[projectKey] = rounded
+                }
+            }
+
             let windowSize = visibleCountByProject[projectKey] ?? Self.pageSize
             let win = SessionPagination.window(
-                sessions: group.sessions,
+                sessions: displaySessions,
                 visibleCount: windowSize,
                 pageSize: Self.pageSize
             )
@@ -835,10 +871,15 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                 )))
             }
 
+            // The hidden (zero-cost) sessions are toggled from a small button
+            // in the group header (which carries `hiddenCount` / `expanded`),
+            // not a separate row — so nothing extra is appended for them here.
             let header = SessionListNode(kind: .projectGroup(
                 key: projectKey,
                 label: group.label,
-                count: group.sessions.count
+                count: group.sessions.count,
+                hiddenCount: hiddenCount,
+                expanded: expanded
             ))
             header.children = children
             roots.append(header)
@@ -947,6 +988,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
             lastRenderSnapshot = RenderSnapshot(
                 sessionFingerprints: [],
                 visibleCounts: [:],
+                hiddenExpanded: [],
                 filter: currentFilter,
                 layoutMode: layoutMode,
                 activeProvider: store.activeProvider,
@@ -1000,6 +1042,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                 )
             },
             visibleCounts: visibleCountByProject,
+            hiddenExpanded: expandedHiddenByProject,
             filter: currentFilter,
             layoutMode: layoutMode,
             activeProvider: activeProvider,
@@ -1345,8 +1388,8 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
         guard let node = item as? SessionListNode else { return nil }
         switch node.kind {
-        case .projectGroup(_, let label, let count):
-            return headerCell(label: label, count: count)
+        case .projectGroup(_, let label, let count, let hiddenCount, let expanded):
+            return headerCell(label: label, count: count, hiddenCount: hiddenCount, expanded: expanded)
         case .session(let session):
             return sessionCell(for: session)
         case .loadMore(_, let nextStep, let remainingAfterStep, let canCollapse):
@@ -1424,6 +1467,32 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// the detail pane.
     private func collapseToFirstPage(for projectKey: String) {
         visibleCountByProject.removeValue(forKey: projectKey)
+        reloadData()
+    }
+
+    /// A session is a "low-signal" hide candidate when its cost aggregate is
+    /// present and non-positive — Codex auto-review assessment threads, empty
+    /// `/clear` sessions, etc., where nothing billable happened. A *missing*
+    /// aggregate (not yet imported) is deliberately NOT hidden: during a cold
+    /// load every aggregate is absent, and hiding on absence would blank the
+    /// sidebar. `costUSD` already feeds the render fingerprint, so a session
+    /// flips between shown/hidden automatically once its cost lands.
+    private func isLowSignalSession(_ session: Session) -> Bool {
+        guard let aggregate = store.sessionListAggregates[session.id] else {
+            return false
+        }
+        return aggregate.costUSD <= 0
+    }
+
+    /// Flip this group's hidden (zero-cost) bucket open/closed and rebuild.
+    /// `expandedHiddenByProject` is part of `RenderSnapshot`, so mutating it
+    /// is enough — the snapshot guard inside `reloadData` detects the change.
+    private func toggleHiddenSessions(for projectKey: String) {
+        if expandedHiddenByProject.contains(projectKey) {
+            expandedHiddenByProject.remove(projectKey)
+        } else {
+            expandedHiddenByProject.insert(projectKey)
+        }
         reloadData()
     }
 
@@ -1576,7 +1645,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
 
     // MARK: - Cell factories
 
-    private func headerCell(label: String, count: Int) -> NSView {
+    private func headerCell(label: String, count: Int, hiddenCount: Int, expanded: Bool) -> NSView {
         let id = NSUserInterfaceItemIdentifier("SessionGroupHeaderCell")
         let cell: SessionListGroupHeaderView
         if let reused = outlineView.makeView(withIdentifier: id, owner: nil) as? SessionListGroupHeaderView {
@@ -1585,7 +1654,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
             cell = SessionListGroupHeaderView()
             cell.identifier = id
         }
-        cell.configure(label: label, count: count)
+        cell.configure(label: label, count: count, hiddenCount: hiddenCount, expanded: expanded)
         return cell
     }
 
@@ -2090,7 +2159,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
 private final class SessionListNode: NSObject {
 
     enum Kind {
-        case projectGroup(key: String, label: String, count: Int)
+        case projectGroup(key: String, label: String, count: Int, hiddenCount: Int, expanded: Bool)
         case session(Session)
         /// "Show N more" / "Show less" action row at the bottom of a
         /// paginated group. Clicking the main area bumps the group's
@@ -2114,7 +2183,7 @@ private final class SessionListNode: NSObject {
 
     var identityKey: String {
         switch kind {
-        case .projectGroup(let key, _, _): return "group:\(key)"
+        case .projectGroup(let key, _, _, _, _): return "group:\(key)"
         case .session(let s):                return "session:\(s.id)"
         case .loadMore(let key, _, _, _):    return "loadMore:\(key)"
         }
@@ -2122,7 +2191,7 @@ private final class SessionListNode: NSObject {
 
     /// Project key iff this node is a group header.
     var projectKey: String? {
-        if case .projectGroup(let k, _, _) = kind { return k }
+        if case .projectGroup(let k, _, _, _, _) = kind { return k }
         return nil
     }
 
@@ -2595,6 +2664,17 @@ private final class SessionListGroupHeaderView: NSTableCellView {
     private let iconView = NSImageView()
     private let labelField = NSTextField(labelWithString: "")
     private let countField = NSTextField(labelWithString: "")
+    /// Right-aligned [count][hiddenToggle] row. The stack drops the toggle
+    /// from layout when hidden, so the count sits flush right when a group
+    /// has no low-signal sessions.
+    private let rightStack = NSStackView()
+
+    /// To the RIGHT of the count: "(N)" — how many low-signal (zero-cost)
+    /// sessions are collapsed; clicking toggles them in place. Detached from
+    /// the stack (isHidden) when the group has none.
+    /// `SessionListOutlineView.mouseDown` hit-tests `isHiddenToggleHit(at:)`
+    /// to route a click here instead of expand/collapse.
+    private let hiddenToggle = NSTextField(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -2621,7 +2701,18 @@ private final class SessionListGroupHeaderView: NSTableCellView {
         countField.textColor = .tertiaryLabelColor
         countField.alignment = .right
 
-        for v in [iconView, labelField, countField] {
+        hiddenToggle.font = .monospacedDigitSystemFont(ofSize: 10, weight: .medium)
+        hiddenToggle.alignment = .right
+
+        rightStack.orientation = .horizontal
+        rightStack.spacing = 5
+        rightStack.alignment = .centerY
+        rightStack.addArrangedSubview(countField)
+        rightStack.addArrangedSubview(hiddenToggle)
+        rightStack.setContentHuggingPriority(.required, for: .horizontal)
+        rightStack.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        for v in [iconView, labelField, rightStack] {
             v.translatesAutoresizingMaskIntoConstraints = false
             addSubview(v)
         }
@@ -2634,20 +2725,42 @@ private final class SessionListGroupHeaderView: NSTableCellView {
 
             labelField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 6),
             labelField.centerYAnchor.constraint(equalTo: centerYAnchor),
-            labelField.trailingAnchor.constraint(lessThanOrEqualTo: countField.leadingAnchor, constant: -6),
+            labelField.trailingAnchor.constraint(lessThanOrEqualTo: rightStack.leadingAnchor, constant: -6),
 
-            countField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            countField.centerYAnchor.constraint(equalTo: centerYAnchor),
+            rightStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            rightStack.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
     }
 
-    func configure(label: String, count: Int) {
+    func configure(label: String, count: Int, hiddenCount: Int, expanded: Bool) {
         labelField.stringValue = label.uppercased()
         countField.stringValue = "\(count)"
-        // VoiceOver: announce "PROJECT, 12 sessions, disclosure triangle"
-        // so users can tell what they're toggling without reading screen.
-        setAccessibilityLabel("\(label), \(count) sessions")
+
+        if hiddenCount > 0 {
+            hiddenToggle.isHidden = false
+            // Brighter when expanded (sessions shown), dimmer when collapsed.
+            // Parenthesised so it reads apart from the group's session count.
+            hiddenToggle.textColor = expanded ? .secondaryLabelColor : .tertiaryLabelColor
+            hiddenToggle.stringValue = "(\(hiddenCount))"
+            let action = expanded ? "Hide" : "Show"
+            setAccessibilityLabel("\(label), \(count) sessions, \(action) \(hiddenCount) hidden")
+        } else {
+            hiddenToggle.isHidden = true
+            hiddenToggle.stringValue = ""
+            setAccessibilityLabel("\(label), \(count) sessions")
+        }
         setAccessibilityRole(.disclosureTriangle)
+    }
+
+    /// True when `point` (in this cell's coordinate space) lands on the
+    /// hidden-toggle. `SessionListOutlineView.mouseDown` uses this to route
+    /// the click to the toggle instead of expanding/collapsing.
+    func isHiddenToggleHit(at point: NSPoint) -> Bool {
+        guard !hiddenToggle.isHidden else { return false }
+        // Convert the toggle's bounds into cell coordinates (it lives inside
+        // `rightStack`), plus a few points of horizontal grace.
+        let rect = convert(hiddenToggle.bounds, from: hiddenToggle)
+        return point.x >= rect.minX - 4 && point.x <= rect.maxX + 4
     }
 }
 
@@ -3052,6 +3165,10 @@ final class SessionListOutlineView: NSOutlineView {
     /// `SessionListViewController.viewDidLoad`.
     var onShowLessClicked: ((String) -> Void)?
 
+    /// Invoked when the user clicks a `.hiddenToggle` row. Argument is the
+    /// owning project key. Wired up by `SessionListViewController.viewDidLoad`.
+    var onHiddenToggleClicked: ((String) -> Void)?
+
     /// Builds the right-click context menu for a session leaf. Wired up by
     /// `SessionListViewController.viewDidLoad` — returning `nil` from the
     /// closure (or leaving it unset) suppresses the menu for that row.
@@ -3087,8 +3204,16 @@ final class SessionListOutlineView: NSOutlineView {
         let row = self.row(at: point)
         if row >= 0, let node = self.item(atRow: row) as? SessionListNode {
             switch node.kind {
-            case .projectGroup:
-                if isItemExpanded(node) {
+            case .projectGroup(let key, _, _, let hiddenCount, _):
+                // A click on the header's hidden-toggle button flips the
+                // group's zero-cost bucket; clicks elsewhere on the header
+                // expand/collapse the group as usual.
+                if hiddenCount > 0,
+                   let cell = view(atColumn: 0, row: row, makeIfNecessary: false)
+                    as? SessionListGroupHeaderView,
+                   cell.isHiddenToggleHit(at: cell.convert(point, from: self)) {
+                    onHiddenToggleClicked?(key)
+                } else if isItemExpanded(node) {
                     animator().collapseItem(node)
                 } else {
                     animator().expandItem(node)

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -2256,6 +2256,24 @@ final class SessionCellView: NSTableCellView {
     /// title truncates first (lower compression resistance), the price
     /// stays. Mirrors the turn outline's Cost column tinting via CostColor.
     private let costLabel = NSTextField(labelWithString: "")
+    /// The cost label's non-selected color (from `CostColor`). Stored so the
+    /// selection handler can restore it after the row deselects.
+    private var costBaseColor: NSColor = .labelColor
+
+    /// NSTableCellView repaints system-colored labels (title, branch, meta)
+    /// white when the row is selected, but the cost label uses a custom
+    /// accent the automatic path leaves untouched — which read as a bug on
+    /// the highlight. Mirror the title: a selected row shows the cost in the
+    /// selection text color so the two match; otherwise the accent/dim color.
+    override var backgroundStyle: NSView.BackgroundStyle {
+        didSet { applyCostLabelColor() }
+    }
+
+    private func applyCostLabelColor() {
+        costLabel.textColor = backgroundStyle == .emphasized
+            ? .alternateSelectedControlTextColor
+            : costBaseColor
+    }
     private let activeDot = NSView()
     /// `person.2.fill` glyph + small count rendered as a paired view in the
     /// trailing edge of the meta row when the session has spawned at least
@@ -2530,9 +2548,12 @@ final class SessionCellView: NSTableCellView {
         }
 
         // Dedicated cost label on the title row.
-        let costDisplay = CostColor.display(cost: totalCost, confidence: costConfidence)
+        let costDisplay = CostColor.display(
+            cost: totalCost, confidence: costConfidence, accentColor: CostColor.accent
+        )
         costLabel.stringValue = costDisplay.text
-        costLabel.textColor = costDisplay.color
+        costBaseColor = costDisplay.color
+        applyCostLabelColor()
         // Codex 신뢰도 설명 툴팁은 비용 라벨로 이동(이전엔 metaLabel에 붙였음).
         costLabel.toolTip = Self.costTooltip(provider: provider, confidence: costConfidence)
 
@@ -2641,7 +2662,9 @@ final class SessionCellView: NSTableCellView {
     // MARK: - Test seams
 
     func costDisplayForTesting(totalCost: Double, confidence: CostConfidence) -> (text: String, color: NSColor) {
-        let d = CostColor.display(cost: totalCost, confidence: confidence)
+        let d = CostColor.display(
+            cost: totalCost, confidence: confidence, accentColor: CostColor.accent
+        )
         return (d.text, d.color)
     }
     var costLabelCompressionResistanceForTesting: Float {

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -1679,9 +1679,12 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// to call it per-session on every reload; the heavy lifting is in
     /// the pure helper so the priority order is unit-tested.
     private func sessionTitleResolved(for session: Session) -> SessionTitleResolver.Resolved {
-        // SQLite-first shells carry the live first-prompt derivation in
-        // `cachedTitle` (importer-updated); the legacy in-memory Turn
-        // preview died with the graphs (5.3).
+        // The legacy in-memory Turn preview died with the graphs (5.3), so
+        // `firstTurnPreview` stays nil here. The first-prompt fallback now
+        // rides on the session shell (`session.firstPrompt`, from
+        // `sessions.first_prompt`) and is applied inside the resolver's
+        // ladder, below `slug` — so Codex sessions with no thread-name
+        // index entry show their first prompt instead of the id prefix.
         SessionTitleResolver.resolve(session: session, firstTurnPreview: nil)
     }
 

--- a/Lupen/UI/Dashboard/SessionTitleResolver.swift
+++ b/Lupen/UI/Dashboard/SessionTitleResolver.swift
@@ -16,7 +16,14 @@ import Foundation
 ///      parse, so cache-hit cold launches render without flashing the
 ///      slug while the parse runs.
 ///   4. `session.slug` — Claude Code's human-readable slug.
-///   5. Session id prefix — last-resort stub so the row is never empty.
+///   5. `session.firstPrompt` — the cleaned first user prompt
+///      (importer-derived, `sessions.first_prompt`). Codex sessions have
+///      no `slug` and may lack a `cachedTitle` when `session_index.jsonl`
+///      carries no thread name; this is what keeps them from falling all
+///      the way to the id prefix. Deliberately placed *below* `slug` so
+///      Claude sessions keep their existing slug label — only sessions
+///      with neither a cached title nor a slug reach it.
+///   6. Session id prefix — last-resort stub so the row is never empty.
 ///
 /// Kept pure (no `store` / no UI framework) so regressions in the
 /// priority order surface as unit test failures rather than manual
@@ -37,6 +44,7 @@ enum SessionTitleResolver {
         case firstTurn    // live `firstTurnPreview`
         case cached       // `session.cachedTitle`
         case slug         // `session.slug`
+        case firstPrompt  // `session.firstPrompt` — importer-derived
         case idPrefix     // fallback
     }
 
@@ -50,7 +58,8 @@ enum SessionTitleResolver {
     /// already trims leading/trailing whitespace before storing, so
     /// `session.customTitle` with only outer whitespace cannot reach here;
     /// but internal spacing ("plan  7") is preserved exactly as typed by
-    /// the user. Same for `firstTurnPreview` / `cachedTitle`.
+    /// the user. Same for `firstTurnPreview` / `cachedTitle` /
+    /// `firstPrompt`.
     static func resolve(
         session: Session,
         firstTurnPreview: String?
@@ -68,6 +77,10 @@ enum SessionTitleResolver {
         }
         if let slug = session.slug, !slug.isEmpty {
             return Resolved(text: slug, origin: .slug)
+        }
+        if let firstPrompt = session.firstPrompt,
+           !firstPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return Resolved(text: firstPrompt, origin: .firstPrompt)
         }
         return Resolved(text: String(session.rawSessionId.prefix(8)), origin: .idPrefix)
     }

--- a/Lupen/UI/Dashboard/SessionTitleResolver.swift
+++ b/Lupen/UI/Dashboard/SessionTitleResolver.swift
@@ -58,8 +58,9 @@ enum SessionTitleResolver {
     /// already trims leading/trailing whitespace before storing, so
     /// `session.customTitle` with only outer whitespace cannot reach here;
     /// but internal spacing ("plan  7") is preserved exactly as typed by
-    /// the user. Same for `firstTurnPreview` / `cachedTitle` /
-    /// `firstPrompt`.
+    /// the user. Same for `firstTurnPreview` / `cachedTitle`. `firstPrompt`
+    /// is the exception: it is importer-extracted (not user-authored), so its
+    /// outer whitespace is trimmed before display (inner spacing preserved).
     static func resolve(
         session: Session,
         firstTurnPreview: String?
@@ -78,9 +79,15 @@ enum SessionTitleResolver {
         if let slug = session.slug, !slug.isEmpty {
             return Resolved(text: slug, origin: .slug)
         }
-        if let firstPrompt = session.firstPrompt,
-           !firstPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return Resolved(text: firstPrompt, origin: .firstPrompt)
+        if let firstPrompt = session.firstPrompt {
+            // Unlike customTitle / firstTurnPreview (user-authored, kept
+            // verbatim), firstPrompt is importer-extracted message text — trim
+            // outer whitespace so a prompt that starts with blank lines or
+            // pasted indentation doesn't render as an empty/indented row.
+            let trimmed = firstPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return Resolved(text: trimmed, origin: .firstPrompt)
+            }
         }
         return Resolved(text: String(session.rawSessionId.prefix(8)), origin: .idPrefix)
     }

--- a/Lupen/UI/Support/CostColor.swift
+++ b/Lupen/UI/Support/CostColor.swift
@@ -13,17 +13,27 @@ struct CostDisplay {
 /// exactly — extracted here so the sidebar can reuse them without
 /// duplicating the ladder. Pure function; no AppKit state beyond `NSColor`.
 enum CostColor {
-    /// Accent for "real" amounts (>= $1): a warm gold that reads a touch
-    /// apart from the title's `labelColor` without clashing, so the title /
-    /// cost boundary stays legible even when they nearly touch. Dynamic per
-    /// appearance — soft gold on dark, deep amber on light (the light dollar
-    /// has to darken since yellow washes out on a white row). Amounts under
-    /// $1 stay dim (`tertiaryLabelColor`); N/A and warnings keep their orange.
+    /// Accent for "real" amounts (>= $1) on the sidebar. Light mode uses the
+    /// systemOrange value (clear on white). Dark mode uses a softer tan that
+    /// sits closer to the title's near-white label color, so on a dark row the
+    /// cost reads as a gentle highlight rather than a hot orange. Same warm
+    /// family as the partial/warning orange; N/A is the slate `unavailable`.
     nonisolated(unsafe) static let accent = NSColor(name: "CostAccent") { appearance in
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         return isDark
-            ? NSColor(srgbRed: 230.0 / 255, green: 206.0 / 255, blue: 130.0 / 255, alpha: 1)
-            : NSColor(srgbRed: 176.0 / 255, green: 122.0 / 255, blue: 10.0 / 255, alpha: 1)
+            ? NSColor(srgbRed: 232.0 / 255, green: 185.0 / 255, blue: 126.0 / 255, alpha: 1)
+            : NSColor(srgbRed: 255.0 / 255, green: 149.0 / 255, blue: 0.0, alpha: 1)
+    }
+
+    /// Unavailable cost (N/A): a calm slate that reads as "not measured"
+    /// rather than competing with the orange cost figures, and distinct from
+    /// the plain dim gray used for sub-$1 amounts. Dynamic per appearance —
+    /// lighter slate on dark, deeper slate on light.
+    nonisolated(unsafe) static let unavailable = NSColor(name: "CostUnavailable") { appearance in
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        return isDark
+            ? NSColor(srgbRed: 144.0 / 255, green: 160.0 / 255, blue: 180.0 / 255, alpha: 1)
+            : NSColor(srgbRed: 94.0 / 255, green: 110.0 / 255, blue: 130.0 / 255, alpha: 1)
     }
 
     static func display(
@@ -35,7 +45,7 @@ enum CostColor {
         accentColor: NSColor? = nil
     ) -> CostDisplay {
         if confidence == .unavailable {
-            return CostDisplay(text: "\(prefix)N/A", color: .systemOrange)
+            return CostDisplay(text: "\(prefix)N/A", color: unavailable)
         }
         guard cost > 0 else {
             return CostDisplay(text: "\(prefix)\(CostFormatter.emDash)", color: .quaternaryLabelColor)

--- a/Lupen/UI/Support/CostColor.swift
+++ b/Lupen/UI/Support/CostColor.swift
@@ -13,12 +13,26 @@ struct CostDisplay {
 /// exactly — extracted here so the sidebar can reuse them without
 /// duplicating the ladder. Pure function; no AppKit state beyond `NSColor`.
 enum CostColor {
+    /// Accent for "real" amounts (>= $1): a warm gold that reads a touch
+    /// apart from the title's `labelColor` without clashing, so the title /
+    /// cost boundary stays legible even when they nearly touch. Dynamic per
+    /// appearance — soft gold on dark, deep amber on light (the light dollar
+    /// has to darken since yellow washes out on a white row). Amounts under
+    /// $1 stay dim (`tertiaryLabelColor`); N/A and warnings keep their orange.
+    nonisolated(unsafe) static let accent = NSColor(name: "CostAccent") { appearance in
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        return isDark
+            ? NSColor(srgbRed: 230.0 / 255, green: 206.0 / 255, blue: 130.0 / 255, alpha: 1)
+            : NSColor(srgbRed: 176.0 / 255, green: 122.0 / 255, blue: 10.0 / 255, alpha: 1)
+    }
+
     static func display(
         cost: Double,
         confidence: CostConfidence,
         prefix: String = "",
         exactColor: NSColor? = nil,
-        warningThreshold: Double = .infinity
+        warningThreshold: Double = .infinity,
+        accentColor: NSColor? = nil
     ) -> CostDisplay {
         if confidence == .unavailable {
             return CostDisplay(text: "\(prefix)N/A", color: .systemOrange)
@@ -33,6 +47,15 @@ enum CostColor {
             return CostDisplay(text: "\(prefix)\(amount)", color: .systemOrange)
         } else if let exactColor {
             return CostDisplay(text: "\(prefix)\(amount)", color: exactColor)
+        } else if let accentColor {
+            // Opt-in (sidebar): >= $1 gets the warm accent so the cost reads a
+            // touch apart from the title; below $1 stays dim. Callers that
+            // don't pass `accentColor` (e.g. the turn outline) keep the legacy
+            // dim-below-0.1 / label-color ladder unchanged.
+            return CostDisplay(
+                text: "\(prefix)\(amount)",
+                color: cost >= 1 ? accentColor : .tertiaryLabelColor
+            )
         } else if cost <= 0.1 {
             return CostDisplay(text: "\(prefix)\(amount)", color: .tertiaryLabelColor)
         } else {

--- a/LupenTests/Domain/SessionListHiddenPartitionTests.swift
+++ b/LupenTests/Domain/SessionListHiddenPartitionTests.swift
@@ -98,4 +98,36 @@ struct SessionListHiddenPartitionTests {
         #expect(r.shown.isEmpty)
         #expect(r.hidden.isEmpty)
     }
+
+    // MARK: - isLowSignal predicate (cost present & <= 0, AND idle)
+
+    @Test("isLowSignal: zero cost + idle is a hide candidate")
+    func lowSignalZeroIdle() {
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: 0, isActive: false) == true)
+    }
+
+    @Test("isLowSignal: negative cost + idle is a hide candidate")
+    func lowSignalNegativeIdle() {
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: -0.01, isActive: false) == true)
+    }
+
+    @Test("isLowSignal: an active session is never hidden, even at zero cost")
+    func lowSignalActiveNeverHidden() {
+        // The regression this fixes: a just-started (active, green-dot)
+        // session has cost 0 but must stay visible.
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: 0, isActive: true) == false)
+    }
+
+    @Test("isLowSignal: positive cost is not hidden")
+    func lowSignalPositiveCost() {
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: 5.0, isActive: false) == false)
+    }
+
+    @Test("isLowSignal: missing aggregate (nil cost) is never hidden")
+    func lowSignalMissingAggregate() {
+        // Cold load before costs import, or a session with no requests at all
+        // (empty /clear shell) — both have no aggregate and stay visible.
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: nil, isActive: false) == false)
+        #expect(SessionListHiddenPartition.isLowSignal(costUSD: nil, isActive: true) == false)
+    }
 }

--- a/LupenTests/Domain/SessionListHiddenPartitionTests.swift
+++ b/LupenTests/Domain/SessionListHiddenPartitionTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+/// Pins the sidebar's zero-cost hiding split. The cost lookup is injected as
+/// `isLowSignal`, so these tests drive the partition rules directly without a
+/// store or view controller (same philosophy as `SessionPaginationTests`).
+@Suite("SessionListHiddenPartition — sidebar zero-cost hiding")
+struct SessionListHiddenPartitionTests {
+
+    private func session(_ id: String) -> Session {
+        Session(id: id, requests: [], projectPath: nil)
+    }
+
+    /// Convenience: low-signal iff the id is in `low`.
+    private func run(
+        _ ids: [String],
+        hidingEnabled: Bool = true,
+        keepShown: Set<String> = [],
+        low: Set<String>
+    ) -> SessionListHiddenPartition.Result {
+        SessionListHiddenPartition.partition(
+            sessions: ids.map(session),
+            hidingEnabled: hidingEnabled,
+            keepShown: keepShown,
+            isLowSignal: { low.contains($0.id) }
+        )
+    }
+
+    // MARK: - Core split
+
+    @Test("non-low-signal sessions stay shown")
+    func nonLowShown() {
+        let r = run(["a", "b"], low: [])
+        #expect(r.shown.map(\.id) == ["a", "b"])
+        #expect(r.hidden.isEmpty)
+    }
+
+    @Test("low-signal sessions move to hidden")
+    func lowHidden() {
+        let r = run(["a", "b"], low: ["a", "b"])
+        #expect(r.shown.isEmpty)
+        #expect(r.hidden.map(\.id) == ["a", "b"])
+    }
+
+    @Test("mixed group splits correctly and preserves input order in each bucket")
+    func mixedPreservesOrder() {
+        // input order: x(low) a y(low) b
+        let r = run(["x", "a", "y", "b"], low: ["x", "y"])
+        #expect(r.shown.map(\.id) == ["a", "b"])
+        #expect(r.hidden.map(\.id) == ["x", "y"])
+    }
+
+    // MARK: - keepShown (selection never hidden)
+
+    @Test("keepShown forces a low-signal session to stay shown")
+    func keepShownOverridesLow() {
+        let r = run(["sel", "x"], keepShown: ["sel"], low: ["sel", "x"])
+        #expect(r.shown.map(\.id) == ["sel"])
+        #expect(r.hidden.map(\.id) == ["x"])
+    }
+
+    @Test("keepShown of a non-low session is a no-op")
+    func keepShownNonLow() {
+        let r = run(["a", "x"], keepShown: ["a"], low: ["x"])
+        #expect(r.shown.map(\.id) == ["a"])
+        #expect(r.hidden.map(\.id) == ["x"])
+    }
+
+    // MARK: - hiding disabled (active search/filter)
+
+    @Test("hidingEnabled=false keeps everything shown, ignoring low/keepShown")
+    func hidingDisabledShowsAll() {
+        let r = run(["a", "b", "c"], hidingEnabled: false, low: ["a", "b", "c"])
+        #expect(r.shown.map(\.id) == ["a", "b", "c"])
+        #expect(r.hidden.isEmpty)
+    }
+
+    // MARK: - Boundaries
+
+    @Test("all low-signal -> everything hidden")
+    func allHidden() {
+        let r = run(["a", "b", "c"], low: ["a", "b", "c"])
+        #expect(r.shown.isEmpty)
+        #expect(r.hidden.map(\.id) == ["a", "b", "c"])
+    }
+
+    @Test("none low-signal -> no hidden bucket (no toggle row)")
+    func allShown() {
+        let r = run(["a", "b"], low: [])
+        #expect(r.hidden.isEmpty)
+        #expect(r.shown.count == 2)
+    }
+
+    @Test("empty input -> empty result")
+    func empty() {
+        let r = run([], low: [])
+        #expect(r.shown.isEmpty)
+        #expect(r.hidden.isEmpty)
+    }
+}

--- a/LupenTests/UI/Dashboard/SessionTitleResolverTests.swift
+++ b/LupenTests/UI/Dashboard/SessionTitleResolverTests.swift
@@ -181,13 +181,23 @@ struct SessionTitleResolverTests {
         #expect(out.origin == .firstPrompt)
     }
 
-    @Test("firstPrompt internal spacing preserved verbatim")
-    func firstPromptInternalSpacingPreserved() {
-        // Outer whitespace pins "trimmed for the emptiness check, returned
-        // raw" — matches the customTitle / firstTurn policy.
+    @Test("firstPrompt outer whitespace trimmed, inner spacing preserved")
+    func firstPromptOuterWhitespaceTrimmed() {
+        // firstPrompt is importer-extracted (not user-authored), so outer
+        // whitespace is trimmed before display while inner spacing stays.
         let s = makeSession(firstPrompt: "  plan  7  ")
         let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
-        #expect(out.text == "  plan  7  ")
+        #expect(out.text == "plan  7")
+        #expect(out.origin == .firstPrompt)
+    }
+
+    @Test("firstPrompt starting with blank lines renders trimmed, not blank")
+    func firstPromptLeadingNewlinesTrimmed() {
+        // Regression pin: a pasted prompt beginning with blank lines must not
+        // produce an empty/indented sidebar row.
+        let s = makeSession(firstPrompt: "\n\n실행해줘")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "실행해줘")
         #expect(out.origin == .firstPrompt)
     }
 

--- a/LupenTests/UI/Dashboard/SessionTitleResolverTests.swift
+++ b/LupenTests/UI/Dashboard/SessionTitleResolverTests.swift
@@ -15,14 +15,21 @@ struct SessionTitleResolverTests {
     private func makeSession(
         id: String = "session-id-1234abcd",
         cachedTitle: String? = nil,
-        customTitle: String? = nil
+        customTitle: String? = nil,
+        shellSlug: String? = nil,
+        firstPrompt: String? = nil
     ) -> Session {
+        // `requests` is empty, so `slug` resolves to `shellSlug` and
+        // `firstPrompt` to `shellFirstPrompt` (the SQLite-first shell
+        // projection path the sidebar actually renders).
         Session(
             id: id,
             requests: [],
             projectPath: nil,
             cachedTitle: cachedTitle,
-            customTitle: customTitle
+            customTitle: customTitle,
+            shellSlug: shellSlug,
+            shellFirstPrompt: firstPrompt
         )
     }
 
@@ -82,6 +89,121 @@ struct SessionTitleResolverTests {
         let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
         #expect(out.text == "abcdefgh")
         #expect(out.origin == .idPrefix)
+    }
+
+    // MARK: - firstPrompt fallback (Codex index-less sessions)
+
+    @Test("firstPrompt used when cached + slug are nil — origin .firstPrompt")
+    func firstPromptFallbackForCodex() {
+        // The exact regression: a Codex session with no `session_index.jsonl`
+        // thread name (cachedTitle nil) and no slug (Codex has none). The
+        // sidebar must show the first prompt, not the raw id prefix.
+        let s = makeSession(
+            id: "019ee44b-9778-7673-82b6-f8b2b39dfb2d",
+            cachedTitle: nil,
+            customTitle: nil,
+            shellSlug: nil,
+            firstPrompt: "멈추지말고 완성단계까지 진행."
+        )
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "멈추지말고 완성단계까지 진행.")
+        #expect(out.origin == .firstPrompt)
+    }
+
+    @Test("slug wins over firstPrompt — Claude sessions keep their slug label")
+    func slugWinsOverFirstPrompt() {
+        // Regression guard for Claude: slug sits ABOVE firstPrompt, so
+        // adding the firstPrompt step must not change a Claude session's
+        // existing sidebar label.
+        let s = makeSession(
+            cachedTitle: nil,
+            customTitle: nil,
+            shellSlug: "harmonic-nibbling-meerkat",
+            firstPrompt: "first user prompt text"
+        )
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "harmonic-nibbling-meerkat")
+        #expect(out.origin == .slug)
+    }
+
+    @Test("cachedTitle wins over firstPrompt")
+    func cachedTitleWinsOverFirstPrompt() {
+        let s = makeSession(
+            cachedTitle: "thread name from index",
+            firstPrompt: "first user prompt text"
+        )
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "thread name from index")
+        #expect(out.origin == .cached)
+    }
+
+    @Test("customTitle wins over firstPrompt")
+    func customTitleWinsOverFirstPrompt() {
+        let s = makeSession(customTitle: "renamed", firstPrompt: "first prompt")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "renamed")
+        #expect(out.origin == .custom)
+    }
+
+    @Test("live firstTurn preview wins over firstPrompt")
+    func firstTurnWinsOverFirstPrompt() {
+        // The live preview is fresher than the importer-derived
+        // first_prompt, so it must stay above firstPrompt in the ladder.
+        let s = makeSession(firstPrompt: "stored first prompt")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: "live preview")
+        #expect(out.text == "live preview")
+        #expect(out.origin == .firstTurn)
+    }
+
+    @Test("empty firstPrompt falls through to id prefix")
+    func emptyFirstPromptFallsThrough() {
+        let s = makeSession(id: "abcdefgh-0000-0000-0000-000000000000", firstPrompt: "")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "abcdefgh")
+        #expect(out.origin == .idPrefix)
+    }
+
+    @Test("whitespace-only firstPrompt falls through to id prefix")
+    func whitespaceFirstPromptFallsThrough() {
+        let s = makeSession(id: "abcdefgh-0000-0000-0000-000000000000", firstPrompt: "   \t\n")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "abcdefgh")
+        #expect(out.origin == .idPrefix)
+    }
+
+    @Test("empty slug is treated as absent — firstPrompt takes over")
+    func emptySlugFallsToFirstPrompt() {
+        // `!slug.isEmpty` means an empty shellSlug must not block the
+        // firstPrompt fallback.
+        let s = makeSession(shellSlug: "", firstPrompt: "first prompt text")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "first prompt text")
+        #expect(out.origin == .firstPrompt)
+    }
+
+    @Test("firstPrompt internal spacing preserved verbatim")
+    func firstPromptInternalSpacingPreserved() {
+        // Outer whitespace pins "trimmed for the emptiness check, returned
+        // raw" — matches the customTitle / firstTurn policy.
+        let s = makeSession(firstPrompt: "  plan  7  ")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "  plan  7  ")
+        #expect(out.origin == .firstPrompt)
+    }
+
+    @Test("Korean / Unicode firstPrompt passes through verbatim")
+    func unicodeFirstPrompt() {
+        let s = makeSession(firstPrompt: "리뷰 — 메모리 reclaim B안")
+        let out = SessionTitleResolver.resolve(session: s, firstTurnPreview: nil)
+        #expect(out.text == "리뷰 — 메모리 reclaim B안")
+        #expect(out.origin == .firstPrompt)
+    }
+
+    @Test("resolveText returns firstPrompt text via the convenience shim")
+    func resolveTextWithFirstPrompt() {
+        let s = makeSession(firstPrompt: "first prompt only")
+        let text = SessionTitleResolver.resolveText(session: s, firstTurnPreview: nil)
+        #expect(text == "first prompt only")
     }
 
     // MARK: - Verbatim text preservation

--- a/LupenTests/UI/Dashboard/TurnOutlineCostColorTests.swift
+++ b/LupenTests/UI/Dashboard/TurnOutlineCostColorTests.swift
@@ -77,8 +77,8 @@ struct TurnOutlineCostColorTests {
         )
     }
 
-    @Test("partial and unavailable costs remain orange")
-    func nonExactCostsRemainOrange() {
+    @Test("partial stays orange; unavailable now reads as the calm slate")
+    func nonExactCostColors() {
         #expect(
             TurnOutlineViewController.costColorForTesting(
                 cost: 0.5,
@@ -89,7 +89,7 @@ struct TurnOutlineCostColorTests {
             TurnOutlineViewController.costColorForTesting(
                 cost: 0.5,
                 confidence: .unavailable
-            )?.isEqual(NSColor.systemOrange) == true
+            )?.isEqual(CostColor.unavailable) == true
         )
     }
 }

--- a/LupenTests/UI/Support/CostColorTests.swift
+++ b/LupenTests/UI/Support/CostColorTests.swift
@@ -3,10 +3,11 @@ import AppKit
 @testable import Lupen
 
 final class CostColorTests: XCTestCase {
-    func testUnavailableIsOrangeNA() {
+    func testUnavailableUsesSlate() {
+        // N/A moved off orange (now the cost accent) onto the calm slate.
         let d = CostColor.display(cost: 5.0, confidence: .unavailable)
         XCTAssertEqual(d.text, "N/A")
-        XCTAssertEqual(d.color, .systemOrange)
+        XCTAssertEqual(d.color, CostColor.unavailable)
     }
 
     func testZeroIsEmDashQuaternary() {

--- a/LupenTests/UI/Support/CostColorTests.swift
+++ b/LupenTests/UI/Support/CostColorTests.swift
@@ -48,4 +48,23 @@ final class CostColorTests: XCTestCase {
         let d = CostColor.display(cost: 5.0, confidence: .exact, exactColor: .systemBlue)
         XCTAssertEqual(d.color, .systemBlue)
     }
+
+    // MARK: - Sidebar accent opt-in (>= $1)
+
+    func testAccentAppliesAtOrAboveDollar() {
+        let d = CostColor.display(cost: 10.02, confidence: .exact, accentColor: CostColor.accent)
+        XCTAssertEqual(d.text, "$10.02")
+        XCTAssertEqual(d.color, CostColor.accent)
+    }
+
+    func testAccentBoundaryAtExactlyOneDollar() {
+        let d = CostColor.display(cost: 1.0, confidence: .exact, accentColor: CostColor.accent)
+        XCTAssertEqual(d.color, CostColor.accent)
+    }
+
+    func testBelowDollarWithAccentIsDim() {
+        // Opted into accent, but under $1 → dim, not accent.
+        let d = CostColor.display(cost: 0.45, confidence: .exact, accentColor: CostColor.accent)
+        XCTAssertEqual(d.color, .tertiaryLabelColor)
+    }
 }


### PR DESCRIPTION
## Summary

Sidebar improvements, mostly for the Codex provider:

- **First-prompt title fallback** — Codex sessions missing a `session_index.jsonl` thread name now show their first user prompt instead of the raw id prefix (e.g. `019ee44b…`).
- **Zero-cost session hiding** — low-signal sessions (Codex auto-review/guardian threads, idle $0 sessions) collapse behind a small `(N)` toggle in each project group's header; clicking mixes them back in by time. Active sessions, the current selection, and sessions with no cost aggregate always stay visible.
- **Cost / N-A recoloring** — cost ≥ \$1 reads orange (a softer tan on dark so it doesn't read hot), N/A reads a calm slate, sub-\$1 stays dim. The provider-mode Claude Code accent is deepened on light mode for legibility. All colors are per-appearance (light/dark) and the selection highlight repaints them white.
- Translated the two non-functional Korean cost-label comments to English (the Korean short-acknowledgment whitelist is intentionally kept — it detects "진행/네/확인" confirmations).

## Tests

New/updated unit tests: `SessionListHiddenPartition` (incl. the `isLowSignal` active/idle/nil gate), `SessionTitleResolver` (firstPrompt ladder + trim), `CostColor` (accent/slate), `TurnOutlineCostColor`. Build and tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)