### PR TITLE
feat: add Manage Sessions & Storage window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ test-artifacts/
 /plan.md
 /plan-*.md
 /research-*.md
+/research-*.html
 
 # Internal research docs — not for the public repo
 docs/Research/

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -188,7 +188,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var verifyCostsWindowController: VerifyCostsWindowController?
     private var preferencesWindowController: PreferencesWindowController?
     private var manageSessionsWindowController: ManageSessionsWindowController?
-    /// 관리 창이 비활성 provider의 인덱스를 읽을 때 쓰는 store 캐시.
+    /// Store cache the manage window uses to read an inactive provider's index.
     private var managedReadStores: [ProviderKind: ProviderStore] = [:]
     private var verifyUsageMenuItem: NSMenuItem?
     private lazy var logWindowController = LogWindowController(logger: LoggerService.shared)
@@ -1027,13 +1027,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         manageSessionsWindowController?.show()
     }
 
-    /// 활성 provider면 인덱싱 store를, 비활성이면 그 provider의 인덱스 DB를
-    /// 직접 열어(읽기/삭제 정합용) 제공한다. codex로 시작해도 관리 창에서
-    /// Claude Code 탭의 세션을 볼 수 있게 한다.
+    /// Provides the indexing store for the active provider, or opens that
+    /// provider's index DB directly (for read/delete consistency) when
+    /// inactive. Lets the manage window show Claude Code tab sessions even
+    /// when started on codex.
     private func manageProviderStore(for provider: ProviderKind) -> ProviderStore? {
         if let startup = sqliteFirstStartups[provider] {
-            // 활성 store를 우선 사용하고, 비활성 시절 열어 둔 읽기전용 풀이 있으면
-            // 해제한다(파일핸들/WAL 누수 방지 — GRDB 풀은 ref 해제 시 닫힘).
+            // Prefer the active store, and release any read-only pool opened
+            // while inactive (avoids file-handle/WAL leaks — a GRDB pool closes
+            // when its ref is released).
             managedReadStores[provider] = nil
             return startup.coordinator.store
         }

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -1032,6 +1032,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Claude Code 탭의 세션을 볼 수 있게 한다.
     private func manageProviderStore(for provider: ProviderKind) -> ProviderStore? {
         if let startup = sqliteFirstStartups[provider] {
+            // 활성 store를 우선 사용하고, 비활성 시절 열어 둔 읽기전용 풀이 있으면
+            // 해제한다(파일핸들/WAL 누수 방지 — GRDB 풀은 ref 해제 시 닫힘).
+            managedReadStores[provider] = nil
             return startup.coordinator.store
         }
         if let cached = managedReadStores[provider] {

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -187,6 +187,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var reportsWindowController: ReportsWindowController?
     private var verifyCostsWindowController: VerifyCostsWindowController?
     private var preferencesWindowController: PreferencesWindowController?
+    private var manageSessionsWindowController: ManageSessionsWindowController?
+    /// 관리 창이 비활성 provider의 인덱스를 읽을 때 쓰는 store 캐시.
+    private var managedReadStores: [ProviderKind: ProviderStore] = [:]
     private var verifyUsageMenuItem: NSMenuItem?
     private lazy var logWindowController = LogWindowController(logger: LoggerService.shared)
     private let smokeTest = LaunchSmokeTestConfig.current()
@@ -911,6 +914,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         verifyUsageMenuItem = verifyItem
         windowMenu.addItem(verifyItem)
 
+        let manageItem = NSMenuItem(
+            title: "Manage Sessions & Storage…",
+            action: #selector(openManageSessions(_:)),
+            keyEquivalent: "m"
+        )
+        manageItem.keyEquivalentModifierMask = [.command, .shift]
+        manageItem.target = self
+        windowMenu.addItem(manageItem)
+
         // The log window is a maintainer-only diagnostic; its entry points
         // (this menu item and the dashboard toolbar button) ship in DEBUG
         // builds only.
@@ -997,6 +1009,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             verifyCostsWindowController = VerifyCostsWindowController(store: store)
         }
         verifyCostsWindowController?.show()
+    }
+
+    // MARK: - Manage Sessions & Storage window
+
+    @objc func openManageSessions(_ sender: Any?) {
+        if manageSessionsWindowController == nil {
+            manageSessionsWindowController = ManageSessionsWindowController(
+                provider: settings.activeProvider,
+                isIndexingProvider: { [weak self] in self?.store.isIndexing ?? false },
+                storeProvider: { [weak self] provider in self?.manageProviderStore(for: provider) },
+                contextProvider: { [weak self] provider in self?.manageContext(for: provider) },
+                requestRescan: { [weak self] provider in self?.sqliteFirstStartups[provider]?.coordinator.requestRescan() },
+                rebuildIndex: { [weak self] provider in self?.sqliteFirstStartups[provider]?.rebuildIndex() }
+            )
+        }
+        manageSessionsWindowController?.show()
+    }
+
+    /// 활성 provider면 인덱싱 store를, 비활성이면 그 provider의 인덱스 DB를
+    /// 직접 열어(읽기/삭제 정합용) 제공한다. codex로 시작해도 관리 창에서
+    /// Claude Code 탭의 세션을 볼 수 있게 한다.
+    private func manageProviderStore(for provider: ProviderKind) -> ProviderStore? {
+        if let startup = sqliteFirstStartups[provider] {
+            return startup.coordinator.store
+        }
+        if let cached = managedReadStores[provider] {
+            return cached
+        }
+        let url = LupenPaths.indexDatabaseURL(for: provider)
+        guard FileManager.default.fileExists(atPath: url.path),
+              let database = try? ProviderDatabase.open(at: url) else { return nil }
+        let store = ProviderStore(database: database)
+        managedReadStores[provider] = store
+        return store
+    }
+
+    private func manageContext(for provider: ProviderKind) -> ManageProviderContext? {
+        switch provider {
+        case .claudeCode:
+            return .claude(projectsDirectory: FileDiscovery().projectsDirectory)
+        case .codex:
+            return .codex(codexHome: CodexSessionDiscovery(codexHome: codexHomeURLFromSettings()).codexHome)
+        }
     }
 
     // MARK: - Preferences window

--- a/Lupen/Domain/Manage/DiskSizer.swift
+++ b/Lupen/Domain/Manage/DiskSizer.swift
@@ -7,15 +7,17 @@
 
 import Foundation
 
-/// 디렉터리/파일의 디스크 점유 크기를 계산하는 순수 헬퍼.
+/// A pure helper that computes the disk allocated size of a directory/file.
 ///
-/// 무거운 재귀 스캔이므로 호출부(`ManageScanService`)가 백그라운드에서
-/// 돌리고, `isCancelled`로 중도 취소한다(plan §3.1 — 메인스레드 블로킹 0).
-/// 크기는 `totalFileAllocatedSize`(실제 점유) 우선, 없으면 논리 크기.
+/// Because this is a heavy recursive scan, the caller (`ManageScanService`)
+/// runs it in the background and cancels mid-way via `isCancelled`
+/// (plan §3.1 — zero main-thread blocking).
+/// Size prefers `totalFileAllocatedSize` (actual allocated size), falling back
+/// to logical size.
 enum DiskSizer {
 
-    /// `url` 아래 모든 정규 파일의 allocated size 합. 디렉터리면 재귀,
-    /// 파일이면 자신의 크기. 존재하지 않으면 0.
+    /// The sum of the allocated size of every regular file under `url`. Recurses
+    /// for a directory; for a file, its own size. 0 if it does not exist.
     static func totalAllocatedSize(at url: URL, isCancelled: () -> Bool = { false }) -> Int64 {
         let fm = FileManager.default
         var isDir: ObjCBool = false
@@ -28,7 +30,7 @@ enum DiskSizer {
             at: url,
             includingPropertiesForKeys: keys,
             options: [],
-            errorHandler: { _, _ in true }   // 읽기 실패한 항목은 건너뛰고 계속
+            errorHandler: { _, _ in true }   // Skip items that fail to read and continue
         ) else { return 0 }
 
         var total: Int64 = 0
@@ -39,7 +41,7 @@ enum DiskSizer {
         return total
     }
 
-    /// 정규 파일 한 개의 allocated size. 디렉터리/심볼릭 등은 0.
+    /// The allocated size of a single regular file. 0 for directories/symlinks/etc.
     static func fileAllocatedSize(_ url: URL) -> Int64 {
         guard let vals = try? url.resourceValues(
             forKeys: [.isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
@@ -49,8 +51,9 @@ enum DiskSizer {
         return 0
     }
 
-    /// 한 디렉터리의 1-depth 자식 항목(전체 디스크 탭용): 각 자식의
-    /// 이름·총 크기·디렉터리 여부. 큰 점유물부터 정렬은 호출부에서.
+    /// The 1-depth child items of a directory (for the All Disk tab): each child's
+    /// name, total size, and whether it is a directory. Sorting largest-allocated-first
+    /// is done by the caller.
     struct Entry: Sendable, Equatable {
         let url: URL
         let name: String
@@ -63,7 +66,7 @@ enum DiskSizer {
         guard let children = try? fm.contentsOfDirectory(
             at: url,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: []   // 숨김 포함 — 큰 dot 디렉터리도 보여줘야 정리에 의미
+            options: []   // Include hidden — large dot directories must show for cleanup to be meaningful
         ) else { return [] }
 
         var out: [Entry] = []

--- a/Lupen/Domain/Manage/DiskSizer.swift
+++ b/Lupen/Domain/Manage/DiskSizer.swift
@@ -1,0 +1,78 @@
+//
+//  DiskSizer.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 디렉터리/파일의 디스크 점유 크기를 계산하는 순수 헬퍼.
+///
+/// 무거운 재귀 스캔이므로 호출부(`ManageScanService`)가 백그라운드에서
+/// 돌리고, `isCancelled`로 중도 취소한다(plan §3.1 — 메인스레드 블로킹 0).
+/// 크기는 `totalFileAllocatedSize`(실제 점유) 우선, 없으면 논리 크기.
+enum DiskSizer {
+
+    /// `url` 아래 모든 정규 파일의 allocated size 합. 디렉터리면 재귀,
+    /// 파일이면 자신의 크기. 존재하지 않으면 0.
+    static func totalAllocatedSize(at url: URL, isCancelled: () -> Bool = { false }) -> Int64 {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { return 0 }
+        if !isDir.boolValue {
+            return fileAllocatedSize(url)
+        }
+        let keys: [URLResourceKey] = [.isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        guard let enumerator = fm.enumerator(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: [],
+            errorHandler: { _, _ in true }   // 읽기 실패한 항목은 건너뛰고 계속
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            if isCancelled() { break }
+            total += fileAllocatedSize(fileURL)
+        }
+        return total
+    }
+
+    /// 정규 파일 한 개의 allocated size. 디렉터리/심볼릭 등은 0.
+    static func fileAllocatedSize(_ url: URL) -> Int64 {
+        guard let vals = try? url.resourceValues(
+            forKeys: [.isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        ), vals.isRegularFile == true else { return 0 }
+        if let s = vals.totalFileAllocatedSize { return Int64(s) }
+        if let s = vals.fileAllocatedSize { return Int64(s) }
+        return 0
+    }
+
+    /// 한 디렉터리의 1-depth 자식 항목(전체 디스크 탭용): 각 자식의
+    /// 이름·총 크기·디렉터리 여부. 큰 점유물부터 정렬은 호출부에서.
+    struct Entry: Sendable, Equatable {
+        let url: URL
+        let name: String
+        let sizeBytes: Int64
+        let isDirectory: Bool
+    }
+
+    static func childEntries(of url: URL, isCancelled: () -> Bool = { false }) -> [Entry] {
+        let fm = FileManager.default
+        guard let children = try? fm.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []   // 숨김 포함 — 큰 dot 디렉터리도 보여줘야 정리에 의미
+        ) else { return [] }
+
+        var out: [Entry] = []
+        for child in children {
+            if isCancelled() { break }
+            let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            let size = totalAllocatedSize(at: child, isCancelled: isCancelled)
+            out.append(Entry(url: child, name: child.lastPathComponent, sizeBytes: size, isDirectory: isDir))
+        }
+        return out
+    }
+}

--- a/Lupen/Domain/Manage/ManageDeletionPlanner.swift
+++ b/Lupen/Domain/Manage/ManageDeletionPlanner.swift
@@ -1,0 +1,69 @@
+//
+//  ManageDeletionPlanner.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 삭제 확인 마찰 단계 (GitLab Pajamas 3단계, research §B-5).
+enum DeletionFriction: Sendable, Equatable {
+    case low     // 단건·가역·안전 → 모달 없이 휴지통 + Undo 스낵바
+    case medium  // 여러 개 또는 주의 → 확인 모달
+    case high    // 대량 또는 미추적 → 모달 + 타이핑 확인
+}
+
+/// 삭제 흐름의 순수 결정 로직(테스트 대상). 실제 휴지통/인덱스 조작은
+/// `ManageTrashService`/`ManageStore`가 담당.
+enum ManageDeletionPlanner {
+    static let bulkCountThreshold = 20
+    static let bulkByteThreshold: Int64 = 1_000_000_000   // 1 GB
+
+    /// 후보가 모두 휴지통 가능한가. blocked/locked가 하나라도 섞이면 false
+    /// (allowlist — 미분류·차단은 삭제 불가).
+    static func allDeletable(_ rows: [ManageRowModel]) -> Bool {
+        !rows.isEmpty && rows.allSatisfy { $0.protection == .deletable }
+    }
+
+    static func totalBytes(_ rows: [ManageRowModel]) -> Int64 {
+        rows.reduce(0) { $0 + $1.sizeBytes }
+    }
+
+    static func friction(rows: [ManageRowModel]) -> DeletionFriction {
+        let count = rows.count
+        let hasUntracked = rows.contains { !$0.isIndexed }
+        if hasUntracked || count >= bulkCountThreshold || totalBytes(rows) >= bulkByteThreshold {
+            return .high
+        }
+        if count > 1 || rows.contains(where: { $0.classification == .caution }) {
+            return .medium
+        }
+        return .low
+    }
+
+    struct ConfirmCopy: Equatable {
+        let title: String
+        let body: String
+        let confirmButton: String
+        let requiresTyping: Bool
+        let typingToken: String
+    }
+
+    static func confirmCopy(rows: [ManageRowModel]) -> ConfirmCopy {
+        let count = rows.count
+        let size = ByteCountFormatter.string(fromByteCount: totalBytes(rows), countStyle: .file)
+        let hasUntracked = rows.contains { !$0.isIndexed }
+        let noun = "\(count) \(hasUntracked ? "item" : "session")\(count == 1 ? "" : "s")"
+        let lead = hasUntracked
+            ? "These files are not tracked by Lupen."
+            : "Conversation history and attached logs will be removed."
+        return ConfirmCopy(
+            title: "Move \(noun) to Trash?",
+            body: "\(lead) Reclaims \(size).\nYou can restore from Trash for 30 days.",
+            confirmButton: "Delete \(noun)",
+            requiresTyping: friction(rows: rows) == .high,
+            typingToken: "DELETE"
+        )
+    }
+}

--- a/Lupen/Domain/Manage/ManageDeletionPlanner.swift
+++ b/Lupen/Domain/Manage/ManageDeletionPlanner.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-/// 삭제 확인 마찰 단계 (GitLab Pajamas 3단계, research §B-5).
+/// Deletion-confirmation friction tiers (GitLab Pajamas 3-tier, research §B-5).
 enum DeletionFriction: Sendable, Equatable {
-    case low     // 단건·가역·안전 → 모달 없이 휴지통 + Undo 스낵바
-    case medium  // 여러 개 또는 주의 → 확인 모달
-    case high    // 대량 또는 미추적 → 모달 + 타이핑 확인
+    case low     // Single, reversible, safe → trash without a modal + Undo snackbar
+    case medium  // Several or caution → confirmation modal
+    case high    // Bulk or untracked → modal + typing confirmation
 }
 
-/// 삭제 흐름의 순수 결정 로직(테스트 대상). 실제 휴지통/인덱스 조작은
-/// `ManageTrashService`/`ManageStore`가 담당.
+/// Pure decision logic for the deletion flow (test target). The actual
+/// Trash/index manipulation is handled by `ManageTrashService`/`ManageStore`.
 enum ManageDeletionPlanner {
     static let bulkCountThreshold = 20
     static let bulkByteThreshold: Int64 = 1_000_000_000   // 1 GB
 
-    /// 후보가 모두 휴지통 가능한가. blocked/locked가 하나라도 섞이면 false
-    /// (allowlist — 미분류·차단은 삭제 불가).
+    /// Whether all candidates are deletable. false if even one blocked/locked is mixed in
+    /// (allowlist — unclassified/blocked are not deletable).
     static func allDeletable(_ rows: [ManageRowModel]) -> Bool {
         !rows.isEmpty && rows.allSatisfy { $0.protection == .deletable }
     }

--- a/Lupen/Domain/Manage/ManageModels.swift
+++ b/Lupen/Domain/Manage/ManageModels.swift
@@ -14,7 +14,6 @@ import Foundation
 /// (research-ccmgr.md §1.6 — 2단계 표시 결정).
 enum ManageScope: String, CaseIterable, Sendable, Identifiable {
     case sessions
-    case projects
     case cache
     case allDisk
 
@@ -23,7 +22,6 @@ enum ManageScope: String, CaseIterable, Sendable, Identifiable {
     var title: String {
         switch self {
         case .sessions: return "Sessions"
-        case .projects: return "Projects"
         case .cache:    return "Lupen Cache"
         case .allDisk:  return "All Disk"
         }
@@ -36,8 +34,6 @@ enum ManageItemKind: String, Sendable, Equatable {
     case session
     /// 세션영역 내부지만 인덱스가 모르는 `.jsonl` (미추적).
     case orphanFile
-    /// 프로젝트 디렉터리 단위 집계.
-    case project
     /// provider 홈 루트의 큰 점유물 (읽기전용 보조 뷰).
     case diskItem
     /// 인덱스에는 있으나 디스크에 원본 파일이 없는 잔재 (prune 대상).

--- a/Lupen/Domain/Manage/ManageModels.swift
+++ b/Lupen/Domain/Manage/ManageModels.swift
@@ -1,0 +1,176 @@
+//
+//  ManageModels.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// "Manage Sessions & Storage" 윈도우의 상단 탭(스코프).
+///
+/// `sessions`/`projects`/`cache`는 기본 뷰(세션영역 내부)로 정리(휴지통)가
+/// 가능하고, `allDisk`는 provider 홈 전체를 보는 읽기전용 보조 뷰다
+/// (research-ccmgr.md §1.6 — 2단계 표시 결정).
+enum ManageScope: String, CaseIterable, Sendable, Identifiable {
+    case sessions
+    case projects
+    case cache
+    case allDisk
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .sessions: return "Sessions"
+        case .projects: return "Projects"
+        case .cache:    return "Lupen Cache"
+        case .allDisk:  return "All Disk"
+        }
+    }
+}
+
+/// 한 행이 나타내는 항목의 종류.
+enum ManageItemKind: String, Sendable, Equatable {
+    /// 인덱스가 아는 세션 (추적).
+    case session
+    /// 세션영역 내부지만 인덱스가 모르는 `.jsonl` (미추적).
+    case orphanFile
+    /// 프로젝트 디렉터리 단위 집계.
+    case project
+    /// provider 홈 루트의 큰 점유물 (읽기전용 보조 뷰).
+    case diskItem
+    /// 인덱스에는 있으나 디스크에 원본 파일이 없는 잔재 (prune 대상).
+    case indexRemnant
+}
+
+/// 삭제 안전 분류 — 시각 언어(색·아이콘)로 사용자에게 신뢰감을 준다.
+/// (research §B-5: 색 단독 의존 금지, 배지/툴팁 텍스트와 병행)
+enum StorageClassification: String, Sendable, Equatable {
+    case safe          // 🟢 재생성 가능·완료 세션
+    case caution       // 🟡 최근/미추적/큰 파일
+    case danger        // 🔴 위험 (동작 가능 여부는 protection이 결정)
+    case unclassified  // ⚪ 분류 규칙 밖
+}
+
+/// 앱 안에서 허용되는 동작. allowlist 모델 — `deletable`만 휴지통 가능.
+enum StorageProtection: String, Sendable, Equatable {
+    /// 휴지통 이동 가능 (확인 마찰은 별도 calibration).
+    case deletable
+    /// 앱 내 삭제 차단 — Reveal in Finder만 (auth/config/앱상태 DB/세션영역 밖/인덱싱 중).
+    case blocked
+    /// 미분류 — 삭제 잠김 (미분류=삭제불가 원칙).
+    case locked
+
+    /// 휴지통 이동을 허용하는 유일한 상태.
+    var canTrash: Bool { self == .deletable }
+}
+
+/// 행 상태 — 이모지 컬럼으로 표시(사용자 요구). 분류(deletable 여부)와 별개로
+/// "왜 주의해야 하는지"를 한눈에 보여준다.
+enum ManageStatus: String, Sendable, Equatable {
+    case normal
+    case recentlyActive
+    case untracked
+    case indexing
+    case blocked
+    case error
+
+    var emoji: String {
+        switch self {
+        case .normal:         return ""
+        case .recentlyActive: return "🕐"
+        case .untracked:      return "❓"
+        case .indexing:       return "⏳"
+        case .blocked:        return "🔒"
+        case .error:          return "⚠️"
+        }
+    }
+    var label: String {
+        switch self {
+        case .normal:         return "Normal"
+        case .recentlyActive: return "Recently active"
+        case .untracked:      return "Untracked"
+        case .indexing:       return "Indexing"
+        case .blocked:        return "Blocked"
+        case .error:          return "Error"
+        }
+    }
+    /// 디테일 패널에 보여줄 상태 설명(정상이면 빈 문자열).
+    var detailDescription: String {
+        switch self {
+        case .normal:         return ""
+        case .recentlyActive: return "Active within the last ~10 minutes. It may be in use — confirm before deleting."
+        case .untracked:      return "Not tracked by the Lupen index. Only path and size are known; delete with extra care."
+        case .indexing:       return "Indexing is in progress. The status updates automatically when it finishes."
+        case .blocked:        return "auth/config, app-state DB, or outside the session area — can't be deleted in-app. Use Reveal in Finder."
+        case .error:          return "The original file is missing on disk (index remnant) or failed to parse."
+        }
+    }
+    /// 상태 컬럼 정렬 순서(우선순위가 높은 상태가 위로).
+    var sortOrder: Int {
+        switch self {
+        case .blocked:        return 0
+        case .error:          return 1
+        case .indexing:       return 2
+        case .untracked:      return 3
+        case .recentlyActive: return 4
+        case .normal:         return 5
+        }
+    }
+}
+
+/// 관리 리스트의 한 행. 인덱스(즉시) + FS 실측(보정)을 대조한 결과.
+/// 순수 값 타입 — UI/동시성 의존 없음(P1 토대, 테스트 대상).
+struct ManageRowModel: Sendable, Equatable, Identifiable {
+    /// provider-scoped 세션 id, 또는 미추적/디스크 항목의 대표 경로.
+    let id: String
+    let provider: ProviderKind
+    let kind: ManageItemKind
+
+    var displayTitle: String
+    /// 원본 세션 id(Resume용). orphan/디스크 항목은 nil.
+    var rawSessionId: String? = nil
+    /// 디코드된 실제 프로젝트 경로(표시·Reveal용).
+    var projectPath: String? = nil
+    /// `~/.claude/projects` 아래 인코딩된 디렉터리명(원본).
+    var encodedProject: String? = nil
+    var branch: String? = nil
+    var firstPrompt: String? = nil
+    /// 세션 시작(생성) 시각 — Created 컬럼.
+    var createdAt: Date? = nil
+    /// 마지막 활동(업데이트) 시각 — Updated 컬럼.
+    var lastActivity: Date? = nil
+
+    /// 디스크 점유 byte. 표시는 `ByteCountFormatter`, **정렬은 이 Int64**.
+    var sizeBytes: Int64 = 0
+    /// true면 인덱스 근사값(실측 전) — UI에서 옅은 색/`~`로 표시.
+    var isEstimatedSize: Bool = false
+    var fileCount: Int = 0
+
+    /// 삭제 대상 파일 경로들(세션의 모든 source 파일).
+    var filePaths: [String] = []
+    /// 세션 동반 디렉터리 `<sessionId>/`(있으면 함께 휴지통).
+    var companionDirectory: String? = nil
+
+    var parseState: StoreParseState? = nil
+    var status: ManageStatus = .normal
+    var classification: StorageClassification = .unclassified
+    var protection: StorageProtection = .locked
+    var isIndexed: Bool = false
+    var existsOnDisk: Bool = true
+
+    /// 컬럼 표시용 짧은 프로젝트명(경로의 마지막 컴포넌트).
+    var projectName: String {
+        guard let projectPath, !projectPath.isEmpty else { return "—" }
+        let name = (projectPath as NSString).lastPathComponent
+        return name.isEmpty ? projectPath : name
+    }
+
+    /// 휴지통 이동 시 실제로 옮길 경로(파일 + 동반 디렉터리).
+    var trashTargets: [String] {
+        var targets = filePaths
+        if let companionDirectory { targets.append(companionDirectory) }
+        return targets
+    }
+}

--- a/Lupen/Domain/Manage/ManageModels.swift
+++ b/Lupen/Domain/Manage/ManageModels.swift
@@ -7,11 +7,12 @@
 
 import Foundation
 
-/// "Manage Sessions & Storage" 윈도우의 상단 탭(스코프).
+/// Top-level tabs (scopes) of the "Manage Sessions & Storage" window.
 ///
-/// `sessions`/`projects`/`cache`는 기본 뷰(세션영역 내부)로 정리(휴지통)가
-/// 가능하고, `allDisk`는 provider 홈 전체를 보는 읽기전용 보조 뷰다
-/// (research-ccmgr.md §1.6 — 2단계 표시 결정).
+/// `sessions`/`projects`/`cache` are primary views (inside the session area)
+/// where cleanup (Trash) is allowed; `allDisk` is a read-only secondary view
+/// covering the whole provider home
+/// (research-ccmgr.md §1.6 — two-tier display decision).
 enum ManageScope: String, CaseIterable, Sendable, Identifiable {
     case sessions
     case cache
@@ -28,42 +29,44 @@ enum ManageScope: String, CaseIterable, Sendable, Identifiable {
     }
 }
 
-/// 한 행이 나타내는 항목의 종류.
+/// The kind of item a row represents.
 enum ManageItemKind: String, Sendable, Equatable {
-    /// 인덱스가 아는 세션 (추적).
+    /// A session known to the index (tracked).
     case session
-    /// 세션영역 내부지만 인덱스가 모르는 `.jsonl` (미추적).
+    /// A `.jsonl` inside the session area but unknown to the index (untracked).
     case orphanFile
-    /// provider 홈 루트의 큰 점유물 (읽기전용 보조 뷰).
+    /// A large allocated-size item at the provider home root (read-only secondary view).
     case diskItem
-    /// 인덱스에는 있으나 디스크에 원본 파일이 없는 잔재 (prune 대상).
+    /// An index remnant present in the index but whose original file is gone on disk (prune candidate).
     case indexRemnant
 }
 
-/// 삭제 안전 분류 — 시각 언어(색·아이콘)로 사용자에게 신뢰감을 준다.
-/// (research §B-5: 색 단독 의존 금지, 배지/툴팁 텍스트와 병행)
+/// Deletion-safety classification — a visual language (color/icon) that builds
+/// user trust.
+/// (research §B-5: never rely on color alone; pair with badge/tooltip text)
 enum StorageClassification: String, Sendable, Equatable {
-    case safe          // 🟢 재생성 가능·완료 세션
-    case caution       // 🟡 최근/미추적/큰 파일
-    case danger        // 🔴 위험 (동작 가능 여부는 protection이 결정)
-    case unclassified  // ⚪ 분류 규칙 밖
+    case safe          // 🟢 Regenerable / completed session
+    case caution       // 🟡 Recent / untracked / large file
+    case danger        // 🔴 Dangerous (whether the action is allowed is decided by protection)
+    case unclassified  // ⚪ Outside the classification rules
 }
 
-/// 앱 안에서 허용되는 동작. allowlist 모델 — `deletable`만 휴지통 가능.
+/// The actions allowed inside the app. An allowlist model — only `deletable`
+/// can be trashed.
 enum StorageProtection: String, Sendable, Equatable {
-    /// 휴지통 이동 가능 (확인 마찰은 별도 calibration).
+    /// Can be moved to Trash (confirmation friction is calibrated separately).
     case deletable
-    /// 앱 내 삭제 차단 — Reveal in Finder만 (auth/config/앱상태 DB/세션영역 밖/인덱싱 중).
+    /// In-app deletion blocked — Reveal in Finder only (auth/config, app-state DB, outside the session area, or indexing in progress).
     case blocked
-    /// 미분류 — 삭제 잠김 (미분류=삭제불가 원칙).
+    /// Unclassified — deletion locked (unclassified = not deletable principle).
     case locked
 
-    /// 휴지통 이동을 허용하는 유일한 상태.
+    /// The only state that allows a move to Trash.
     var canTrash: Bool { self == .deletable }
 }
 
-/// 행 상태 — 이모지 컬럼으로 표시(사용자 요구). 분류(deletable 여부)와 별개로
-/// "왜 주의해야 하는지"를 한눈에 보여준다.
+/// Row status — shown in an emoji column (per user request). Independent of
+/// classification (whether deletable), it shows "why you should be careful" at a glance.
 enum ManageStatus: String, Sendable, Equatable {
     case normal
     case recentlyActive
@@ -92,7 +95,7 @@ enum ManageStatus: String, Sendable, Equatable {
         case .error:          return "Error"
         }
     }
-    /// 디테일 패널에 보여줄 상태 설명(정상이면 빈 문자열).
+    /// Status description shown in the detail panel (empty string when normal).
     var detailDescription: String {
         switch self {
         case .normal:         return ""
@@ -103,7 +106,7 @@ enum ManageStatus: String, Sendable, Equatable {
         case .error:          return "The original file is missing on disk (index remnant) or failed to parse."
         }
     }
-    /// 상태 컬럼 정렬 순서(우선순위가 높은 상태가 위로).
+    /// Sort order for the status column (higher-priority statuses on top).
     var sortOrder: Int {
         switch self {
         case .blocked:        return 0
@@ -116,37 +119,38 @@ enum ManageStatus: String, Sendable, Equatable {
     }
 }
 
-/// 관리 리스트의 한 행. 인덱스(즉시) + FS 실측(보정)을 대조한 결과.
-/// 순수 값 타입 — UI/동시성 의존 없음(P1 토대, 테스트 대상).
+/// One row in the management list. The result of reconciling the index (instant)
+/// with the FS measurement (correction). A pure value type — no UI/concurrency
+/// dependencies (P1 foundation, test target).
 struct ManageRowModel: Sendable, Equatable, Identifiable {
-    /// provider-scoped 세션 id, 또는 미추적/디스크 항목의 대표 경로.
+    /// Provider-scoped session id, or the representative path of an untracked/disk item.
     let id: String
     let provider: ProviderKind
     let kind: ManageItemKind
 
     var displayTitle: String
-    /// 원본 세션 id(Resume용). orphan/디스크 항목은 nil.
+    /// Original session id (for Resume). nil for orphan/disk items.
     var rawSessionId: String? = nil
-    /// 디코드된 실제 프로젝트 경로(표시·Reveal용).
+    /// The decoded actual project path (for display/Reveal).
     var projectPath: String? = nil
-    /// `~/.claude/projects` 아래 인코딩된 디렉터리명(원본).
+    /// The encoded directory name under `~/.claude/projects` (original).
     var encodedProject: String? = nil
     var branch: String? = nil
     var firstPrompt: String? = nil
-    /// 세션 시작(생성) 시각 — Created 컬럼.
+    /// Session start (creation) time — the Created column.
     var createdAt: Date? = nil
-    /// 마지막 활동(업데이트) 시각 — Updated 컬럼.
+    /// Last activity (update) time — the Updated column.
     var lastActivity: Date? = nil
 
-    /// 디스크 점유 byte. 표시는 `ByteCountFormatter`, **정렬은 이 Int64**.
+    /// Allocated size in bytes. Displayed via `ByteCountFormatter`, **sorted on this Int64**.
     var sizeBytes: Int64 = 0
-    /// true면 인덱스 근사값(실측 전) — UI에서 옅은 색/`~`로 표시.
+    /// When true, an index approximation (before measurement) — shown dimmed / with `~` in the UI.
     var isEstimatedSize: Bool = false
     var fileCount: Int = 0
 
-    /// 삭제 대상 파일 경로들(세션의 모든 source 파일).
+    /// File paths targeted for deletion (all source files of the session).
     var filePaths: [String] = []
-    /// 세션 동반 디렉터리 `<sessionId>/`(있으면 함께 휴지통).
+    /// The session companion directory `<sessionId>/` (trashed alongside if present).
     var companionDirectory: String? = nil
 
     var parseState: StoreParseState? = nil
@@ -156,14 +160,14 @@ struct ManageRowModel: Sendable, Equatable, Identifiable {
     var isIndexed: Bool = false
     var existsOnDisk: Bool = true
 
-    /// 컬럼 표시용 짧은 프로젝트명(경로의 마지막 컴포넌트).
+    /// Short project name for column display (the last path component).
     var projectName: String {
         guard let projectPath, !projectPath.isEmpty else { return "—" }
         let name = (projectPath as NSString).lastPathComponent
         return name.isEmpty ? projectPath : name
     }
 
-    /// 휴지통 이동 시 실제로 옮길 경로(파일 + 동반 디렉터리).
+    /// The paths actually moved on a Trash operation (files + companion directory).
     var trashTargets: [String] {
         var targets = filePaths
         if let companionDirectory { targets.append(companionDirectory) }

--- a/Lupen/Domain/Manage/ManageProviderContext.swift
+++ b/Lupen/Domain/Manage/ManageProviderContext.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-/// 한 provider에 대한 관리 화면 컨텍스트 — 분류기 영역과 FS 스캔 루트.
-/// AppDelegate가 활성 provider의 소스 경로(Claude `projects/`, Codex 홈)로
-/// 구성해 `ManageStore`에 넘긴다.
+/// The management-screen context for a single provider — the classifier scope
+/// and FS scan roots. AppDelegate constructs it from the active provider's
+/// source paths (Claude `projects/`, Codex home) and passes it to `ManageStore`.
 struct ManageProviderContext: Sendable, Equatable {
     let provider: ProviderKind
-    /// provider 홈 (`~/.claude` 또는 `~/.codex`) — 전체 디스크 탭의 스캔 루트.
+    /// The provider home (`~/.claude` or `~/.codex`) — the scan root of the All Disk tab.
     let providerHome: URL
-    /// 정리 가능한 세션영역 루트 (`projects/` 또는 `sessions/`).
+    /// The cleanable session-area roots (`projects/` or `sessions/`).
     let sessionAreaRoots: [URL]
 
     var classifierScope: StorageClassifier.Scope {
         StorageClassifier.Scope(providerHome: providerHome, sessionAreaRoots: sessionAreaRoots)
     }
 
-    /// Claude: `~/.claude/projects`가 세션영역, 그 부모가 홈.
+    /// Claude: `~/.claude/projects` is the session area, its parent is the home.
     static func claude(projectsDirectory: URL) -> ManageProviderContext {
         ManageProviderContext(
             provider: .claudeCode,
@@ -30,7 +30,7 @@ struct ManageProviderContext: Sendable, Equatable {
         )
     }
 
-    /// Codex: `~/.codex`가 홈, `sessions/`가 세션영역.
+    /// Codex: `~/.codex` is the home, `sessions/` is the session area.
     static func codex(codexHome: URL) -> ManageProviderContext {
         ManageProviderContext(
             provider: .codex,

--- a/Lupen/Domain/Manage/ManageProviderContext.swift
+++ b/Lupen/Domain/Manage/ManageProviderContext.swift
@@ -1,0 +1,41 @@
+//
+//  ManageProviderContext.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 한 provider에 대한 관리 화면 컨텍스트 — 분류기 영역과 FS 스캔 루트.
+/// AppDelegate가 활성 provider의 소스 경로(Claude `projects/`, Codex 홈)로
+/// 구성해 `ManageStore`에 넘긴다.
+struct ManageProviderContext: Sendable, Equatable {
+    let provider: ProviderKind
+    /// provider 홈 (`~/.claude` 또는 `~/.codex`) — 전체 디스크 탭의 스캔 루트.
+    let providerHome: URL
+    /// 정리 가능한 세션영역 루트 (`projects/` 또는 `sessions/`).
+    let sessionAreaRoots: [URL]
+
+    var classifierScope: StorageClassifier.Scope {
+        StorageClassifier.Scope(providerHome: providerHome, sessionAreaRoots: sessionAreaRoots)
+    }
+
+    /// Claude: `~/.claude/projects`가 세션영역, 그 부모가 홈.
+    static func claude(projectsDirectory: URL) -> ManageProviderContext {
+        ManageProviderContext(
+            provider: .claudeCode,
+            providerHome: projectsDirectory.deletingLastPathComponent(),
+            sessionAreaRoots: [projectsDirectory]
+        )
+    }
+
+    /// Codex: `~/.codex`가 홈, `sessions/`가 세션영역.
+    static func codex(codexHome: URL) -> ManageProviderContext {
+        ManageProviderContext(
+            provider: .codex,
+            providerHome: codexHome,
+            sessionAreaRoots: [codexHome.appendingPathComponent("sessions")]
+        )
+    }
+}

--- a/Lupen/Domain/Manage/ManageReconciler.swift
+++ b/Lupen/Domain/Manage/ManageReconciler.swift
@@ -7,30 +7,33 @@
 
 import Foundation
 
-/// 인덱스(즉시) 데이터와 파일시스템 실측을 대조해 관리 리스트 행을 만든다.
-/// (research-ccmgr.md §1.6 — 추적/미추적/잔재 3상태)
+/// Builds the manage-list rows by cross-checking index (immediate) data
+/// against filesystem measurement.
+/// (research-ccmgr.md §1.6 — tracked/untracked/index-remnant three states)
 ///
-/// 순수 함수 — 이미 조회된 배열을 받아 계산만 한다(ProviderStore/FS 접근은
-/// 호출부 `ManageStore`/`ManageScanService`가 담당, 테스트 용이).
+/// Pure function — takes already-queried arrays and only computes
+/// (ProviderStore/FS access is the caller's job — `ManageStore`/
+/// `ManageScanService` — for testability).
 struct ManageReconciler {
 
-    /// 인덱스가 아는 한 세션의 입력 묶음.
+    /// The input bundle for one session as the index knows it.
     struct IndexedSession: Sendable {
         let row: StoreSessionRow
         let sourceFiles: [StoreSourceFile]
         let aggregate: StoreSessionListAggregate?
     }
 
-    /// 세션영역 스캔에서 발견한 디스크 파일.
+    /// A disk file found by the session-area scan.
     struct DiskFile: Sendable, Equatable {
         let path: String
         let sizeBytes: Int64
         let modifiedAt: Date?
     }
 
-    /// - Parameter scanned: 파일시스템 실측이 끝났는가. false면 1차(인덱스만)
-    ///   렌더 — 세션은 디스크에 있다고 가정(잔재 오판 방지)하고 orphan은 내지
-    ///   않는다. true면 diskFiles로 존재 확인·미추적 발견까지 한다.
+    /// - Parameter scanned: Whether filesystem measurement is done. If false,
+    ///   first-pass (index-only) render — sessions are assumed to exist on disk
+    ///   (avoids false index-remnant calls) and no orphans are produced. If
+    ///   true, also confirms existence via diskFiles and finds untracked files.
     static func reconcile(
         provider: ProviderKind,
         indexed: [IndexedSession],
@@ -44,7 +47,7 @@ struct ManageReconciler {
         var claimed = Set<String>()
         var rows: [ManageRowModel] = []
 
-        // 1) 인덱스 세션 — 추적 또는 잔재.
+        // 1) Indexed sessions — tracked or index remnant.
         for session in indexed {
             let allPaths = session.sourceFiles.map(\.path)
             claimed.formUnion(allPaths)
@@ -54,8 +57,8 @@ struct ManageReconciler {
             let indexSize = session.sourceFiles.reduce(Int64(0)) { $0 + $1.byteSize }
             let lastMod = session.sourceFiles.compactMap(\.modifiedAt).max() ?? session.row.endTime
 
-            // Claude 세션의 동반 디렉터리 `<sessionId>/`(서브에이전트 보관) —
-            // 휴지통 시 부모 jsonl과 함께 통째로 옮긴다.
+            // Claude session's companion directory `<sessionId>/` (holds
+            // subagents) — moved wholesale together with the parent jsonl on Trash.
             var companion: String?
             if provider == .claudeCode,
                session.sourceFiles.contains(where: { $0.isSubagent }),
@@ -67,7 +70,7 @@ struct ManageReconciler {
             let classification: StorageClassification
             let protection: StorageProtection
             if kind == .indexRemnant {
-                // 원본이 디스크에 없음 — 파일 삭제는 의미 없고 인덱스 prune 대상.
+                // Original is not on disk — file deletion is meaningless; this is an index-prune target.
                 classification = .unclassified
                 protection = .locked
             } else {
@@ -112,8 +115,9 @@ struct ManageReconciler {
             ))
         }
 
-        // 2) 미추적 orphan — 세션영역에 있으나 인덱스가 모르는 `.jsonl`.
-        //    실측 전(scanned=false)에는 디스크를 모르므로 만들지 않는다.
+        // 2) Untracked orphans — `.jsonl` in the session area that the index
+        //    doesn't know about. Not produced before measurement
+        //    (scanned=false), since disk state is unknown.
         if scanned {
             for file in diskFiles where !claimed.contains(file.path) && file.path.hasSuffix(".jsonl") {
                 let url = URL(fileURLWithPath: file.path)
@@ -159,8 +163,8 @@ struct ManageReconciler {
 
     // MARK: - Helpers
 
-    /// 행 상태(이모지 컬럼). 우선순위: 차단 > 에러(잔재/파싱실패) > 미추적 >
-    /// 인덱싱 중 > 최근 활동 > 정상.
+    /// Row status (emoji column). Priority: blocked > error (index remnant/
+    /// parse failure) > untracked > indexing > recently active > normal.
     static func status(
         isIndexing: Bool,
         isIndexed: Bool,
@@ -192,10 +196,10 @@ struct ManageReconciler {
         let raw = session.row.projectPath
         switch provider {
         case .claudeCode:
-            // Claude는 project_path가 인코딩된 디렉터리명 → 실제 경로로 디코드.
+            // For Claude, project_path is an encoded directory name → decode to the real path.
             return (title, raw.map { ProjectPathDecoder.decodeFullPath($0) }, raw)
         case .codex:
-            // Codex는 project_path가 이미 실제 cwd.
+            // For Codex, project_path is already the real cwd.
             return (title, raw, nil)
         }
     }

--- a/Lupen/Domain/Manage/ManageReconciler.swift
+++ b/Lupen/Domain/Manage/ManageReconciler.swift
@@ -1,0 +1,202 @@
+//
+//  ManageReconciler.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 인덱스(즉시) 데이터와 파일시스템 실측을 대조해 관리 리스트 행을 만든다.
+/// (research-ccmgr.md §1.6 — 추적/미추적/잔재 3상태)
+///
+/// 순수 함수 — 이미 조회된 배열을 받아 계산만 한다(ProviderStore/FS 접근은
+/// 호출부 `ManageStore`/`ManageScanService`가 담당, 테스트 용이).
+struct ManageReconciler {
+
+    /// 인덱스가 아는 한 세션의 입력 묶음.
+    struct IndexedSession: Sendable {
+        let row: StoreSessionRow
+        let sourceFiles: [StoreSourceFile]
+        let aggregate: StoreSessionListAggregate?
+    }
+
+    /// 세션영역 스캔에서 발견한 디스크 파일.
+    struct DiskFile: Sendable, Equatable {
+        let path: String
+        let sizeBytes: Int64
+        let modifiedAt: Date?
+    }
+
+    /// - Parameter scanned: 파일시스템 실측이 끝났는가. false면 1차(인덱스만)
+    ///   렌더 — 세션은 디스크에 있다고 가정(잔재 오판 방지)하고 orphan은 내지
+    ///   않는다. true면 diskFiles로 존재 확인·미추적 발견까지 한다.
+    static func reconcile(
+        provider: ProviderKind,
+        indexed: [IndexedSession],
+        diskFiles: [DiskFile],
+        classifier: StorageClassifier,
+        isIndexing: Bool,
+        scanned: Bool = true,
+        now: Date = Date()
+    ) -> [ManageRowModel] {
+        let diskByPath = Dictionary(diskFiles.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
+        var claimed = Set<String>()
+        var rows: [ManageRowModel] = []
+
+        // 1) 인덱스 세션 — 추적 또는 잔재.
+        for session in indexed {
+            let allPaths = session.sourceFiles.map(\.path)
+            claimed.formUnion(allPaths)
+
+            let parentPaths = session.sourceFiles.filter { !$0.isSubagent }.map(\.path)
+            let existsOnDisk = scanned ? allPaths.contains { diskByPath[$0] != nil } : true
+            let indexSize = session.sourceFiles.reduce(Int64(0)) { $0 + $1.byteSize }
+            let lastMod = session.sourceFiles.compactMap(\.modifiedAt).max() ?? session.row.endTime
+
+            // Claude 세션의 동반 디렉터리 `<sessionId>/`(서브에이전트 보관) —
+            // 휴지통 시 부모 jsonl과 함께 통째로 옮긴다.
+            var companion: String?
+            if provider == .claudeCode,
+               session.sourceFiles.contains(where: { $0.isSubagent }),
+               let parent = parentPaths.first {
+                companion = URL(fileURLWithPath: parent).deletingPathExtension().path
+            }
+
+            let kind: ManageItemKind = existsOnDisk ? .session : .indexRemnant
+            let classification: StorageClassification
+            let protection: StorageProtection
+            if kind == .indexRemnant {
+                // 원본이 디스크에 없음 — 파일 삭제는 의미 없고 인덱스 prune 대상.
+                classification = .unclassified
+                protection = .locked
+            } else {
+                (classification, protection) = classifier.classify(
+                    path: parentPaths.first ?? allPaths.first ?? "",
+                    isIndexed: true,
+                    isIndexing: isIndexing,
+                    lastModified: lastMod,
+                    now: now
+                )
+            }
+
+            let hasFailed = session.sourceFiles.contains { $0.parseState == .failed }
+            let status = Self.status(
+                isIndexing: isIndexing, isIndexed: true, protection: protection,
+                hasFailed: hasFailed, lastModified: lastMod, now: now
+            )
+            let described = describe(session: session, provider: provider)
+            rows.append(ManageRowModel(
+                id: session.row.id,
+                provider: provider,
+                kind: kind,
+                displayTitle: described.title,
+                rawSessionId: session.row.rawId,
+                projectPath: described.decodedPath,
+                encodedProject: described.encoded,
+                branch: session.row.lastGitBranch,
+                firstPrompt: session.row.firstPrompt,
+                createdAt: session.row.startTime,
+                lastActivity: lastMod,
+                sizeBytes: indexSize,
+                isEstimatedSize: true,
+                fileCount: session.sourceFiles.count,
+                filePaths: parentPaths,
+                companionDirectory: companion,
+                parseState: nil,
+                status: status,
+                classification: classification,
+                protection: protection,
+                isIndexed: true,
+                existsOnDisk: existsOnDisk
+            ))
+        }
+
+        // 2) 미추적 orphan — 세션영역에 있으나 인덱스가 모르는 `.jsonl`.
+        //    실측 전(scanned=false)에는 디스크를 모르므로 만들지 않는다.
+        if scanned {
+            for file in diskFiles where !claimed.contains(file.path) && file.path.hasSuffix(".jsonl") {
+                let url = URL(fileURLWithPath: file.path)
+                let (classification, protection) = classifier.classify(
+                    path: file.path,
+                    isIndexed: false,
+                    isIndexing: isIndexing,
+                    lastModified: file.modifiedAt,
+                    now: now
+                )
+                let status = Self.status(
+                    isIndexing: isIndexing, isIndexed: false, protection: protection,
+                    hasFailed: false, lastModified: file.modifiedAt, now: now
+                )
+                rows.append(ManageRowModel(
+                    id: file.path,
+                    provider: provider,
+                    kind: .orphanFile,
+                    displayTitle: url.lastPathComponent,
+                    projectPath: url.deletingLastPathComponent().path,
+                    encodedProject: nil,
+                    branch: nil,
+                    firstPrompt: nil,
+                    createdAt: file.modifiedAt,
+                    lastActivity: file.modifiedAt,
+                    sizeBytes: file.sizeBytes,
+                    isEstimatedSize: false,
+                    fileCount: 1,
+                    filePaths: [file.path],
+                    companionDirectory: nil,
+                    parseState: nil,
+                    status: status,
+                    classification: classification,
+                    protection: protection,
+                    isIndexed: false,
+                    existsOnDisk: true
+                ))
+            }
+        }
+
+        return rows
+    }
+
+    // MARK: - Helpers
+
+    /// 행 상태(이모지 컬럼). 우선순위: 차단 > 에러(잔재/파싱실패) > 미추적 >
+    /// 인덱싱 중 > 최근 활동 > 정상.
+    static func status(
+        isIndexing: Bool,
+        isIndexed: Bool,
+        protection: StorageProtection,
+        hasFailed: Bool,
+        lastModified: Date?,
+        now: Date,
+        activeWindow: TimeInterval = 600
+    ) -> ManageStatus {
+        if protection == .blocked { return .blocked }
+        if protection == .locked || hasFailed { return .error }
+        if !isIndexed { return .untracked }
+        if isIndexing { return .indexing }
+        if let lastModified, now.timeIntervalSince(lastModified) < activeWindow {
+            return .recentlyActive
+        }
+        return .normal
+    }
+
+    private static func describe(
+        session: IndexedSession,
+        provider: ProviderKind
+    ) -> (title: String, decodedPath: String?, encoded: String?) {
+        let title = ManageTitleFormatter.sessionTitle(
+            firstPrompt: session.row.firstPrompt,
+            cachedTitle: session.row.cachedTitle,
+            customTitle: session.row.customTitle
+        )
+        let raw = session.row.projectPath
+        switch provider {
+        case .claudeCode:
+            // Claude는 project_path가 인코딩된 디렉터리명 → 실제 경로로 디코드.
+            return (title, raw.map { ProjectPathDecoder.decodeFullPath($0) }, raw)
+        case .codex:
+            // Codex는 project_path가 이미 실제 cwd.
+            return (title, raw, nil)
+        }
+    }
+}

--- a/Lupen/Domain/Manage/ManageRowFilter.swift
+++ b/Lupen/Domain/Manage/ManageRowFilter.swift
@@ -1,0 +1,56 @@
+//
+//  ManageRowFilter.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 컬럼 정렬 키 — NSTableView 헤더 클릭과 1:1 대응.
+enum ManageRowSort: String, Sendable {
+    case status
+    case project
+    case session
+    case created
+    case updated
+    case size
+    case files
+}
+
+/// 행 목록에 검색·정렬을 적용하는 순수 변환(테스트 대상). 정렬은 표시값이
+/// 아니라 raw 값으로 — 사전식 정렬 깨짐 방지(research §B-4).
+enum ManageRowFilter {
+    static func apply(_ rows: [ManageRowModel], search: String, sort: ManageRowSort, ascending: Bool) -> [ManageRowModel] {
+        var result = rows
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if !query.isEmpty {
+            result = result.filter { row in
+                row.displayTitle.lowercased().contains(query)
+                    || (row.projectPath?.lowercased().contains(query) ?? false)
+                    || (row.branch?.lowercased().contains(query) ?? false)
+            }
+        }
+        result.sort { lhs, rhs in
+            let ascendingOrder: Bool
+            switch sort {
+            case .status:
+                ascendingOrder = lhs.status.sortOrder < rhs.status.sortOrder
+            case .project:
+                ascendingOrder = lhs.projectName.localizedCaseInsensitiveCompare(rhs.projectName) == .orderedAscending
+            case .session:
+                ascendingOrder = lhs.displayTitle.localizedCaseInsensitiveCompare(rhs.displayTitle) == .orderedAscending
+            case .created:
+                ascendingOrder = (lhs.createdAt ?? .distantPast) < (rhs.createdAt ?? .distantPast)
+            case .updated:
+                ascendingOrder = (lhs.lastActivity ?? .distantPast) < (rhs.lastActivity ?? .distantPast)
+            case .size:
+                ascendingOrder = lhs.sizeBytes < rhs.sizeBytes
+            case .files:
+                ascendingOrder = lhs.fileCount < rhs.fileCount
+            }
+            return ascending ? ascendingOrder : !ascendingOrder
+        }
+        return result
+    }
+}

--- a/Lupen/Domain/Manage/ManageRowFilter.swift
+++ b/Lupen/Domain/Manage/ManageRowFilter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// 컬럼 정렬 키 — NSTableView 헤더 클릭과 1:1 대응.
+/// Column sort keys — a 1:1 mapping to NSTableView header clicks.
 enum ManageRowSort: String, Sendable {
     case status
     case project
@@ -18,8 +18,9 @@ enum ManageRowSort: String, Sendable {
     case files
 }
 
-/// 행 목록에 검색·정렬을 적용하는 순수 변환(테스트 대상). 정렬은 표시값이
-/// 아니라 raw 값으로 — 사전식 정렬 깨짐 방지(research §B-4).
+/// A pure transform that applies search/sort to a row list (test target). Sorting
+/// is on raw values rather than display values — to avoid broken lexicographic
+/// ordering (research §B-4).
 enum ManageRowFilter {
     static func apply(_ rows: [ManageRowModel], search: String, sort: ManageRowSort, ascending: Bool) -> [ManageRowModel] {
         var result = rows

--- a/Lupen/Domain/Manage/ManageScanService.swift
+++ b/Lupen/Domain/Manage/ManageScanService.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-/// 스캔 취소 플래그. `Task.detached`는 부모 Task의 취소를 전파받지 않으므로,
-/// 호출부(`ManageStore`)가 새 load를 시작할 때 이 플래그로 진행 중인 스캔을
-/// 명시적으로 중단시킨다(빠른 provider 토글 시 버려질 스캔의 CPU 낭비 방지).
+/// Scan cancellation flag. Because `Task.detached` does not inherit the parent
+/// Task's cancellation, the caller (`ManageStore`) uses this flag to explicitly
+/// stop an in-progress scan when it starts a new load (avoiding wasted CPU on
+/// scans that will be discarded during rapid provider toggling).
 final class ScanCancellationFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var _cancelled = false
@@ -17,13 +18,14 @@ final class ScanCancellationFlag: @unchecked Sendable {
     func cancel() { lock.lock(); _cancelled = true; lock.unlock() }
 }
 
-/// 세션영역/홈 디렉터리를 백그라운드(detached, utility QoS)에서 스캔한다.
-/// 메인스레드 블로킹 0 (plan §3.1). 오래된 결과의 폐기는 호출부 `ManageStore`가
-/// generation 토큰으로, 진행 중단은 `ScanCancellationFlag`로 처리한다.
+/// Scans the session area / home directory in the background (detached, utility
+/// QoS). Zero main-thread blocking (plan §3.1). Discarding stale results is
+/// handled by the caller `ManageStore` via a generation token; mid-way
+/// cancellation is handled by `ScanCancellationFlag`.
 struct ManageScanService: Sendable {
 
-    /// 세션영역의 모든 `.jsonl` 인벤토리 — `ManageReconciler`의 diskFiles
-    /// 입력(존재 확인 + 미추적 발견).
+    /// An inventory of every `.jsonl` in the session area — the diskFiles input
+    /// to `ManageReconciler` (existence check + untracked discovery).
     func scanSessionArea(roots: [URL], isCancelled: @escaping @Sendable () -> Bool = { false }) async -> [ManageReconciler.DiskFile] {
         await Task.detached(priority: .utility) {
             var out: [ManageReconciler.DiskFile] = []
@@ -35,7 +37,7 @@ struct ManageScanService: Sendable {
         }.value
     }
 
-    /// 전체 디스크 탭 — provider 홈의 1-depth 점유물(읽기전용).
+    /// The All Disk tab — the 1-depth allocated-size items of the provider home (read-only).
     func scanDiskItems(home: URL, isCancelled: @escaping @Sendable () -> Bool = { false }) async -> [DiskSizer.Entry] {
         await Task.detached(priority: .utility) {
             DiskSizer.childEntries(of: home, isCancelled: isCancelled)

--- a/Lupen/Domain/Manage/ManageScanService.swift
+++ b/Lupen/Domain/Manage/ManageScanService.swift
@@ -1,0 +1,59 @@
+//
+//  ManageScanService.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 세션영역/홈 디렉터리를 백그라운드(detached, utility QoS)에서 스캔한다.
+/// 메인스레드 블로킹 0 (plan §3.1). 오래된 결과의 폐기(취소)는 호출부
+/// `ManageStore`가 generation 토큰으로 처리한다.
+struct ManageScanService: Sendable {
+
+    /// 세션영역의 모든 `.jsonl` 인벤토리 — `ManageReconciler`의 diskFiles
+    /// 입력(존재 확인 + 미추적 발견).
+    func scanSessionArea(roots: [URL]) async -> [ManageReconciler.DiskFile] {
+        await Task.detached(priority: .utility) {
+            var out: [ManageReconciler.DiskFile] = []
+            for root in roots {
+                Self.collectJSONLFiles(in: root, into: &out)
+            }
+            return out
+        }.value
+    }
+
+    /// 전체 디스크 탭 — provider 홈의 1-depth 점유물(읽기전용).
+    func scanDiskItems(home: URL) async -> [DiskSizer.Entry] {
+        await Task.detached(priority: .utility) {
+            DiskSizer.childEntries(of: home)
+        }.value
+    }
+
+    // MARK: - Internal
+
+    static func collectJSONLFiles(in root: URL, into out: inout [ManageReconciler.DiskFile]) {
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .contentModificationDateKey,
+        ]
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: Array(keys),
+            options: [],
+            errorHandler: { _, _ in true }
+        ) else { return }
+
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl",
+                  let vals = try? url.resourceValues(forKeys: keys),
+                  vals.isRegularFile == true else { continue }
+            let size = Int64(vals.totalFileAllocatedSize ?? vals.fileAllocatedSize ?? 0)
+            out.append(ManageReconciler.DiskFile(
+                path: url.path,
+                sizeBytes: size,
+                modifiedAt: vals.contentModificationDate
+            ))
+        }
+    }
+}

--- a/Lupen/Domain/Manage/ManageScanService.swift
+++ b/Lupen/Domain/Manage/ManageScanService.swift
@@ -7,33 +7,44 @@
 
 import Foundation
 
+/// 스캔 취소 플래그. `Task.detached`는 부모 Task의 취소를 전파받지 않으므로,
+/// 호출부(`ManageStore`)가 새 load를 시작할 때 이 플래그로 진행 중인 스캔을
+/// 명시적으로 중단시킨다(빠른 provider 토글 시 버려질 스캔의 CPU 낭비 방지).
+final class ScanCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _cancelled = false
+    var isCancelled: Bool { lock.lock(); defer { lock.unlock() }; return _cancelled }
+    func cancel() { lock.lock(); _cancelled = true; lock.unlock() }
+}
+
 /// 세션영역/홈 디렉터리를 백그라운드(detached, utility QoS)에서 스캔한다.
-/// 메인스레드 블로킹 0 (plan §3.1). 오래된 결과의 폐기(취소)는 호출부
-/// `ManageStore`가 generation 토큰으로 처리한다.
+/// 메인스레드 블로킹 0 (plan §3.1). 오래된 결과의 폐기는 호출부 `ManageStore`가
+/// generation 토큰으로, 진행 중단은 `ScanCancellationFlag`로 처리한다.
 struct ManageScanService: Sendable {
 
     /// 세션영역의 모든 `.jsonl` 인벤토리 — `ManageReconciler`의 diskFiles
     /// 입력(존재 확인 + 미추적 발견).
-    func scanSessionArea(roots: [URL]) async -> [ManageReconciler.DiskFile] {
+    func scanSessionArea(roots: [URL], isCancelled: @escaping @Sendable () -> Bool = { false }) async -> [ManageReconciler.DiskFile] {
         await Task.detached(priority: .utility) {
             var out: [ManageReconciler.DiskFile] = []
             for root in roots {
-                Self.collectJSONLFiles(in: root, into: &out)
+                if isCancelled() { break }
+                Self.collectJSONLFiles(in: root, into: &out, isCancelled: isCancelled)
             }
             return out
         }.value
     }
 
     /// 전체 디스크 탭 — provider 홈의 1-depth 점유물(읽기전용).
-    func scanDiskItems(home: URL) async -> [DiskSizer.Entry] {
+    func scanDiskItems(home: URL, isCancelled: @escaping @Sendable () -> Bool = { false }) async -> [DiskSizer.Entry] {
         await Task.detached(priority: .utility) {
-            DiskSizer.childEntries(of: home)
+            DiskSizer.childEntries(of: home, isCancelled: isCancelled)
         }.value
     }
 
     // MARK: - Internal
 
-    static func collectJSONLFiles(in root: URL, into out: inout [ManageReconciler.DiskFile]) {
+    static func collectJSONLFiles(in root: URL, into out: inout [ManageReconciler.DiskFile], isCancelled: () -> Bool = { false }) {
         let keys: Set<URLResourceKey> = [
             .isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .contentModificationDateKey,
         ]
@@ -45,6 +56,7 @@ struct ManageScanService: Sendable {
         ) else { return }
 
         for case let url as URL in enumerator {
+            if isCancelled() { return }
             guard url.pathExtension == "jsonl",
                   let vals = try? url.resourceValues(forKeys: keys),
                   vals.isRegularFile == true else { continue }

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -8,12 +8,14 @@
 import Foundation
 import Observation
 
-/// "Manage Sessions & Storage" 윈도우의 관찰 가능 상태. 인덱스에서 즉시
-/// 렌더하고(plan §3.1) 백그라운드 FS 실측으로 보정한다. 기존
-/// `AppStateStore`/인덱스는 건드리지 않는 창 전용 store(회귀 0).
+/// Observable state for the "Manage Sessions & Storage" window. Renders
+/// immediately from the index (plan §3.1) and refines via background FS
+/// measurement. A window-only store that never touches the existing
+/// `AppStateStore`/index (zero regression).
 ///
-/// provider별 `ProviderStore`·컨텍스트는 AppDelegate가 클로저로 주입한다
-/// (`sqliteFirstStartups`는 동적이라 스냅샷이 아닌 접근자로).
+/// Per-provider `ProviderStore`/context are injected by AppDelegate as
+/// closures (`sqliteFirstStartups` is dynamic, so accessors rather than a
+/// snapshot).
 @MainActor
 @Observable
 final class ManageStore {
@@ -26,9 +28,9 @@ final class ManageStore {
     var selectedIDs: Set<String> = []
     private(set) var isScanning = false
     private(set) var provider: ProviderKind
-    /// 현재 provider가 인덱싱 중인가(인덱싱 중엔 세션이 보호되어 blocked).
+    /// Whether the current provider is indexing (sessions are protected and blocked while indexing).
     var isIndexingNow: Bool { isIndexingProvider() }
-    /// 전체 디스크 탭(읽기전용) 항목 — 큰 점유물 내림차순.
+    /// All-disk tab (read-only) entries — largest occupants first.
     private(set) var diskItems: [DiskSizer.Entry] = []
 
     private let isIndexingProvider: @MainActor () -> Bool
@@ -36,12 +38,12 @@ final class ManageStore {
     private let contextProvider: @MainActor (ProviderKind) -> ManageProviderContext?
     private let requestRescan: @MainActor (ProviderKind) -> Void
     private let rebuildIndex: @MainActor (ProviderKind) -> Void
-    /// AppKit 뷰가 갱신을 받기 위한 콜백(@Observable 자동 추적 대신 명시적).
+    /// Callback for AppKit views to receive updates (explicit, instead of @Observable auto-tracking).
     @ObservationIgnored var onChange: (@MainActor () -> Void)?
     private let scanService = ManageScanService()
     private let trashService = ManageTrashService()
     private var scanGeneration = 0
-    /// 진행 중 스캔을 중단시키는 플래그(새 load마다 교체 — 토글 시 CPU 낭비 방지).
+    /// Flag that aborts an in-flight scan (replaced on each load — avoids wasted CPU when toggling).
     private var scanFlag: ScanCancellationFlag?
 
     init(
@@ -69,8 +71,9 @@ final class ManageStore {
     var selectedCount: Int { selectedIDs.count }
     var selectedReclaimBytes: Int64 { selectedRows.reduce(0) { $0 + $1.sizeBytes } }
 
-    /// 전체 디스크 탭(읽기전용) — provider 홈의 큰 점유물을 행으로. 세션영역
-    /// 밖이므로 전부 blocked(앱 내 삭제 차단 — Reveal만).
+    /// All-disk tab (read-only) — large occupants of the provider home as
+    /// rows. Outside the session area, so all blocked (in-app deletion
+    /// disabled — Reveal only).
     var allDiskRows: [ManageRowModel] {
         diskItems.map { entry in
             ManageRowModel(
@@ -94,16 +97,16 @@ final class ManageStore {
     // MARK: - Cache inspection
 
     struct CacheInfo: Sendable, Equatable {
-        var indexBytes: Int64      // index.sqlite3 (메인)
+        var indexBytes: Int64      // index.sqlite3 (main)
         var walBytes: Int64        // -wal
         var shmBytes: Int64        // -shm
         var snapshotBytes: Int64
         var coverage: StoreCoverage?
-        var lastIndexed: Date?     // index.sqlite3 마지막 수정 시각
+        var lastIndexed: Date?     // index.sqlite3 last-modified time
     }
     private(set) var cacheInfo: CacheInfo?
 
-    /// 관리 창에서 Reveal에 쓰는 provider별 저장 디렉터리.
+    /// Per-provider storage directory used by Reveal in the manage window.
     var providerSupportRoot: URL {
         LupenPaths.providerRoot(for: provider)
     }
@@ -123,14 +126,14 @@ final class ManageStore {
         )
     }
 
-    /// 인덱스 재빌드(원본 로그 불변) — 기존 rebuild 경로 재사용.
+    /// Rebuild the index (original logs untouched) — reuses the existing rebuild path.
     func rebuildCacheIndex() {
         rebuildIndex(provider)
         loadCacheInfo()
     }
 
-    /// 스냅샷 JSON 캐시만 삭제(Lupen 파생 데이터 — 재생성됨). 인덱스 DB는
-    /// 건드리지 않는다.
+    /// Delete only the snapshot JSON caches (Lupen-derived data — regenerated).
+    /// The index DB is left untouched.
     func clearSnapshots() {
         for url in snapshotURLs(root: LupenPaths.applicationSupportRoot()) {
             try? FileManager.default.removeItem(at: url)
@@ -146,15 +149,15 @@ final class ManageStore {
 
     // MARK: - Selection
 
-    /// 단일 선택 시 인스펙터에 표시할 행(여러 개면 nil → 요약).
+    /// Row to show in the inspector on single selection (nil if multiple → summary).
     var inspectedRow: ManageRowModel? {
         selectedIDs.count == 1 ? rows.first { selectedIDs.contains($0.id) } : nil
     }
 
     func clearSelection() { selectedIDs = []; onChange?() }
 
-    /// 테이블 행 선택을 반영(인스펙터 + collector). 삭제 가능 여부 게이트는
-    /// performTrash가 담당하므로 선택 자체는 모든 행을 허용한다.
+    /// Reflect table row selection (inspector + collector). The deletability
+    /// gate is performTrash's job, so selection itself allows every row.
     func setSelectedIDs(_ ids: Set<String>) {
         guard ids != selectedIDs else { return }
         selectedIDs = ids
@@ -165,8 +168,8 @@ final class ManageStore {
         guard newProvider != provider else { return }
         provider = newProvider
         selectedIDs = []
-        // 이전 provider 행을 즉시 비워, 비동기 load의 1차 렌더 전까지 잘못된
-        // provider 데이터가 보이는 깜빡임을 막는다.
+        // Clear the previous provider's rows immediately to avoid a flicker
+        // of wrong-provider data before the async load's first render.
         rows = []
         diskItems = []
         load()
@@ -186,9 +189,10 @@ final class ManageStore {
         let classifier = StorageClassifier(scope: context.classifierScope)
         let prov = provider
 
-        // 진행 중 스캔을 취소하고 새 세대를 시작한다. 인덱스 읽기(대량 세션의
-        // 동기 DB 조회)와 FS 실측을 모두 백그라운드에서 수행해 메인스레드
-        // 반응성을 보장한다(plan §3 — 메인 블로킹 0).
+        // Cancel any in-flight scan and start a new generation. Both the
+        // index read (synchronous DB queries over many sessions) and FS
+        // measurement run in the background to keep the main thread
+        // responsive (plan §3 — zero main-thread blocking).
         scanFlag?.cancel()
         let flag = ScanCancellationFlag()
         scanFlag = flag
@@ -198,8 +202,9 @@ final class ManageStore {
         onChange?()
 
         Task { @MainActor in
-            // 1차: 인덱스만(근사 크기) — 잔재/미추적 판정 보류. loadIndexed는
-            // detached로 돌려 메인을 막지 않고, 결과 반영 시 최신 load인지 확인.
+            // Pass 1: index only (approximate size) — defer index-remnant/
+            // untracked judgement. Run loadIndexed detached so it doesn't
+            // block main, and verify this is still the latest load before applying.
             let indexed = await Task.detached(priority: .userInitiated) {
                 Self.loadIndexed(from: store)
             }.value
@@ -211,14 +216,15 @@ final class ManageStore {
             self.loadCacheInfo()
             self.onChange?()
 
-            // 2차: 백그라운드 FS 실측 → 정확 크기·미추적·잔재 보정(취소 가능).
+            // Pass 2: background FS measurement → refine exact size, untracked,
+            // and index remnants (cancellable).
             let disk = await self.scanService.scanSessionArea(
                 roots: context.sessionAreaRoots, isCancelled: { flag.isCancelled })
             let items = await self.scanService.scanDiskItems(
                 home: context.providerHome, isCancelled: { flag.isCancelled })
-            // 더 새로운 load가 시작됐으면 이 결과는 버린다.
+            // Discard this result if a newer load has started.
             guard generation == self.scanGeneration else { return }
-            // 스캔 중 인덱싱 상태가 바뀔 수 있으니 보정 시점에 재평가.
+            // Indexing state may change during the scan, so re-evaluate at refine time.
             self.rows = ManageReconciler.reconcile(
                 provider: prov, indexed: indexed, diskFiles: disk,
                 classifier: classifier, isIndexing: self.isIndexingProvider(), scanned: true
@@ -231,18 +237,20 @@ final class ManageStore {
 
     // MARK: - Deletion (trash + index reconcile + Undo)
 
-    /// 행들을 휴지통으로 보내고 인덱스를 정합시킨다. 실제로 옮겨진 행의
-    /// 세션 전체 소스를 인덱스에서 제거한다(동반 디렉터리의 서브에이전트
-    /// 포함). 반환된 Outcome으로 Undo 스낵바를 띄운다.
+    /// Send rows to the Trash and reconcile the index. Removes the entire
+    /// session's sources from the index for rows that actually moved
+    /// (including subagents in the companion directory). Use the returned
+    /// Outcome to show the Undo snackbar.
     @discardableResult
     func trash(rows: [ManageRowModel]) async -> ManageTrashService.Outcome {
         let outcome = await trashService.trash(rows.flatMap(\.trashTargets))
         let trashed = Set(outcome.trashedPaths)
         if let store = storeProvider(provider) {
             var indexPaths: [String] = []
-            // 부모 파일(jsonl)이 실제로 휴지통에 간 행만 세션 전체 인덱스를
-            // 정리한다. companion 디렉터리만 성공하고 부모가 실패한 경우엔
-            // 인덱스를 유지(부모가 디스크에 남아 정합 — 부분 실패 안전).
+            // Only prune the whole session's index for rows whose parent file
+            // (jsonl) actually went to the Trash. If only the companion
+            // directory succeeded and the parent failed, keep the index
+            // (the parent remains on disk, staying consistent — safe partial failure).
             for row in rows where row.filePaths.contains(where: { trashed.contains($0) }) {
                 if let raw = row.rawSessionId, let sources = try? store.sourceFiles(sessionRawId: raw) {
                     indexPaths.append(contentsOf: sources.map(\.path))
@@ -260,7 +268,7 @@ final class ManageStore {
         return outcome
     }
 
-    /// Undo — 휴지통에서 복원하고 인덱스 재등록을 트리거(rescan)한 뒤 재렌더.
+    /// Undo — restore from the Trash, trigger index re-registration (rescan), then re-render.
     func undoTrash(_ entries: [ManageTrashService.RestoreEntry]) async {
         await trashService.restore(entries)
         requestRescan(provider)
@@ -277,7 +285,7 @@ final class ManageStore {
             ManageReconciler.IndexedSession(
                 row: row,
                 sourceFiles: byRaw[row.rawId] ?? [],
-                aggregate: nil   // reconcile 미사용 — sessionListAggregates() GROUP BY 비용 회피.
+                aggregate: nil   // unused by reconcile — avoids sessionListAggregates() GROUP BY cost.
             )
         }
     }

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -41,6 +41,8 @@ final class ManageStore {
     private let scanService = ManageScanService()
     private let trashService = ManageTrashService()
     private var scanGeneration = 0
+    /// 진행 중 스캔을 중단시키는 플래그(새 load마다 교체 — 토글 시 CPU 낭비 방지).
+    private var scanFlag: ScanCancellationFlag?
 
     init(
         provider: ProviderKind,
@@ -163,6 +165,10 @@ final class ManageStore {
         guard newProvider != provider else { return }
         provider = newProvider
         selectedIDs = []
+        // 이전 provider 행을 즉시 비워, 비동기 load의 1차 렌더 전까지 잘못된
+        // provider 데이터가 보이는 깜빡임을 막는다.
+        rows = []
+        diskItems = []
         load()
     }
 
@@ -173,29 +179,43 @@ final class ManageStore {
             rows = []
             diskItems = []
             cacheInfo = nil
+            isScanning = false
             onChange?()
             return
         }
-        let indexed = Self.loadIndexed(from: store)
         let classifier = StorageClassifier(scope: context.classifierScope)
-        let indexing = isIndexingProvider()
         let prov = provider
 
-        // 1차: 인덱스만(근사 크기) — 즉시 렌더, 잔재/미추적 판정 보류.
-        rows = ManageReconciler.reconcile(
-            provider: prov, indexed: indexed, diskFiles: [],
-            classifier: classifier, isIndexing: indexing, scanned: false
-        )
-        loadCacheInfo()
-        onChange?()
-
-        // 2차: 백그라운드 FS 실측 → 정확 크기·미추적·잔재 보정.
+        // 진행 중 스캔을 취소하고 새 세대를 시작한다. 인덱스 읽기(대량 세션의
+        // 동기 DB 조회)와 FS 실측을 모두 백그라운드에서 수행해 메인스레드
+        // 반응성을 보장한다(plan §3 — 메인 블로킹 0).
+        scanFlag?.cancel()
+        let flag = ScanCancellationFlag()
+        scanFlag = flag
         scanGeneration += 1
         let generation = scanGeneration
         isScanning = true
+        onChange?()
+
         Task { @MainActor in
-            let disk = await self.scanService.scanSessionArea(roots: context.sessionAreaRoots)
-            let items = await self.scanService.scanDiskItems(home: context.providerHome)
+            // 1차: 인덱스만(근사 크기) — 잔재/미추적 판정 보류. loadIndexed는
+            // detached로 돌려 메인을 막지 않고, 결과 반영 시 최신 load인지 확인.
+            let indexed = await Task.detached(priority: .userInitiated) {
+                Self.loadIndexed(from: store)
+            }.value
+            guard generation == self.scanGeneration else { return }
+            self.rows = ManageReconciler.reconcile(
+                provider: prov, indexed: indexed, diskFiles: [],
+                classifier: classifier, isIndexing: self.isIndexingProvider(), scanned: false
+            )
+            self.loadCacheInfo()
+            self.onChange?()
+
+            // 2차: 백그라운드 FS 실측 → 정확 크기·미추적·잔재 보정(취소 가능).
+            let disk = await self.scanService.scanSessionArea(
+                roots: context.sessionAreaRoots, isCancelled: { flag.isCancelled })
+            let items = await self.scanService.scanDiskItems(
+                home: context.providerHome, isCancelled: { flag.isCancelled })
             // 더 새로운 load가 시작됐으면 이 결과는 버린다.
             guard generation == self.scanGeneration else { return }
             // 스캔 중 인덱싱 상태가 바뀔 수 있으니 보정 시점에 재평가.
@@ -249,21 +269,20 @@ final class ManageStore {
 
     // MARK: - Index loading (synchronous index reads — fast)
 
-    static func loadIndexed(from store: ProviderStore) -> [ManageReconciler.IndexedSession] {
+    nonisolated static func loadIndexed(from store: ProviderStore) -> [ManageReconciler.IndexedSession] {
         let sessions = (try? allSessions(store)) ?? []
         let sources = (try? store.allSourceFiles()) ?? []
-        let aggregates = (try? store.sessionListAggregates()) ?? [:]
         let byRaw = Dictionary(grouping: sources) { $0.sessionRawId ?? "" }
         return sessions.map { row in
             ManageReconciler.IndexedSession(
                 row: row,
                 sourceFiles: byRaw[row.rawId] ?? [],
-                aggregate: aggregates[row.id]
+                aggregate: nil   // reconcile 미사용 — sessionListAggregates() GROUP BY 비용 회피.
             )
         }
     }
 
-    static func allSessions(_ store: ProviderStore) throws -> [StoreSessionRow] {
+    nonisolated static func allSessions(_ store: ProviderStore) throws -> [StoreSessionRow] {
         var out: [StoreSessionRow] = []
         var cursor: StoreSessionPageCursor?
         repeat {

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -1,0 +1,276 @@
+//
+//  ManageStore.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+import Observation
+
+/// "Manage Sessions & Storage" 윈도우의 관찰 가능 상태. 인덱스에서 즉시
+/// 렌더하고(plan §3.1) 백그라운드 FS 실측으로 보정한다. 기존
+/// `AppStateStore`/인덱스는 건드리지 않는 창 전용 store(회귀 0).
+///
+/// provider별 `ProviderStore`·컨텍스트는 AppDelegate가 클로저로 주입한다
+/// (`sqliteFirstStartups`는 동적이라 스냅샷이 아닌 접근자로).
+@MainActor
+@Observable
+final class ManageStore {
+
+    private(set) var rows: [ManageRowModel] = []
+    var searchText: String = ""
+    var sortKey: ManageRowSort = .size
+    var sortAscending: Bool = false
+    var scope: ManageScope = .sessions
+    var selectedIDs: Set<String> = []
+    private(set) var isScanning = false
+    private(set) var provider: ProviderKind
+    /// 현재 provider가 인덱싱 중인가(인덱싱 중엔 세션이 보호되어 blocked).
+    var isIndexingNow: Bool { isIndexingProvider() }
+    /// 전체 디스크 탭(읽기전용) 항목 — 큰 점유물 내림차순.
+    private(set) var diskItems: [DiskSizer.Entry] = []
+
+    private let isIndexingProvider: @MainActor () -> Bool
+    private let storeProvider: @MainActor (ProviderKind) -> ProviderStore?
+    private let contextProvider: @MainActor (ProviderKind) -> ManageProviderContext?
+    private let requestRescan: @MainActor (ProviderKind) -> Void
+    private let rebuildIndex: @MainActor (ProviderKind) -> Void
+    /// AppKit 뷰가 갱신을 받기 위한 콜백(@Observable 자동 추적 대신 명시적).
+    @ObservationIgnored var onChange: (@MainActor () -> Void)?
+    private let scanService = ManageScanService()
+    private let trashService = ManageTrashService()
+    private var scanGeneration = 0
+
+    init(
+        provider: ProviderKind,
+        isIndexingProvider: @escaping @MainActor () -> Bool,
+        storeProvider: @escaping @MainActor (ProviderKind) -> ProviderStore?,
+        contextProvider: @escaping @MainActor (ProviderKind) -> ManageProviderContext?,
+        requestRescan: @escaping @MainActor (ProviderKind) -> Void,
+        rebuildIndex: @escaping @MainActor (ProviderKind) -> Void
+    ) {
+        self.provider = provider
+        self.isIndexingProvider = isIndexingProvider
+        self.storeProvider = storeProvider
+        self.contextProvider = contextProvider
+        self.requestRescan = requestRescan
+        self.rebuildIndex = rebuildIndex
+    }
+
+    // MARK: - Derived
+
+    var displayRows: [ManageRowModel] {
+        ManageRowFilter.apply(rows, search: searchText, sort: sortKey, ascending: sortAscending)
+    }
+    var selectedRows: [ManageRowModel] { rows.filter { selectedIDs.contains($0.id) } }
+    var selectedCount: Int { selectedIDs.count }
+    var selectedReclaimBytes: Int64 { selectedRows.reduce(0) { $0 + $1.sizeBytes } }
+
+    /// 전체 디스크 탭(읽기전용) — provider 홈의 큰 점유물을 행으로. 세션영역
+    /// 밖이므로 전부 blocked(앱 내 삭제 차단 — Reveal만).
+    var allDiskRows: [ManageRowModel] {
+        diskItems.map { entry in
+            ManageRowModel(
+                id: entry.url.path,
+                provider: provider,
+                kind: .diskItem,
+                displayTitle: entry.name,
+                projectPath: entry.url.path,
+                sizeBytes: entry.sizeBytes,
+                fileCount: 0,
+                filePaths: [entry.url.path],
+                status: .blocked,
+                classification: .danger,
+                protection: .blocked,
+                isIndexed: false,
+                existsOnDisk: true
+            )
+        }
+    }
+
+    // MARK: - Cache inspection
+
+    struct CacheInfo: Sendable, Equatable {
+        var indexBytes: Int64      // index.sqlite3 (메인)
+        var walBytes: Int64        // -wal
+        var shmBytes: Int64        // -shm
+        var snapshotBytes: Int64
+        var coverage: StoreCoverage?
+        var lastIndexed: Date?     // index.sqlite3 마지막 수정 시각
+    }
+    private(set) var cacheInfo: CacheInfo?
+
+    /// 관리 창에서 Reveal에 쓰는 provider별 저장 디렉터리.
+    var providerSupportRoot: URL {
+        LupenPaths.providerRoot(for: provider)
+    }
+
+    func loadCacheInfo() {
+        let root = LupenPaths.applicationSupportRoot()
+        let indexURL = LupenPaths.indexDatabaseURL(for: provider, appSupportRoot: root)
+        let indexBytes = DiskSizer.fileAllocatedSize(indexURL)
+        let walBytes = DiskSizer.fileAllocatedSize(URL(fileURLWithPath: indexURL.path + "-wal"))
+        let shmBytes = DiskSizer.fileAllocatedSize(URL(fileURLWithPath: indexURL.path + "-shm"))
+        let snapshotBytes = snapshotURLs(root: root).reduce(Int64(0)) { $0 + DiskSizer.fileAllocatedSize($1) }
+        let coverage = try? storeProvider(provider)?.coverage()
+        let lastIndexed = (try? FileManager.default.attributesOfItem(atPath: indexURL.path))?[.modificationDate] as? Date
+        cacheInfo = CacheInfo(
+            indexBytes: indexBytes, walBytes: walBytes, shmBytes: shmBytes,
+            snapshotBytes: snapshotBytes, coverage: coverage, lastIndexed: lastIndexed
+        )
+    }
+
+    /// 인덱스 재빌드(원본 로그 불변) — 기존 rebuild 경로 재사용.
+    func rebuildCacheIndex() {
+        rebuildIndex(provider)
+        loadCacheInfo()
+    }
+
+    /// 스냅샷 JSON 캐시만 삭제(Lupen 파생 데이터 — 재생성됨). 인덱스 DB는
+    /// 건드리지 않는다.
+    func clearSnapshots() {
+        for url in snapshotURLs(root: LupenPaths.applicationSupportRoot()) {
+            try? FileManager.default.removeItem(at: url)
+        }
+        loadCacheInfo()
+    }
+
+    private func snapshotURLs(root: URL) -> [URL] {
+        [LupenPaths.sessionCacheURL(for: provider, appSupportRoot: root),
+         LupenPaths.parseSnapshotURL(for: provider, appSupportRoot: root),
+         LupenPaths.offsetsURL(for: provider, appSupportRoot: root)]
+    }
+
+    // MARK: - Selection
+
+    /// 단일 선택 시 인스펙터에 표시할 행(여러 개면 nil → 요약).
+    var inspectedRow: ManageRowModel? {
+        selectedIDs.count == 1 ? rows.first { selectedIDs.contains($0.id) } : nil
+    }
+
+    func clearSelection() { selectedIDs = []; onChange?() }
+
+    /// 테이블 행 선택을 반영(인스펙터 + collector). 삭제 가능 여부 게이트는
+    /// performTrash가 담당하므로 선택 자체는 모든 행을 허용한다.
+    func setSelectedIDs(_ ids: Set<String>) {
+        guard ids != selectedIDs else { return }
+        selectedIDs = ids
+        onChange?()
+    }
+
+    func switchProvider(_ newProvider: ProviderKind) {
+        guard newProvider != provider else { return }
+        provider = newProvider
+        selectedIDs = []
+        load()
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard let store = storeProvider(provider), let context = contextProvider(provider) else {
+            rows = []
+            diskItems = []
+            cacheInfo = nil
+            onChange?()
+            return
+        }
+        let indexed = Self.loadIndexed(from: store)
+        let classifier = StorageClassifier(scope: context.classifierScope)
+        let indexing = isIndexingProvider()
+        let prov = provider
+
+        // 1차: 인덱스만(근사 크기) — 즉시 렌더, 잔재/미추적 판정 보류.
+        rows = ManageReconciler.reconcile(
+            provider: prov, indexed: indexed, diskFiles: [],
+            classifier: classifier, isIndexing: indexing, scanned: false
+        )
+        loadCacheInfo()
+        onChange?()
+
+        // 2차: 백그라운드 FS 실측 → 정확 크기·미추적·잔재 보정.
+        scanGeneration += 1
+        let generation = scanGeneration
+        isScanning = true
+        Task { @MainActor in
+            let disk = await self.scanService.scanSessionArea(roots: context.sessionAreaRoots)
+            let items = await self.scanService.scanDiskItems(home: context.providerHome)
+            // 더 새로운 load가 시작됐으면 이 결과는 버린다.
+            guard generation == self.scanGeneration else { return }
+            // 스캔 중 인덱싱 상태가 바뀔 수 있으니 보정 시점에 재평가.
+            self.rows = ManageReconciler.reconcile(
+                provider: prov, indexed: indexed, diskFiles: disk,
+                classifier: classifier, isIndexing: self.isIndexingProvider(), scanned: true
+            )
+            self.diskItems = items.sorted { $0.sizeBytes > $1.sizeBytes }
+            self.isScanning = false
+            self.onChange?()
+        }
+    }
+
+    // MARK: - Deletion (trash + index reconcile + Undo)
+
+    /// 행들을 휴지통으로 보내고 인덱스를 정합시킨다. 실제로 옮겨진 행의
+    /// 세션 전체 소스를 인덱스에서 제거한다(동반 디렉터리의 서브에이전트
+    /// 포함). 반환된 Outcome으로 Undo 스낵바를 띄운다.
+    @discardableResult
+    func trash(rows: [ManageRowModel]) async -> ManageTrashService.Outcome {
+        let outcome = await trashService.trash(rows.flatMap(\.trashTargets))
+        let trashed = Set(outcome.trashedPaths)
+        if let store = storeProvider(provider) {
+            var indexPaths: [String] = []
+            // 부모 파일(jsonl)이 실제로 휴지통에 간 행만 세션 전체 인덱스를
+            // 정리한다. companion 디렉터리만 성공하고 부모가 실패한 경우엔
+            // 인덱스를 유지(부모가 디스크에 남아 정합 — 부분 실패 안전).
+            for row in rows where row.filePaths.contains(where: { trashed.contains($0) }) {
+                if let raw = row.rawSessionId, let sources = try? store.sourceFiles(sessionRawId: raw) {
+                    indexPaths.append(contentsOf: sources.map(\.path))
+                } else {
+                    indexPaths.append(contentsOf: row.filePaths)
+                }
+            }
+            if !indexPaths.isEmpty {
+                try? store.deleteSources(paths: indexPaths)
+                _ = try? store.pruneSessionsWithoutSources()
+            }
+        }
+        selectedIDs = []
+        load()
+        return outcome
+    }
+
+    /// Undo — 휴지통에서 복원하고 인덱스 재등록을 트리거(rescan)한 뒤 재렌더.
+    func undoTrash(_ entries: [ManageTrashService.RestoreEntry]) async {
+        await trashService.restore(entries)
+        requestRescan(provider)
+        load()
+    }
+
+    // MARK: - Index loading (synchronous index reads — fast)
+
+    static func loadIndexed(from store: ProviderStore) -> [ManageReconciler.IndexedSession] {
+        let sessions = (try? allSessions(store)) ?? []
+        let sources = (try? store.allSourceFiles()) ?? []
+        let aggregates = (try? store.sessionListAggregates()) ?? [:]
+        let byRaw = Dictionary(grouping: sources) { $0.sessionRawId ?? "" }
+        return sessions.map { row in
+            ManageReconciler.IndexedSession(
+                row: row,
+                sourceFiles: byRaw[row.rawId] ?? [],
+                aggregate: aggregates[row.id]
+            )
+        }
+    }
+
+    static func allSessions(_ store: ProviderStore) throws -> [StoreSessionRow] {
+        var out: [StoreSessionRow] = []
+        var cursor: StoreSessionPageCursor?
+        repeat {
+            let page = try store.sessionPage(visibleOnly: false, projectPath: nil, limit: 500, cursor: cursor)
+            out.append(contentsOf: page.rows)
+            cursor = page.nextCursor
+        } while cursor != nil
+        return out
+    }
+}

--- a/Lupen/Domain/Manage/ManageTitleFormatter.swift
+++ b/Lupen/Domain/Manage/ManageTitleFormatter.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
-/// 세션 행의 1차 제목을 만든다. 첫 프롬프트를 식별자로 쓰되, 사용자가
-/// 직접 붙인 이름(`/rename`)이 있으면 그게 가장 권위 있다(Session.swift 주석).
+/// Builds the primary title for a session row. The first prompt is used as the
+/// identifier, but a name the user set themselves (`/rename`) is the most
+/// authoritative if present (see Session.swift comments).
 ///
-/// 우선순위: `customTitle`(사용자 지정) → `firstPrompt`(내용) →
-/// `cachedTitle`(자동) → 폴백. (plan §2를 다듬음 — 식별력 우선.)
-/// 표시 문자열은 개행·코드펜스·연속 공백을 한 줄로 정규화한다(research §B-4).
+/// Priority: `customTitle` (user-set) → `firstPrompt` (content) →
+/// `cachedTitle` (automatic) → fallback. (Refines plan §2 — identifiability first.)
+/// The display string normalizes newlines, code fences, and runs of whitespace
+/// into a single line (research §B-4).
 enum ManageTitleFormatter {
 
     static let emptyFallback = "(Untitled session)"
@@ -31,7 +33,7 @@ enum ManageTitleFormatter {
         return cleaned.isEmpty ? emptyFallback : truncate(cleaned, maxLength: maxLength)
     }
 
-    /// 개행/탭/코드펜스를 공백으로 접고 연속 공백을 하나로 만든다.
+    /// Folds newlines/tabs/code fences into spaces and collapses runs of whitespace into one.
     static func clean(_ raw: String) -> String {
         let noFence = raw.replacingOccurrences(of: "```", with: " ")
         return noFence
@@ -39,7 +41,7 @@ enum ManageTitleFormatter {
             .joined(separator: " ")
     }
 
-    /// `maxLength`를 넘으면 말줄임(…)으로 자른다.
+    /// Truncates with an ellipsis (…) when it exceeds `maxLength`.
     static func truncate(_ s: String, maxLength: Int = 80) -> String {
         guard maxLength > 1, s.count > maxLength else { return s }
         let head = s.prefix(maxLength - 1).trimmingCharacters(in: .whitespaces)

--- a/Lupen/Domain/Manage/ManageTitleFormatter.swift
+++ b/Lupen/Domain/Manage/ManageTitleFormatter.swift
@@ -1,0 +1,53 @@
+//
+//  ManageTitleFormatter.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 세션 행의 1차 제목을 만든다. 첫 프롬프트를 식별자로 쓰되, 사용자가
+/// 직접 붙인 이름(`/rename`)이 있으면 그게 가장 권위 있다(Session.swift 주석).
+///
+/// 우선순위: `customTitle`(사용자 지정) → `firstPrompt`(내용) →
+/// `cachedTitle`(자동) → 폴백. (plan §2를 다듬음 — 식별력 우선.)
+/// 표시 문자열은 개행·코드펜스·연속 공백을 한 줄로 정규화한다(research §B-4).
+enum ManageTitleFormatter {
+
+    static let emptyFallback = "(Untitled session)"
+
+    static func sessionTitle(
+        firstPrompt: String?,
+        cachedTitle: String?,
+        customTitle: String?,
+        maxLength: Int = 80
+    ) -> String {
+        let chosen = nonEmpty(customTitle)
+            ?? nonEmpty(firstPrompt)
+            ?? nonEmpty(cachedTitle)
+        guard let chosen else { return emptyFallback }
+        let cleaned = clean(chosen)
+        return cleaned.isEmpty ? emptyFallback : truncate(cleaned, maxLength: maxLength)
+    }
+
+    /// 개행/탭/코드펜스를 공백으로 접고 연속 공백을 하나로 만든다.
+    static func clean(_ raw: String) -> String {
+        let noFence = raw.replacingOccurrences(of: "```", with: " ")
+        return noFence
+            .split(whereSeparator: { $0 == "\n" || $0 == "\r" || $0 == "\t" || $0 == " " })
+            .joined(separator: " ")
+    }
+
+    /// `maxLength`를 넘으면 말줄임(…)으로 자른다.
+    static func truncate(_ s: String, maxLength: Int = 80) -> String {
+        guard maxLength > 1, s.count > maxLength else { return s }
+        let head = s.prefix(maxLength - 1).trimmingCharacters(in: .whitespaces)
+        return head + "…"
+    }
+
+    private static func nonEmpty(_ s: String?) -> String? {
+        guard let s, !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return s
+    }
+}

--- a/Lupen/Domain/Manage/ManageTrashService.swift
+++ b/Lupen/Domain/Manage/ManageTrashService.swift
@@ -7,16 +7,17 @@
 
 import Foundation
 
-/// 휴지통 이동과 복원(Undo)을 담당. 영구 삭제(`removeItem`)는 제공하지 않는다
-/// — 안전 최우선(plan §13). 사용자가 영구 삭제를 원하면 Finder 휴지통을
-/// 비운다. 백그라운드(detached)에서 실행해 메인스레드 블로킹 0.
+/// Handles moving items to Trash and restoring them (Undo). It does not offer
+/// permanent deletion (`removeItem`) — safety first (plan §13). If the user
+/// wants permanent deletion, they empty the Finder Trash. Runs in the background
+/// (detached) for zero main-thread blocking.
 struct ManageTrashService: Sendable {
 
-    /// 한 번 휴지통 작업의 결과.
+    /// The result of a single Trash operation.
     struct Outcome: Sendable, Equatable {
         var trashedPaths: [String] = []
         var failedPaths: [String] = []
-        /// Undo용 (원래 경로 → 휴지통 안 URL).
+        /// For Undo (original path → URL inside Trash).
         var restore: [RestoreEntry] = []
     }
 
@@ -25,8 +26,9 @@ struct ManageTrashService: Sendable {
         let trashedURL: URL
     }
 
-    /// `paths`를 휴지통으로 이동. 이미 없는 경로는 조용히 건너뛴다(성공 취급
-    /// 아님 — trashed에 안 넣음). 대량 시 Put Back 보존을 위해 한 항목씩 처리.
+    /// Moves `paths` to Trash. Paths that no longer exist are silently skipped
+    /// (not treated as success — not added to trashed). Processes one item at a
+    /// time to preserve Put Back in bulk operations.
     func trash(_ paths: [String]) async -> Outcome {
         await Task.detached(priority: .userInitiated) {
             var outcome = Outcome()
@@ -49,8 +51,8 @@ struct ManageTrashService: Sendable {
         }.value
     }
 
-    /// Undo — 휴지통의 항목을 원래 경로로 되돌린다. 원래 경로에 이미 무언가
-    /// 있으면(재생성) 건너뛴다.
+    /// Undo — restores items from Trash to their original paths. Skips when
+    /// something already exists at the original path (recreated).
     func restore(_ entries: [RestoreEntry]) async {
         await Task.detached(priority: .userInitiated) {
             let fm = FileManager.default

--- a/Lupen/Domain/Manage/ManageTrashService.swift
+++ b/Lupen/Domain/Manage/ManageTrashService.swift
@@ -1,0 +1,64 @@
+//
+//  ManageTrashService.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 휴지통 이동과 복원(Undo)을 담당. 영구 삭제(`removeItem`)는 제공하지 않는다
+/// — 안전 최우선(plan §13). 사용자가 영구 삭제를 원하면 Finder 휴지통을
+/// 비운다. 백그라운드(detached)에서 실행해 메인스레드 블로킹 0.
+struct ManageTrashService: Sendable {
+
+    /// 한 번 휴지통 작업의 결과.
+    struct Outcome: Sendable, Equatable {
+        var trashedPaths: [String] = []
+        var failedPaths: [String] = []
+        /// Undo용 (원래 경로 → 휴지통 안 URL).
+        var restore: [RestoreEntry] = []
+    }
+
+    struct RestoreEntry: Sendable, Equatable {
+        let originalPath: String
+        let trashedURL: URL
+    }
+
+    /// `paths`를 휴지통으로 이동. 이미 없는 경로는 조용히 건너뛴다(성공 취급
+    /// 아님 — trashed에 안 넣음). 대량 시 Put Back 보존을 위해 한 항목씩 처리.
+    func trash(_ paths: [String]) async -> Outcome {
+        await Task.detached(priority: .userInitiated) {
+            var outcome = Outcome()
+            let fm = FileManager.default
+            for path in paths {
+                guard fm.fileExists(atPath: path) else { continue }
+                let url = URL(fileURLWithPath: path)
+                var resulting: NSURL?
+                do {
+                    try fm.trashItem(at: url, resultingItemURL: &resulting)
+                    outcome.trashedPaths.append(path)
+                    if let resultingURL = resulting as URL? {
+                        outcome.restore.append(RestoreEntry(originalPath: path, trashedURL: resultingURL))
+                    }
+                } catch {
+                    outcome.failedPaths.append(path)
+                }
+            }
+            return outcome
+        }.value
+    }
+
+    /// Undo — 휴지통의 항목을 원래 경로로 되돌린다. 원래 경로에 이미 무언가
+    /// 있으면(재생성) 건너뛴다.
+    func restore(_ entries: [RestoreEntry]) async {
+        await Task.detached(priority: .userInitiated) {
+            let fm = FileManager.default
+            for entry in entries {
+                let original = URL(fileURLWithPath: entry.originalPath)
+                guard !fm.fileExists(atPath: entry.originalPath) else { continue }
+                try? fm.moveItem(at: entry.trashedURL, to: original)
+            }
+        }.value
+    }
+}

--- a/Lupen/Domain/Manage/StorageClassifier.swift
+++ b/Lupen/Domain/Manage/StorageClassifier.swift
@@ -82,14 +82,16 @@ struct StorageClassifier: Sendable {
         ]
         if blockedSuffixes.contains(where: { name.hasSuffix($0) }) { return true }
 
-        // auth / credentials / config 계열.
-        let blockedPrefixes = ["auth", "credentials", ".credentials", "config", ".env"]
-        if blockedPrefixes.contains(where: { name.hasPrefix($0) }) { return true }
-
-        let blockedExact = ["config.toml", "config.json", "auth.json", ".env"]
-        if blockedExact.contains(name) { return true }
-
-        return false
+        // auth / credentials / config 계열 — 정확 파일명만 차단한다. prefix
+        // 매칭(`hasPrefix`)은 `configuration-notes.jsonl`처럼 정상 세션 로그까지
+        // 잠그므로 쓰지 않는다. 실제 민감 파일(auth.json/.credentials.json 등)은
+        // provider 홈 루트에 있어 isInsideSessionArea=false로 이미 차단되며,
+        // 여기 exact 목록은 그 위에 더하는 다층 방어다.
+        let blockedExact = [
+            "config.toml", "config.json", "auth.json", ".env",
+            "credentials.json", ".credentials.json",
+        ]
+        return blockedExact.contains(name)
     }
 
     // MARK: - Containment

--- a/Lupen/Domain/Manage/StorageClassifier.swift
+++ b/Lupen/Domain/Manage/StorageClassifier.swift
@@ -7,32 +7,33 @@
 
 import Foundation
 
-/// 경로를 삭제 안전 분류로 매핑한다. **allowlist 기반** — 명시적으로
-/// 안전하다고 판정된 경로만 `deletable`이 되고, 규칙 밖은 모두 `locked`.
+/// Maps a path to a deletion-safety classification. **Allowlist-based** —
+/// only paths explicitly judged safe become `deletable`; anything outside
+/// the rules is `locked`.
 ///
-/// 절대 제약(plan §5.1):
-/// - auth / config / 앱 상태 DB(`*.sqlite`)는 **하드 차단**(`blocked`).
-/// - 인덱싱 중·세션영역 밖은 차단.
-/// - 세션영역(`~/.claude/projects`·`~/.codex/sessions`) 내부만 삭제 허용.
+/// Absolute constraints (plan §5.1):
+/// - auth / config / app-state DBs (`*.sqlite`) are **hard-blocked** (`blocked`).
+/// - Blocked while indexing or outside the session area.
+/// - Deletion allowed only inside the session area (`~/.claude/projects`·`~/.codex/sessions`).
 struct StorageClassifier: Sendable {
 
-    /// provider별 영역 정의. `sessionAreaRoots` 안의 파일만 삭제 후보가 된다.
+    /// Per-provider area definition. Only files inside `sessionAreaRoots` are deletion candidates.
     struct Scope: Sendable, Equatable {
-        /// provider 홈 (`~/.claude` 또는 `~/.codex`).
+        /// Provider home (`~/.claude` or `~/.codex`).
         let providerHome: URL
-        /// 정리 가능한 세션영역 루트 (`projects/` 또는 `sessions/`).
+        /// Cleanable session-area roots (`projects/` or `sessions/`).
         let sessionAreaRoots: [URL]
     }
 
     let scope: Scope
-    /// "활성"으로 간주할 최근 수정 임계. 이 안에 수정된 항목은 caution.
-    var activeWindow: TimeInterval = 600  // 10분
+    /// Recent-modification threshold to treat as "active". Items modified within this window are caution.
+    var activeWindow: TimeInterval = 600  // 10 minutes
 
-    /// 경로 하나를 분류한다.
+    /// Classify a single path.
     /// - Parameters:
-    ///   - isIndexed: 인덱스가 추적 중인 항목인가(미추적이면 caution↑).
-    ///   - isIndexing: 현재 해당 provider가 인덱싱 중인가(맞으면 차단).
-    ///   - lastModified: 마지막 수정 시각(활성 보호 판정).
+    ///   - isIndexed: Whether the index is tracking this item (untracked raises caution).
+    ///   - isIndexing: Whether this provider is currently indexing (if so, block).
+    ///   - lastModified: Last-modified time (for active protection).
     func classify(
         path: String,
         isIndexed: Bool,
@@ -43,38 +44,38 @@ struct StorageClassifier: Sendable {
         let url = URL(fileURLWithPath: path).standardizedFileURL
         let name = url.lastPathComponent.lowercased()
 
-        // 1) 하드 차단: auth/config/앱 상태 DB/lock — 어디에 있든 막는다.
+        // 1) Hard-block: auth/config/app-state DB/lock — blocked wherever they are.
         if Self.isHardBlocked(name: name) {
             return (.danger, .blocked)
         }
 
-        // 2) 인덱싱 중 — 안전을 위해 일괄 차단.
+        // 2) While indexing — block everything for safety.
         if isIndexing {
             return (.danger, .blocked)
         }
 
-        // 3) 세션영역 내부가 아니면 정리 불가.
+        // 3) Not cleanable if outside the session area.
         guard isInsideSessionArea(url) else {
-            // provider 홈 안이긴 하면(전체 디스크 항목) 읽기전용 차단,
-            // 완전히 밖이면 미분류 잠김.
+            // If inside the provider home (all-disk item), read-only block;
+            // if entirely outside, unclassified and locked.
             return isInsideProviderHome(url) ? (.danger, .blocked) : (.unclassified, .locked)
         }
 
-        // 4) 세션영역 내부 — deletable. 위험도만 분류.
+        // 4) Inside the session area — deletable. Classify only the risk level.
         if let lastModified, now.timeIntervalSince(lastModified) < activeWindow {
-            return (.caution, .deletable)   // 최근 활동 — 주의하되 삭제 가능
+            return (.caution, .deletable)   // recent activity — caution, but deletable
         }
         if !isIndexed {
-            return (.caution, .deletable)   // 미추적 — 주의
+            return (.caution, .deletable)   // untracked — caution
         }
         return (.safe, .deletable)
     }
 
     // MARK: - Hard-block rules
 
-    /// auth/config/앱 상태 DB/lock 파일인지. 파일명 소문자 기준.
+    /// Whether this is an auth/config/app-state DB/lock file. Lowercased filename.
     static func isHardBlocked(name: String) -> Bool {
-        // SQLite/DB/lock 계열 (앱 상태 — 절대 삭제 금지).
+        // SQLite/DB/lock family (app state — never delete).
         let blockedSuffixes = [
             ".sqlite", ".sqlite3", ".db",
             ".sqlite-wal", ".sqlite-shm", ".sqlite3-wal", ".sqlite3-shm",
@@ -82,11 +83,12 @@ struct StorageClassifier: Sendable {
         ]
         if blockedSuffixes.contains(where: { name.hasSuffix($0) }) { return true }
 
-        // auth / credentials / config 계열 — 정확 파일명만 차단한다. prefix
-        // 매칭(`hasPrefix`)은 `configuration-notes.jsonl`처럼 정상 세션 로그까지
-        // 잠그므로 쓰지 않는다. 실제 민감 파일(auth.json/.credentials.json 등)은
-        // provider 홈 루트에 있어 isInsideSessionArea=false로 이미 차단되며,
-        // 여기 exact 목록은 그 위에 더하는 다층 방어다.
+        // auth / credentials / config family — block exact filenames only.
+        // Prefix matching (`hasPrefix`) would lock legitimate session logs
+        // like `configuration-notes.jsonl`, so it isn't used. Real sensitive
+        // files (auth.json/.credentials.json, etc.) live at the provider home
+        // root and are already blocked by isInsideSessionArea=false; this exact
+        // list is a defense-in-depth layer on top of that.
         let blockedExact = [
             "config.toml", "config.json", "auth.json", ".env",
             "credentials.json", ".credentials.json",
@@ -104,8 +106,9 @@ struct StorageClassifier: Sendable {
         Self.isDescendant(url, of: scope.providerHome)
     }
 
-    /// `url`이 `root`의 (엄격한) 하위 경로인가. 경로 컴포넌트 prefix 비교라
-    /// `..`/심볼릭이 섞여도 `standardizedFileURL`로 정규화 후 판정한다.
+    /// Whether `url` is a (strict) descendant of `root`. Path-component prefix
+    /// comparison, normalized via `standardizedFileURL` first so `..`/symlinks
+    /// in the mix are handled.
     static func isDescendant(_ url: URL, of root: URL) -> Bool {
         let u = url.standardizedFileURL.pathComponents
         let r = root.standardizedFileURL.pathComponents

--- a/Lupen/Domain/Manage/StorageClassifier.swift
+++ b/Lupen/Domain/Manage/StorageClassifier.swift
@@ -1,0 +1,113 @@
+//
+//  StorageClassifier.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 경로를 삭제 안전 분류로 매핑한다. **allowlist 기반** — 명시적으로
+/// 안전하다고 판정된 경로만 `deletable`이 되고, 규칙 밖은 모두 `locked`.
+///
+/// 절대 제약(plan §5.1):
+/// - auth / config / 앱 상태 DB(`*.sqlite`)는 **하드 차단**(`blocked`).
+/// - 인덱싱 중·세션영역 밖은 차단.
+/// - 세션영역(`~/.claude/projects`·`~/.codex/sessions`) 내부만 삭제 허용.
+struct StorageClassifier: Sendable {
+
+    /// provider별 영역 정의. `sessionAreaRoots` 안의 파일만 삭제 후보가 된다.
+    struct Scope: Sendable, Equatable {
+        /// provider 홈 (`~/.claude` 또는 `~/.codex`).
+        let providerHome: URL
+        /// 정리 가능한 세션영역 루트 (`projects/` 또는 `sessions/`).
+        let sessionAreaRoots: [URL]
+    }
+
+    let scope: Scope
+    /// "활성"으로 간주할 최근 수정 임계. 이 안에 수정된 항목은 caution.
+    var activeWindow: TimeInterval = 600  // 10분
+
+    /// 경로 하나를 분류한다.
+    /// - Parameters:
+    ///   - isIndexed: 인덱스가 추적 중인 항목인가(미추적이면 caution↑).
+    ///   - isIndexing: 현재 해당 provider가 인덱싱 중인가(맞으면 차단).
+    ///   - lastModified: 마지막 수정 시각(활성 보호 판정).
+    func classify(
+        path: String,
+        isIndexed: Bool,
+        isIndexing: Bool,
+        lastModified: Date?,
+        now: Date = Date()
+    ) -> (classification: StorageClassification, protection: StorageProtection) {
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        let name = url.lastPathComponent.lowercased()
+
+        // 1) 하드 차단: auth/config/앱 상태 DB/lock — 어디에 있든 막는다.
+        if Self.isHardBlocked(name: name) {
+            return (.danger, .blocked)
+        }
+
+        // 2) 인덱싱 중 — 안전을 위해 일괄 차단.
+        if isIndexing {
+            return (.danger, .blocked)
+        }
+
+        // 3) 세션영역 내부가 아니면 정리 불가.
+        guard isInsideSessionArea(url) else {
+            // provider 홈 안이긴 하면(전체 디스크 항목) 읽기전용 차단,
+            // 완전히 밖이면 미분류 잠김.
+            return isInsideProviderHome(url) ? (.danger, .blocked) : (.unclassified, .locked)
+        }
+
+        // 4) 세션영역 내부 — deletable. 위험도만 분류.
+        if let lastModified, now.timeIntervalSince(lastModified) < activeWindow {
+            return (.caution, .deletable)   // 최근 활동 — 주의하되 삭제 가능
+        }
+        if !isIndexed {
+            return (.caution, .deletable)   // 미추적 — 주의
+        }
+        return (.safe, .deletable)
+    }
+
+    // MARK: - Hard-block rules
+
+    /// auth/config/앱 상태 DB/lock 파일인지. 파일명 소문자 기준.
+    static func isHardBlocked(name: String) -> Bool {
+        // SQLite/DB/lock 계열 (앱 상태 — 절대 삭제 금지).
+        let blockedSuffixes = [
+            ".sqlite", ".sqlite3", ".db",
+            ".sqlite-wal", ".sqlite-shm", ".sqlite3-wal", ".sqlite3-shm",
+            ".db-wal", ".db-shm", ".lock"
+        ]
+        if blockedSuffixes.contains(where: { name.hasSuffix($0) }) { return true }
+
+        // auth / credentials / config 계열.
+        let blockedPrefixes = ["auth", "credentials", ".credentials", "config", ".env"]
+        if blockedPrefixes.contains(where: { name.hasPrefix($0) }) { return true }
+
+        let blockedExact = ["config.toml", "config.json", "auth.json", ".env"]
+        if blockedExact.contains(name) { return true }
+
+        return false
+    }
+
+    // MARK: - Containment
+
+    func isInsideSessionArea(_ url: URL) -> Bool {
+        scope.sessionAreaRoots.contains { Self.isDescendant(url, of: $0) }
+    }
+
+    func isInsideProviderHome(_ url: URL) -> Bool {
+        Self.isDescendant(url, of: scope.providerHome)
+    }
+
+    /// `url`이 `root`의 (엄격한) 하위 경로인가. 경로 컴포넌트 prefix 비교라
+    /// `..`/심볼릭이 섞여도 `standardizedFileURL`로 정규화 후 판정한다.
+    static func isDescendant(_ url: URL, of root: URL) -> Bool {
+        let u = url.standardizedFileURL.pathComponents
+        let r = root.standardizedFileURL.pathComponents
+        guard u.count > r.count else { return false }
+        return Array(u.prefix(r.count)) == r
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageCacheView.swift
+++ b/Lupen/UI/ManageSessions/ManageCacheView.swift
@@ -1,0 +1,95 @@
+//
+//  ManageCacheView.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import SwiftUI
+
+/// Lupen 캐시 점검 탭 — 인덱스/스냅샷 크기(파일별), 인덱싱 완료율·실패·마지막
+/// 시각을 보고하고 재빌드·정리·Reveal을 제공한다. UI 문자열은 영어(앱 전역 정책).
+struct ManageCacheView: View {
+    let store: ManageStore
+    let onRebuild: () -> Void
+    let onClearSnapshots: () -> Void
+    let onReveal: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Lupen Cache").font(.title3).bold()
+                Text(store.provider == .claudeCode ? "Claude Code index" : "Codex index")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                if let info = store.cacheInfo {
+                    card("Storage") {
+                        row("index.sqlite3", byteString(info.indexBytes))
+                        if info.walBytes > 0 { row("WAL", byteString(info.walBytes)) }
+                        if info.shmBytes > 0 { row("SHM", byteString(info.shmBytes)) }
+                        row("Snapshot cache", byteString(info.snapshotBytes))
+                        Divider()
+                        row("Total", byteString(info.indexBytes + info.walBytes + info.shmBytes + info.snapshotBytes), bold: true)
+                    }
+                    if let coverage = info.coverage {
+                        card("Indexing") {
+                            row("Imported", "\(coverage.importedSources) / \(coverage.totalSources)")
+                            if coverage.failedSources > 0 {
+                                row("Failed", "⚠️ \(coverage.failedSources)", valueColor: .orange)
+                            }
+                            if coverage.pendingSources > 0 {
+                                row("Pending", "\(coverage.pendingSources)", valueColor: .secondary)
+                            }
+                            if let last = info.lastIndexed {
+                                row("Last indexed", last.formatted(date: .abbreviated, time: .shortened))
+                            }
+                            row("Status", coverage.isComplete ? "✅ Complete" : "⏳ In progress")
+                        }
+                    }
+                } else {
+                    Text("Loading cache info…").foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 8) {
+                    Button { onRebuild() } label: { Label("Rebuild Index", systemImage: "arrow.clockwise") }
+                    Button { onClearSnapshots() } label: { Label("Clear Snapshot Cache", systemImage: "trash") }
+                    Button { onReveal() } label: { Label("Open Application Support", systemImage: "folder") }
+                }
+                .controlSize(.regular)
+
+                Text("Rebuild and clear don't touch your original session logs.")
+                    .font(.caption).foregroundStyle(.tertiary)
+                Spacer()
+            }
+            .padding(20)
+            .frame(maxWidth: 560, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func card<Content: View>(_ title: String, @ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            content()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.25), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func row(_ key: String, _ value: String, bold: Bool = false, valueColor: Color? = nil) -> some View {
+        HStack {
+            Text(key).foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .fontWeight(bold ? .semibold : .regular)
+                .monospacedDigit()
+                .foregroundStyle(valueColor ?? .primary)
+        }
+        .font(.callout)
+    }
+
+    private func byteString(_ bytes: Int64) -> String {
+        bytes == 0 ? "0 KB" : ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageCacheView.swift
+++ b/Lupen/UI/ManageSessions/ManageCacheView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-/// Lupen 캐시 점검 탭 — 인덱스/스냅샷 크기(파일별), 인덱싱 완료율·실패·마지막
-/// 시각을 보고하고 재빌드·정리·Reveal을 제공한다. UI 문자열은 영어(앱 전역 정책).
+/// Lupen cache inspection tab — reports index/snapshot size (per file), indexing
+/// completion rate/failures/last time, and offers rebuild/cleanup/Reveal. UI
+/// strings are English (app-wide policy).
 struct ManageCacheView: View {
     let store: ManageStore
     let onRebuild: () -> Void

--- a/Lupen/UI/ManageSessions/ManageInspectorView.swift
+++ b/Lupen/UI/ManageSessions/ManageInspectorView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 /// 우측 인스펙터 — 단일 선택 행의 상세, 또는 다중 선택 요약. Sessions 탭에서만
-/// 노출(ViewController가 제어). 분류(안전/주의)는 표시하지 않는다 — 삭제 시
-/// 얼럿으로만 작동. UI 문자열은 영어(앱 전역 정책).
+/// 노출(ViewController가 제어). 분류는 표시하지 않고 상태(비정상)만 박스로
+/// 안내. UI 문자열은 영어(앱 전역 정책).
 struct ManageInspectorView: View {
     let store: ManageStore
     let actions: ManageRowActions
@@ -61,18 +61,7 @@ struct ManageInspectorView: View {
             Text(row.provider == .claudeCode ? "Claude Code session" : "Codex session")
                 .font(.caption).foregroundStyle(.secondary)
 
-            if row.status != .normal {
-                HStack(alignment: .top, spacing: 6) {
-                    Text(row.status.emoji)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(row.status.label).font(.caption).fontWeight(.semibold)
-                        Text(row.status.detailDescription).font(.caption2).foregroundStyle(.secondary)
-                    }
-                }
-                .padding(8)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
-            }
+            if row.status != .normal { statusBox(row) }
 
             VStack(alignment: .leading, spacing: 5) {
                 metaRow("Path", row.projectPath ?? "—")
@@ -100,6 +89,19 @@ struct ManageInspectorView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private func statusBox(_ row: ManageRowModel) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(row.status.emoji)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.status.label).font(.caption).fontWeight(.semibold)
+                Text(row.status.detailDescription).font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+    }
+
     private func metaRow(_ key: String, _ value: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(key).foregroundStyle(.tertiary).frame(width: 56, alignment: .leading)
@@ -110,20 +112,24 @@ struct ManageInspectorView: View {
     @ViewBuilder
     private func actionButtons(_ row: ManageRowModel) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            if row.kind == .session {
-                Button { actions.resume(row) } label: { Label("Resume", systemImage: "play.fill") }
-                Button { actions.copyCommand(row) } label: { Label("Copy Resume Command", systemImage: "doc.on.doc") }
-            }
-            Button { actions.reveal(row) } label: { Label("Reveal in Finder", systemImage: "folder") }
-            if row.projectPath != nil {
-                Button { actions.openFolder(row) } label: { Label("Open Project Folder", systemImage: "folder.badge.gearshape") }
-                Button { actions.openTerminal(row) } label: { Label("Open in Terminal", systemImage: "terminal") }
-            }
-            if row.kind == .session {
-                Button { actions.export(row) } label: { Label("Export…", systemImage: "square.and.arrow.up") }
-            }
-            if row.protection == .deletable {
-                Button(role: .destructive) { actions.trashRow(row) } label: { Label("Move to Trash", systemImage: "trash") }
+            if row.kind == .diskItem {
+                Button { actions.reveal(row) } label: { Label("Reveal in Finder", systemImage: "folder") }
+            } else {
+                if row.kind == .session {
+                    Button { actions.resume(row) } label: { Label("Resume", systemImage: "play.fill") }
+                    Button { actions.copyCommand(row) } label: { Label("Copy Resume Command", systemImage: "doc.on.doc") }
+                }
+                Button { actions.reveal(row) } label: { Label("Reveal in Finder", systemImage: "folder") }
+                if row.projectPath != nil {
+                    Button { actions.openFolder(row) } label: { Label("Open Project Folder", systemImage: "folder.badge.gearshape") }
+                    Button { actions.openTerminal(row) } label: { Label("Open in Terminal", systemImage: "terminal") }
+                }
+                if row.kind == .session {
+                    Button { actions.export(row) } label: { Label("Export…", systemImage: "square.and.arrow.up") }
+                }
+                if row.protection == .deletable {
+                    Button(role: .destructive) { actions.trashRow(row) } label: { Label("Move to Trash", systemImage: "trash") }
+                }
             }
         }
         .buttonStyle(.bordered)

--- a/Lupen/UI/ManageSessions/ManageInspectorView.swift
+++ b/Lupen/UI/ManageSessions/ManageInspectorView.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 
-/// 우측 인스펙터 — 단일 선택 행의 상세, 또는 다중 선택 요약. Sessions 탭에서만
-/// 노출(ViewController가 제어). 분류는 표시하지 않고 상태(비정상)만 박스로
-/// 안내. UI 문자열은 영어(앱 전역 정책).
+/// Right inspector — detail of the single selected row, or a multi-selection
+/// summary. Shown only on the Sessions tab (controlled by the ViewController).
+/// Doesn't show classification; surfaces only the status (abnormal) in a box.
+/// UI strings are English (app-wide policy).
 struct ManageInspectorView: View {
     let store: ManageStore
     let actions: ManageRowActions

--- a/Lupen/UI/ManageSessions/ManageInspectorView.swift
+++ b/Lupen/UI/ManageSessions/ManageInspectorView.swift
@@ -1,0 +1,139 @@
+//
+//  ManageInspectorView.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import SwiftUI
+
+/// 우측 인스펙터 — 단일 선택 행의 상세, 또는 다중 선택 요약. Sessions 탭에서만
+/// 노출(ViewController가 제어). 분류(안전/주의)는 표시하지 않는다 — 삭제 시
+/// 얼럿으로만 작동. UI 문자열은 영어(앱 전역 정책).
+struct ManageInspectorView: View {
+    let store: ManageStore
+    let actions: ManageRowActions
+
+    var body: some View {
+        ScrollView {
+            content.padding(16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.selectedCount > 1 {
+            multiSelection
+        } else if let row = store.inspectedRow {
+            detail(row)
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "sidebar.right").font(.largeTitle).foregroundStyle(.tertiary)
+            Text("Select an item to see details.")
+                .font(.callout).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 220)
+    }
+
+    private var multiSelection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("\(store.selectedCount) selected").font(.headline)
+            Text("Reclaims ~\(byteString(store.selectedReclaimBytes))")
+                .foregroundStyle(.secondary)
+            Button(role: .destructive) { actions.trashSelected() } label: {
+                Label("Move Selected to Trash", systemImage: "trash")
+            }
+            .buttonStyle(.bordered)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func detail(_ row: ManageRowModel) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(row.displayTitle).font(.headline).lineLimit(3)
+            Text(row.provider == .claudeCode ? "Claude Code session" : "Codex session")
+                .font(.caption).foregroundStyle(.secondary)
+
+            if row.status != .normal {
+                HStack(alignment: .top, spacing: 6) {
+                    Text(row.status.emoji)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.status.label).font(.caption).fontWeight(.semibold)
+                        Text(row.status.detailDescription).font(.caption2).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                metaRow("Path", row.projectPath ?? "—")
+                if let branch = row.branch, !branch.isEmpty { metaRow("Branch", "⎇ \(branch)") }
+                metaRow("Size", "\(byteString(row.sizeBytes)) · \(row.fileCount) files")
+                if let created = row.createdAt { metaRow("Created", dateString(created)) }
+                if let updated = row.lastActivity { metaRow("Updated", dateString(updated)) }
+            }
+            .font(.caption)
+
+            if let prompt = row.firstPrompt, !prompt.isEmpty {
+                Text("First prompt").font(.caption).foregroundStyle(.secondary)
+                ScrollView {
+                    Text(prompt).font(.caption).textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 90)
+                .padding(8)
+                .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            actionButtons(row)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func metaRow(_ key: String, _ value: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(key).foregroundStyle(.tertiary).frame(width: 56, alignment: .leading)
+            Text(value).foregroundStyle(.primary).textSelection(.enabled)
+        }
+    }
+
+    @ViewBuilder
+    private func actionButtons(_ row: ManageRowModel) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if row.kind == .session {
+                Button { actions.resume(row) } label: { Label("Resume", systemImage: "play.fill") }
+                Button { actions.copyCommand(row) } label: { Label("Copy Resume Command", systemImage: "doc.on.doc") }
+            }
+            Button { actions.reveal(row) } label: { Label("Reveal in Finder", systemImage: "folder") }
+            if row.projectPath != nil {
+                Button { actions.openFolder(row) } label: { Label("Open Project Folder", systemImage: "folder.badge.gearshape") }
+                Button { actions.openTerminal(row) } label: { Label("Open in Terminal", systemImage: "terminal") }
+            }
+            if row.kind == .session {
+                Button { actions.export(row) } label: { Label("Export…", systemImage: "square.and.arrow.up") }
+            }
+            if row.protection == .deletable {
+                Button(role: .destructive) { actions.trashRow(row) } label: { Label("Move to Trash", systemImage: "trash") }
+            }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+    }
+
+    private func byteString(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+    private func dateString(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .shortened)
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageRowActions.swift
+++ b/Lupen/UI/ManageSessions/ManageRowActions.swift
@@ -1,0 +1,23 @@
+//
+//  ManageRowActions.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import Foundation
+
+/// 인스펙터·컨텍스트 메뉴 액션 묶음. `ManageViewController`가 구성해
+/// SwiftUI 인스펙터에 주입한다(뷰는 동작 구현을 모름 — 분리).
+struct ManageRowActions {
+    var resume: (ManageRowModel) -> Void
+    var reveal: (ManageRowModel) -> Void
+    var openFolder: (ManageRowModel) -> Void
+    var openTerminal: (ManageRowModel) -> Void
+    var copyCommand: (ManageRowModel) -> Void
+    var export: (ManageRowModel) -> Void
+    /// 단일 행 휴지통(P4에서 마찰·Undo 연결).
+    var trashRow: (ManageRowModel) -> Void
+    /// 선택 묶음 휴지통(collector — P4).
+    var trashSelected: () -> Void
+}

--- a/Lupen/UI/ManageSessions/ManageRowActions.swift
+++ b/Lupen/UI/ManageSessions/ManageRowActions.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-/// 인스펙터·컨텍스트 메뉴 액션 묶음. `ManageViewController`가 구성해
-/// SwiftUI 인스펙터에 주입한다(뷰는 동작 구현을 모름 — 분리).
+/// Bundle of inspector/context-menu actions. `ManageViewController` builds it
+/// and injects it into the SwiftUI inspector (the view doesn't know the behavior
+/// implementation — separation).
 struct ManageRowActions {
     var resume: (ManageRowModel) -> Void
     var reveal: (ManageRowModel) -> Void
@@ -16,8 +17,8 @@ struct ManageRowActions {
     var openTerminal: (ManageRowModel) -> Void
     var copyCommand: (ManageRowModel) -> Void
     var export: (ManageRowModel) -> Void
-    /// 단일 행 휴지통(P4에서 마찰·Undo 연결).
+    /// Single-row Trash (friction/Undo wired in P4).
     var trashRow: (ManageRowModel) -> Void
-    /// 선택 묶음 휴지통(collector — P4).
+    /// Trash the selected batch (collector — P4).
     var trashSelected: () -> Void
 }

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -1,0 +1,54 @@
+//
+//  ManageSessionsWindowController.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import AppKit
+
+/// "Manage Sessions & Storage" 윈도우를 호스팅한다. AppDelegate가 lazy
+/// 싱글톤으로 생성·재사용 — Reports/Verify Costs와 동일 패턴.
+@MainActor
+final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate {
+
+    init(
+        provider: ProviderKind,
+        isIndexingProvider: @escaping @MainActor () -> Bool,
+        storeProvider: @escaping @MainActor (ProviderKind) -> ProviderStore?,
+        contextProvider: @escaping @MainActor (ProviderKind) -> ManageProviderContext?,
+        requestRescan: @escaping @MainActor (ProviderKind) -> Void,
+        rebuildIndex: @escaping @MainActor (ProviderKind) -> Void
+    ) {
+        let store = ManageStore(
+            provider: provider,
+            isIndexingProvider: isIndexingProvider,
+            storeProvider: storeProvider,
+            contextProvider: contextProvider,
+            requestRescan: requestRescan,
+            rebuildIndex: rebuildIndex
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1040, height: 680),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Manage Sessions & Storage"
+        window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 820, height: 520)
+        window.center()
+        window.setFrameAutosaveName("ManageSessionsWindow")
+        window.contentViewController = ManageViewController(store: store)
+
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    func show() {
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -7,8 +7,8 @@
 
 import AppKit
 
-/// "Manage Sessions & Storage" 윈도우를 호스팅한다. AppDelegate가 lazy
-/// 싱글톤으로 생성·재사용 — Reports/Verify Costs와 동일 패턴.
+/// Hosts the "Manage Sessions & Storage" window. AppDelegate creates and reuses
+/// it as a lazy singleton — same pattern as Reports/Verify Costs.
 @MainActor
 final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate {
 

--- a/Lupen/UI/ManageSessions/ManageTableView.swift
+++ b/Lupen/UI/ManageSessions/ManageTableView.swift
@@ -7,8 +7,8 @@
 
 import AppKit
 
-/// 키보드 단축키(⌫=선택 항목 휴지통)를 위한 NSTableView 서브클래스.
-/// ↑↓ 행 이동·선택은 NSTableView 기본 동작.
+/// NSTableView subclass for a keyboard shortcut (⌫ = Trash selected items).
+/// ↑↓ row navigation/selection is NSTableView's default behavior.
 final class ManageTableView: NSTableView {
     var onDelete: (() -> Void)?
 

--- a/Lupen/UI/ManageSessions/ManageTableView.swift
+++ b/Lupen/UI/ManageSessions/ManageTableView.swift
@@ -1,0 +1,23 @@
+//
+//  ManageTableView.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import AppKit
+
+/// 키보드 단축키(⌫=선택 항목 휴지통)를 위한 NSTableView 서브클래스.
+/// ↑↓ 행 이동·선택은 NSTableView 기본 동작.
+final class ManageTableView: NSTableView {
+    var onDelete: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 51, 117:       // delete, forward delete
+            onDelete?()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -37,7 +37,7 @@ final class ManageViewController: NSViewController {
     private let providerSeg = NSSegmentedControl(
         labels: ["Claude Code", "Codex"], trackingMode: .selectOne, target: nil, action: nil)
     private let scopeSeg = NSSegmentedControl(
-        labels: ["Sessions", "Projects", "Lupen Cache", "All Disk"], trackingMode: .selectOne, target: nil, action: nil)
+        labels: ["Sessions", "Lupen Cache", "All Disk"], trackingMode: .selectOne, target: nil, action: nil)
     private let searchField = NSSearchField()
     private let scrollView = NSScrollView()
     private let tableView = ManageTableView()
@@ -99,7 +99,6 @@ final class ManageViewController: NSViewController {
         scopeSeg.selectedSegment = 0
         scopeSeg.target = self
         scopeSeg.action = #selector(scopeChanged)
-        scopeSeg.setEnabled(false, forSegment: 1)   // Projects 탭은 추후 제공
 
         searchField.placeholderString = "Search prompts…"
         searchField.target = self
@@ -271,7 +270,7 @@ final class ManageViewController: NSViewController {
         store.switchProvider(providerSeg.selectedSegment == 0 ? .claudeCode : .codex)
     }
     @objc private func scopeChanged() {
-        let scopes: [ManageScope] = [.sessions, .projects, .cache, .allDisk]
+        let scopes: [ManageScope] = [.sessions, .cache, .allDisk]
         store.scope = scopes[min(scopeSeg.selectedSegment, scopes.count - 1)]
         store.clearSelection()
         refresh()
@@ -513,12 +512,13 @@ final class ManageViewController: NSViewController {
 
         if showCache {
             statusLabel.isHidden = true
-        } else if store.scope == .projects {
-            statusLabel.stringValue = "Coming soon."
-            statusLabel.isHidden = false
         } else if cachedRows.isEmpty {
-            let scanningText = store.scope == .allDisk ? "Measuring disk items…" : "Loading sessions…"
-            let emptyText = store.scope == .allDisk ? "No items to show." : "No sessions for this provider."
+            let scanningText = store.scope == .allDisk ? "Measuring disk items…" : "Loading…"
+            let emptyText: String
+            switch store.scope {
+            case .allDisk:  emptyText = "No items to show."
+            default:        emptyText = "No sessions for this provider."
+            }
             statusLabel.stringValue = store.isScanning ? scanningText
                 : (store.searchText.isEmpty ? emptyText : "No matching items.")
             statusLabel.isHidden = false

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -1,0 +1,652 @@
+//
+//  ManageViewController.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/20.
+//
+
+import AppKit
+import SwiftUI
+
+/// 관리 윈도우 본문 — 상단 바(provider·탭·검색) + 다중 컬럼 테이블(헤더 정렬,
+/// 행 다중선택) + Sessions 전용 인스펙터 + 하단 collector 바. 분류 배지/inline
+/// bar 없음 — 분류는 삭제 시 얼럿으로만 작동(사용자 요구).
+final class ManageViewController: NSViewController {
+
+    private struct Column {
+        let id: String
+        let title: String
+        let width: CGFloat
+        let sort: ManageRowSort?
+        let rightAligned: Bool
+        let flexible: Bool
+    }
+    private let columns: [Column] = [
+        Column(id: "status", title: "", width: 32, sort: .status, rightAligned: false, flexible: false),
+        Column(id: "project", title: "Project", width: 104, sort: .project, rightAligned: false, flexible: false),
+        Column(id: "session", title: "Session", width: 320, sort: .session, rightAligned: false, flexible: true),
+        Column(id: "created", title: "Created", width: 120, sort: .created, rightAligned: false, flexible: false),
+        Column(id: "updated", title: "Updated", width: 120, sort: .updated, rightAligned: false, flexible: false),
+        Column(id: "size", title: "Size", width: 90, sort: .size, rightAligned: true, flexible: false),
+        Column(id: "files", title: "Files", width: 60, sort: .files, rightAligned: true, flexible: false),
+    ]
+
+    private let store: ManageStore
+    private let sessionResumer = SessionResumer()
+
+    private let providerSeg = NSSegmentedControl(
+        labels: ["Claude Code", "Codex"], trackingMode: .selectOne, target: nil, action: nil)
+    private let scopeSeg = NSSegmentedControl(
+        labels: ["Sessions", "Projects", "Lupen Cache", "All Disk"], trackingMode: .selectOne, target: nil, action: nil)
+    private let searchField = NSSearchField()
+    private let scrollView = NSScrollView()
+    private let tableView = ManageTableView()
+    private let statusLabel = NSTextField(labelWithString: "")
+    private let collectorBar = NSView()
+    private let collectorLabel = NSTextField(labelWithString: "")
+    private let clearButton = NSButton(title: "Clear Selection", target: nil, action: nil)
+    private let trashButton = NSButton(title: "Move to Trash", target: nil, action: nil)
+    private var inspectorHosting: NSHostingController<ManageInspectorView>!
+    private var cacheHosting: NSHostingController<ManageCacheView>!
+    private var inspectorWidth: NSLayoutConstraint!
+    private var leftSeparator: NSView?
+
+    private var cachedRows: [ManageRowModel] = []
+    private var snackbar: NSView?
+    private var pendingRestore: [ManageTrashService.RestoreEntry] = []
+    private var indexingPoll: Timer?
+    private var isRestoringSelection = false
+    /// buildUI가 모든 뷰/제약을 만들기 전에는 refresh를 실행하지 않는다
+    /// (sortDescriptors/delegate 설정이 sortDescriptorsDidChange를 조기에 호출).
+    private var isReady = false
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy/MM/dd HH:mm"
+        return formatter
+    }()
+
+    init(store: ManageStore) {
+        self.store = store
+        super.init(nibName: nil, bundle: nil)
+    }
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 1100, height: 680))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildUI()
+        store.onChange = { [weak self] in self?.refresh() }
+        store.load()
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        indexingPoll?.invalidate()
+        indexingPoll = nil
+    }
+
+    // MARK: - Build
+
+    private func buildUI() {
+        providerSeg.selectedSegment = store.provider == .claudeCode ? 0 : 1
+        providerSeg.target = self
+        providerSeg.action = #selector(providerChanged)
+
+        scopeSeg.selectedSegment = 0
+        scopeSeg.target = self
+        scopeSeg.action = #selector(scopeChanged)
+        scopeSeg.setEnabled(false, forSegment: 1)   // Projects 탭은 추후 제공
+
+        searchField.placeholderString = "Search prompts…"
+        searchField.target = self
+        searchField.action = #selector(searchChanged)
+        searchField.sendsWholeSearchString = false
+        searchField.sendsSearchStringImmediately = true
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let toolbar = NSStackView(views: [providerSeg, scopeSeg, NSView(), searchField])
+        toolbar.orientation = .horizontal
+        toolbar.spacing = 10
+        toolbar.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 8, right: 14)
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.setHuggingPriority(.required, for: .vertical)
+
+        // table (multi-column)
+        tableView.allowsMultipleSelection = true
+        tableView.usesAutomaticRowHeights = false
+        tableView.rowHeight = 26
+        tableView.style = .inset
+        tableView.selectionHighlightStyle = .regular
+        tableView.dataSource = self
+        tableView.onDelete = { [weak self] in self?.performTrash(rows: self?.store.selectedRows ?? []) }
+        tableView.target = self
+        tableView.doubleAction = #selector(rowDoubleClicked)
+        for column in columns {
+            let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(column.id))
+            col.title = column.title
+            col.width = column.width
+            col.minWidth = column.id == "status" ? 28 : 40
+            if column.sort != nil {
+                col.sortDescriptorPrototype = NSSortDescriptor(key: column.id, ascending: true)
+            }
+            // Session만 테이블 리사이즈 시 늘어나게(여유 공간을 Session이 가짐).
+            col.resizingMask = column.flexible ? [.autoresizingMask, .userResizingMask] : .userResizingMask
+            tableView.addTableColumn(col)
+        }
+        tableView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+        tableView.sortDescriptors = [NSSortDescriptor(key: "size", ascending: false)]
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.alignment = .center
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        cacheHosting = NSHostingController(rootView: ManageCacheView(
+            store: store,
+            onRebuild: { [weak self] in self?.confirmRebuild() },
+            onClearSnapshots: { [weak self] in self?.confirmClearSnapshots() },
+            onReveal: { [weak self] in self?.revealSupport() }
+        ))
+        addChild(cacheHosting)
+        let cacheView = cacheHosting.view
+        cacheView.translatesAutoresizingMaskIntoConstraints = false
+        cacheView.isHidden = true
+
+        let leftPane = NSView()
+        leftPane.translatesAutoresizingMaskIntoConstraints = false
+        leftPane.addSubview(scrollView)
+        leftPane.addSubview(statusLabel)
+        leftPane.addSubview(cacheView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: leftPane.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: leftPane.bottomAnchor),
+            statusLabel.centerXAnchor.constraint(equalTo: leftPane.centerXAnchor),
+            statusLabel.centerYAnchor.constraint(equalTo: leftPane.centerYAnchor),
+            cacheView.topAnchor.constraint(equalTo: leftPane.topAnchor),
+            cacheView.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor),
+            cacheView.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor),
+            cacheView.bottomAnchor.constraint(equalTo: leftPane.bottomAnchor),
+        ])
+
+        // inspector (Sessions 탭에서만 — width toggle)
+        inspectorHosting = NSHostingController(rootView: ManageInspectorView(store: store, actions: makeActions()))
+        addChild(inspectorHosting)
+        let inspectorContainer = inspectorHosting.view
+        inspectorContainer.translatesAutoresizingMaskIntoConstraints = false
+        let leftSep = makeVerticalSeparator()
+        leftSeparator = leftSep
+
+        // collector
+        collectorBar.wantsLayer = true
+        collectorBar.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        collectorBar.translatesAutoresizingMaskIntoConstraints = false
+        collectorLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        clearButton.target = self; clearButton.action = #selector(clearTapped); clearButton.bezelStyle = .rounded
+        trashButton.target = self; trashButton.action = #selector(trashTapped); trashButton.bezelStyle = .rounded
+        trashButton.contentTintColor = .systemRed
+        let collectorStack = NSStackView(views: [collectorLabel, NSView(), clearButton, trashButton])
+        collectorStack.orientation = .horizontal
+        collectorStack.spacing = 10
+        collectorStack.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 8, right: 14)
+        collectorStack.translatesAutoresizingMaskIntoConstraints = false
+        collectorBar.addSubview(collectorStack)
+        NSLayoutConstraint.activate([
+            collectorStack.leadingAnchor.constraint(equalTo: collectorBar.leadingAnchor),
+            collectorStack.trailingAnchor.constraint(equalTo: collectorBar.trailingAnchor),
+            collectorStack.topAnchor.constraint(equalTo: collectorBar.topAnchor),
+            collectorStack.bottomAnchor.constraint(equalTo: collectorBar.bottomAnchor),
+        ])
+
+        let topSep = makeSeparator()
+        let botSep = makeSeparator()
+        for sub in [toolbar, topSep, leftPane, leftSep, inspectorContainer, botSep, collectorBar] {
+            view.addSubview(sub)
+        }
+
+        inspectorWidth = inspectorContainer.widthAnchor.constraint(equalToConstant: 320)
+
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: view.topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 200),
+
+            topSep.heightAnchor.constraint(equalToConstant: 1),
+            topSep.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
+            topSep.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topSep.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            leftPane.topAnchor.constraint(equalTo: topSep.bottomAnchor),
+            leftPane.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            leftPane.bottomAnchor.constraint(equalTo: botSep.topAnchor),
+
+            leftSep.topAnchor.constraint(equalTo: topSep.bottomAnchor),
+            leftSep.bottomAnchor.constraint(equalTo: botSep.topAnchor),
+            leftSep.leadingAnchor.constraint(equalTo: leftPane.trailingAnchor),
+            leftSep.widthAnchor.constraint(equalToConstant: 1),
+
+            inspectorContainer.topAnchor.constraint(equalTo: topSep.bottomAnchor),
+            inspectorContainer.leadingAnchor.constraint(equalTo: leftSep.trailingAnchor),
+            inspectorContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            inspectorContainer.bottomAnchor.constraint(equalTo: botSep.topAnchor),
+            inspectorWidth,
+
+            botSep.heightAnchor.constraint(equalToConstant: 1),
+            botSep.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            botSep.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            collectorBar.topAnchor.constraint(equalTo: botSep.bottomAnchor),
+            collectorBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectorBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectorBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            collectorBar.heightAnchor.constraint(equalToConstant: 44),
+        ])
+        // delegate는 모든 뷰/제약 설정 후 연결 — 위 sortDescriptors 초기화가
+        // sortDescriptorsDidChange를 호출해 nil(cacheHosting/inspectorWidth)을
+        // 건드리는 것을 막는다.
+        tableView.delegate = self
+        isReady = true
+        refresh()
+    }
+
+    private func makeSeparator() -> NSView {
+        let box = NSBox(); box.boxType = .separator
+        box.translatesAutoresizingMaskIntoConstraints = false
+        return box
+    }
+    private func makeVerticalSeparator() -> NSView { makeSeparator() }
+
+    // MARK: - Toolbar actions
+
+    @objc private func providerChanged() {
+        store.switchProvider(providerSeg.selectedSegment == 0 ? .claudeCode : .codex)
+    }
+    @objc private func scopeChanged() {
+        let scopes: [ManageScope] = [.sessions, .projects, .cache, .allDisk]
+        store.scope = scopes[min(scopeSeg.selectedSegment, scopes.count - 1)]
+        store.clearSelection()
+        refresh()
+    }
+    @objc private func searchChanged() {
+        store.searchText = searchField.stringValue
+        refresh()
+    }
+    @objc private func clearTapped() {
+        store.clearSelection()
+        refresh()
+    }
+    @objc private func trashTapped() { performTrash(rows: store.selectedRows) }
+
+    // MARK: - Row actions
+
+    private func makeActions() -> ManageRowActions {
+        ManageRowActions(
+            resume: { [weak self] row in self?.resume(row) },
+            reveal: { [weak self] row in self?.reveal(row) },
+            openFolder: { [weak self] row in self?.openFolder(row) },
+            openTerminal: { [weak self] row in self?.openTerminal(row) },
+            copyCommand: { [weak self] row in self?.copyCommand(row) },
+            export: { [weak self] row in self?.export(row) },
+            trashRow: { [weak self] row in self?.performTrash(rows: [row]) },
+            trashSelected: { [weak self] in self?.performTrash(rows: self?.store.selectedRows ?? []) }
+        )
+    }
+
+    private func reveal(_ row: ManageRowModel) {
+        guard let path = row.filePaths.first ?? row.projectPath else { return }
+        runOpen(["-R", path])
+    }
+    private func openFolder(_ row: ManageRowModel) {
+        guard let path = row.projectPath else { return }
+        runOpen([path])
+    }
+    private func openTerminal(_ row: ManageRowModel) {
+        guard let path = row.projectPath else { return }
+        runOpen(["-a", "Terminal", path])
+    }
+    private func runOpen(_ args: [String]) {
+        let process = Process()
+        process.launchPath = "/usr/bin/open"
+        process.arguments = args
+        try? process.run()
+    }
+    private func resume(_ row: ManageRowModel) {
+        guard let session = makeSession(row) else { return }
+        do { try sessionResumer.resume(session: session) } catch { showActionError(error) }
+    }
+    private func copyCommand(_ row: ManageRowModel) {
+        guard let session = makeSession(row) else { return }
+        do { _ = try sessionResumer.copyResumeCommand(for: session) } catch { showActionError(error) }
+    }
+    private func export(_ row: ManageRowModel) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.prompt = "Export"
+        panel.message = "Choose a folder to copy the session files into."
+        guard panel.runModal() == .OK, let dest = panel.url else { return }
+        for path in row.trashTargets {
+            let src = URL(fileURLWithPath: path)
+            try? FileManager.default.copyItem(at: src, to: dest.appendingPathComponent(src.lastPathComponent))
+        }
+    }
+    private func makeSession(_ row: ManageRowModel) -> Session? {
+        guard row.kind == .session else { return nil }
+        return Session(
+            id: row.id, provider: row.provider, rawSessionId: row.rawSessionId ?? row.id,
+            requests: [], projectPath: row.encodedProject ?? row.projectPath
+        )
+    }
+    private func showActionError(_ error: Error) { NSAlert(error: error).runModal() }
+
+    // MARK: - Deletion flow
+
+    private func performTrash(rows: [ManageRowModel]) {
+        guard !rows.isEmpty else { return }
+        guard ManageDeletionPlanner.allDeletable(rows) else {
+            let alert = NSAlert()
+            alert.messageText = "Some items can't be deleted."
+            alert.informativeText = "Blocked (auth/config, app state, outside the session area) or unclassified items can't be moved to Trash."
+            alert.runModal()
+            return
+        }
+        if ManageDeletionPlanner.friction(rows: rows) == .low {
+            trashNow(rows)
+            return
+        }
+        guard confirmDeletion(ManageDeletionPlanner.confirmCopy(rows: rows)) else { return }
+        trashNow(rows)
+    }
+
+    private func trashNow(_ rows: [ManageRowModel]) {
+        let attempted = rows.count
+        Task { @MainActor in
+            let outcome = await store.trash(rows: rows)
+            showUndoSnackbar(outcome: outcome, attempted: attempted)
+        }
+    }
+
+    private func confirmDeletion(_ copy: ManageDeletionPlanner.ConfirmCopy) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = copy.title
+        alert.informativeText = copy.body
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: copy.confirmButton)
+        alert.addButton(withTitle: "Cancel")
+        guard copy.requiresTyping else {
+            return alert.runModal() == .alertFirstButtonReturn
+        }
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = "Type \(copy.typingToken) to continue"
+        alert.accessoryView = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return false }
+        if field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) != copy.typingToken {
+            let warn = NSAlert()
+            warn.messageText = "Input didn't match — cancelled."
+            warn.runModal()
+            return false
+        }
+        return true
+    }
+
+    private func showUndoSnackbar(outcome: ManageTrashService.Outcome, attempted: Int) {
+        snackbar?.removeFromSuperview()
+        guard !outcome.trashedPaths.isEmpty || !outcome.failedPaths.isEmpty else { return }
+        pendingRestore = outcome.restore
+
+        let bar = NSView()
+        bar.wantsLayer = true
+        bar.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        bar.layer?.cornerRadius = 9
+        bar.layer?.borderWidth = 1
+        bar.layer?.borderColor = NSColor.separatorColor.cgColor
+        bar.translatesAutoresizingMaskIntoConstraints = false
+
+        let label = NSTextField(labelWithString: snackbarText(outcome, attempted: attempted))
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        let undo = NSButton(title: "Undo", target: self, action: #selector(undoTapped))
+        undo.bezelStyle = .rounded
+        undo.isHidden = outcome.restore.isEmpty
+        let stack = NSStackView(views: [label, undo])
+        stack.spacing = 12
+        stack.edgeInsets = NSEdgeInsets(top: 8, left: 14, bottom: 8, right: 12)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        bar.addSubview(stack)
+        view.addSubview(bar)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: bar.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: bar.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: bar.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bar.bottomAnchor),
+            bar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            bar.bottomAnchor.constraint(equalTo: collectorBar.topAnchor, constant: -14),
+        ])
+        snackbar = bar
+        let current = bar
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6) { [weak self, weak current] in
+            if self?.snackbar === current { self?.snackbar = nil }
+            current?.removeFromSuperview()
+        }
+    }
+
+    @objc private func undoTapped() {
+        let entries = pendingRestore
+        pendingRestore = []
+        snackbar?.removeFromSuperview()
+        snackbar = nil
+        Task { @MainActor in await store.undoTrash(entries) }
+    }
+
+    private func snackbarText(_ outcome: ManageTrashService.Outcome, attempted: Int) -> String {
+        let failed = outcome.failedPaths.count
+        if failed == 0 { return "Moved \(attempted) to Trash." }
+        if outcome.trashedPaths.isEmpty { return "Couldn't move items (\(failed) failed)." }
+        return "Partly deleted — \(failed) failed."
+    }
+
+    // MARK: - Cache tab
+
+    private func confirmRebuild() {
+        let alert = NSAlert()
+        alert.messageText = "Rebuild the index?"
+        alert.informativeText = "Clears the derived index and re-scans your session logs. Original logs are not modified."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Rebuild")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        store.rebuildCacheIndex()
+    }
+
+    private func confirmClearSnapshots() {
+        let alert = NSAlert()
+        alert.messageText = "Clear the snapshot cache?"
+        alert.informativeText = "Deletes only Lupen's derived JSON cache. The index DB and original logs are kept, and it's regenerated on next launch."
+        alert.addButton(withTitle: "Clear")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        store.clearSnapshots()
+    }
+
+    private func revealSupport() {
+        runOpen([store.providerSupportRoot.path])
+    }
+
+    // MARK: - Refresh
+
+    private func refresh() {
+        guard isReady else { return }
+        switch store.scope {
+        case .sessions:
+            cachedRows = store.displayRows
+        case .allDisk:
+            cachedRows = ManageRowFilter.apply(store.allDiskRows, search: store.searchText, sort: store.sortKey, ascending: store.sortAscending)
+        default:
+            cachedRows = []
+        }
+
+        let showCache = store.scope == .cache
+        cacheHosting.view.isHidden = !showCache
+        scrollView.isHidden = showCache
+        // 인스펙터·구분선은 Sessions 탭에서만 — width 0만으로는 0폭 뷰가
+        // 텍스트를 세로로 렌더하므로 isHidden까지 토글한다.
+        let showInspector = store.scope == .sessions
+        inspectorHosting.view.isHidden = !showInspector
+        leftSeparator?.isHidden = !showInspector
+        inspectorWidth.constant = showInspector ? 320 : 0
+
+        isRestoringSelection = true
+        tableView.reloadData()
+        let indexes = IndexSet(cachedRows.enumerated().filter { store.selectedIDs.contains($0.element.id) }.map(\.offset))
+        tableView.selectRowIndexes(indexes, byExtendingSelection: false)
+        isRestoringSelection = false
+
+        updateCollector()
+
+        if showCache {
+            statusLabel.isHidden = true
+        } else if store.scope == .projects {
+            statusLabel.stringValue = "Coming soon."
+            statusLabel.isHidden = false
+        } else if cachedRows.isEmpty {
+            let scanningText = store.scope == .allDisk ? "Measuring disk items…" : "Loading sessions…"
+            let emptyText = store.scope == .allDisk ? "No items to show." : "No sessions for this provider."
+            statusLabel.stringValue = store.isScanning ? scanningText
+                : (store.searchText.isEmpty ? emptyText : "No matching items.")
+            statusLabel.isHidden = false
+        } else {
+            statusLabel.isHidden = true
+        }
+
+        view.window?.subtitle = store.isIndexingNow ? "Indexing — you can clean up when it finishes" : ""
+        syncIndexingPoll()
+    }
+
+    private func updateCollector() {
+        // collector(선택/휴지통)는 정리 가능한 Sessions 탭에서만. All Disk·Cache는
+        // 읽기전용이라 휴지통 버튼이 무의미하다.
+        let count = store.selectedCount
+        if store.scope == .sessions && count > 0 {
+            let size = ByteCountFormatter.string(fromByteCount: store.selectedReclaimBytes, countStyle: .file)
+            collectorLabel.stringValue = "\(count) selected · \(size)"
+            clearButton.isHidden = false
+            trashButton.isHidden = false
+        } else {
+            collectorLabel.stringValue = ""
+            clearButton.isHidden = true
+            trashButton.isHidden = true
+        }
+    }
+
+    /// All Disk 항목은 읽기전용 — 더블클릭으로 Finder에서 보여준다.
+    @objc private func rowDoubleClicked() {
+        let row = tableView.clickedRow
+        guard row >= 0, row < cachedRows.count else { return }
+        if store.scope == .allDisk { reveal(cachedRows[row]) }
+    }
+
+    private func syncIndexingPoll() {
+        if store.isIndexingNow {
+            if indexingPoll == nil {
+                indexingPoll = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        if !self.store.isIndexingNow {
+                            self.indexingPoll?.invalidate()
+                            self.indexingPoll = nil
+                            self.store.load()
+                        }
+                    }
+                }
+            }
+        } else {
+            indexingPoll?.invalidate()
+            indexingPoll = nil
+        }
+    }
+}
+
+extension ManageViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int { cachedRows.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard let tableColumn, row < cachedRows.count else { return nil }
+        let model = cachedRows[row]
+        let columnId = tableColumn.identifier.rawValue
+        let rightAligned = columns.first { $0.id == columnId }?.rightAligned ?? false
+        let cell = makeCell(tableView, columnId: columnId, rightAligned: rightAligned)
+        cell.textField?.stringValue = text(for: model, columnId: columnId)
+        cell.textField?.font = columnId == "session"
+            ? .systemFont(ofSize: 12, weight: .medium)
+            : .systemFont(ofSize: 12)
+        cell.textField?.textColor = (columnId == "created" || columnId == "updated") ? .secondaryLabelColor : .labelColor
+        switch columnId {
+        case "project": cell.toolTip = model.projectPath
+        case "status":  cell.toolTip = model.status.label
+        default:        cell.toolTip = nil
+        }
+        return cell
+    }
+
+    private func text(for row: ManageRowModel, columnId: String) -> String {
+        switch columnId {
+        case "status":  return row.status.emoji
+        case "project": return row.projectName
+        case "session": return row.displayTitle
+        case "created": return row.createdAt.map { dateFormatter.string(from: $0) } ?? "—"
+        case "updated": return row.lastActivity.map { dateFormatter.string(from: $0) } ?? "—"
+        case "size":    return ByteCountFormatter.string(fromByteCount: row.sizeBytes, countStyle: .file)
+        case "files":   return row.fileCount > 0 ? "\(row.fileCount)" : "—"
+        default:        return ""
+        }
+    }
+
+    private func makeCell(_ tableView: NSTableView, columnId: String, rightAligned: Bool) -> NSTableCellView {
+        let cellId = NSUserInterfaceItemIdentifier("cell_\(columnId)")
+        if let existing = tableView.makeView(withIdentifier: cellId, owner: self) as? NSTableCellView {
+            return existing
+        }
+        let cell = NSTableCellView()
+        cell.identifier = cellId
+        let field = NSTextField(labelWithString: "")
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.lineBreakMode = .byTruncatingTail
+        field.alignment = columnId == "status" ? .center : (rightAligned ? .right : .left)
+        if rightAligned { field.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular) }
+        cell.addSubview(field)
+        cell.textField = field
+        NSLayoutConstraint.activate([
+            field.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 6),
+            field.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+            field.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard !isRestoringSelection else { return }
+        let ids = Set(tableView.selectedRowIndexes.compactMap { idx -> String? in
+            idx < cachedRows.count ? cachedRows[idx].id : nil
+        })
+        store.setSelectedIDs(ids)
+        updateCollector()
+    }
+
+    func tableView(_ tableView: NSTableView, sortDescriptorsDidChange oldDescriptors: [NSSortDescriptor]) {
+        guard isReady else { return }
+        guard let descriptor = tableView.sortDescriptors.first,
+              let key = descriptor.key,
+              let sort = ManageRowSort(rawValue: key) else { return }
+        store.sortKey = sort
+        store.sortAscending = descriptor.ascending
+        refresh()
+    }
+}

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -8,9 +8,10 @@
 import AppKit
 import SwiftUI
 
-/// 관리 윈도우 본문 — 상단 바(provider·탭·검색) + 다중 컬럼 테이블(헤더 정렬,
-/// 행 다중선택) + Sessions 전용 인스펙터 + 하단 collector 바. 분류 배지/inline
-/// bar 없음 — 분류는 삭제 시 얼럿으로만 작동(사용자 요구).
+/// Manage window body — top bar (provider/tab/search) + multi-column table
+/// (header sort, row multi-selection) + Sessions-only inspector + bottom
+/// collector bar. No classification badge/inline bar — classification only
+/// surfaces via the delete alert (per user requirement).
 final class ManageViewController: NSViewController {
 
     private struct Column {
@@ -30,7 +31,7 @@ final class ManageViewController: NSViewController {
         Column(id: "size", title: "Size", width: 90, sort: .size, rightAligned: true, flexible: false),
         Column(id: "files", title: "Files", width: 60, sort: .files, rightAligned: true, flexible: false),
     ]
-    /// flexible(=session) 컬럼이 줄어들 수 있는 최소폭. 그 이하로는 줄이지 않는다.
+    /// Minimum width the flexible (=session) column can shrink to. Never narrower.
     private let flexibleColumnMinWidth: CGFloat = 200
 
     private let store: ManageStore
@@ -58,8 +59,8 @@ final class ManageViewController: NSViewController {
     private var pendingRestore: [ManageTrashService.RestoreEntry] = []
     private var indexingPoll: Timer?
     private var isRestoringSelection = false
-    /// buildUI가 모든 뷰/제약을 만들기 전에는 refresh를 실행하지 않는다
-    /// (sortDescriptors/delegate 설정이 sortDescriptorsDidChange를 조기에 호출).
+    /// Don't run refresh until buildUI has created all views/constraints
+    /// (setting sortDescriptors/delegate fires sortDescriptorsDidChange early).
     private var isReady = false
 
     private let dateFormatter: DateFormatter = {
@@ -82,8 +83,8 @@ final class ManageViewController: NSViewController {
         super.viewDidLoad()
         buildUI()
         store.onChange = { [weak self] in self?.refresh() }
-        // load는 viewDidAppear에서 — 윈도우를 닫았다 다시 열어도 디스크/인덱스
-        // 변화를 반영하도록(재오픈 stale 방지).
+        // load runs in viewDidAppear — so reopening the window reflects disk/index
+        // changes (avoids stale state on reopen).
     }
 
     override func viewDidAppear() {
@@ -99,8 +100,9 @@ final class ManageViewController: NSViewController {
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        // 윈도우 리사이즈·인스펙터 토글로 테이블 가용폭이 바뀔 때마다 Session 폭을
-        // 다시 맞춘다(고정 6컬럼은 그대로, Session만 늘고 줄어듦).
+        // Re-fit the Session width whenever the table's available width changes
+        // via window resize or inspector toggle (the 6 fixed columns stay put,
+        // only Session grows and shrinks).
         adjustFlexibleColumnWidth()
     }
 
@@ -145,20 +147,20 @@ final class ManageViewController: NSViewController {
             col.width = column.width
             col.minWidth = column.id == "status" ? 28 : 40
             if column.id == "status" {
-                // 헤더 텍스트가 빈 컬럼이라 VoiceOver에 의미가 전달되지 않으므로 라벨 부여.
+                // Header text is empty for this column, so VoiceOver gets no meaning — assign a label.
                 col.headerCell.setAccessibilityLabel("Status")
             }
             if column.sort != nil {
                 col.sortDescriptorPrototype = NSSortDescriptor(key: column.id, ascending: true)
             }
-            // 자동 리사이즈는 끄고(아래 .noColumnAutoresizing) Session 폭을
-            // viewDidLayout에서 직접 재계산한다. 사용자 수동 드래그만 허용.
+            // Disable auto-resizing (.noColumnAutoresizing below) and recompute the
+            // Session width directly in viewDidLayout. Allow only manual user drag.
             col.resizingMask = .userResizingMask
             tableView.addTableColumn(col)
         }
-        // 한 컬럼(Session)만 여유 공간을 흡수하는 정책을 명시적 재계산으로 통일한다.
-        // uniform/sequential 같은 전역 자동 리사이즈는 끄고(컬럼 마스크와의 모순 제거)
-        // viewDidLayout에서 Session 폭 = 가용폭 − 고정컬럼합 으로 직접 맞춘다.
+        // Unify the policy where only one column (Session) absorbs slack via explicit recompute.
+        // Disable global auto-resizing like uniform/sequential (removes conflict with column masks)
+        // and set Session width = available width − fixed column sum directly in viewDidLayout.
         tableView.columnAutoresizingStyle = .noColumnAutoresizing
         tableView.sortDescriptors = [NSSortDescriptor(key: "size", ascending: false)]
         scrollView.documentView = tableView
@@ -199,7 +201,7 @@ final class ManageViewController: NSViewController {
             cacheView.bottomAnchor.constraint(equalTo: leftPane.bottomAnchor),
         ])
 
-        // inspector (Sessions 탭에서만 — width toggle)
+        // inspector (Sessions tab only — width toggle)
         inspectorHosting = NSHostingController(rootView: ManageInspectorView(store: store, actions: makeActions()))
         addChild(inspectorHosting)
         let inspectorContainer = inspectorHosting.view
@@ -208,7 +210,7 @@ final class ManageViewController: NSViewController {
         leftSeparator = leftSep
 
         // collector
-        collectorBar.fillColor = .windowBackgroundColor   // updateLayer에서 모드별 재해석
+        collectorBar.fillColor = .windowBackgroundColor   // reinterpreted per mode in updateLayer
         collectorBar.translatesAutoresizingMaskIntoConstraints = false
         collectorLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         clearButton.target = self; clearButton.action = #selector(clearTapped); clearButton.bezelStyle = .rounded
@@ -271,9 +273,9 @@ final class ManageViewController: NSViewController {
             collectorBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             collectorBar.heightAnchor.constraint(equalToConstant: 44),
         ])
-        // delegate는 모든 뷰/제약 설정 후 연결 — 위 sortDescriptors 초기화가
-        // sortDescriptorsDidChange를 호출해 nil(cacheHosting/inspectorWidth)을
-        // 건드리는 것을 막는다.
+        // Wire the delegate only after all views/constraints are set — prevents the
+        // sortDescriptors initialization above from firing sortDescriptorsDidChange
+        // and touching nil (cacheHosting/inspectorWidth).
         tableView.delegate = self
         isReady = true
         refresh()
@@ -286,10 +288,11 @@ final class ManageViewController: NSViewController {
     }
     private func makeVerticalSeparator() -> NSView { makeSeparator() }
 
-    /// Session(flexible) 컬럼 폭을 "테이블 가용폭 − 고정컬럼합"으로 맞춘다.
-    /// .inset 스타일 인셋과 세로 스크롤러 폭이 빠진 실제 콘텐츠 폭(scrollView의
-    /// contentSize)을 기준으로 계산하므로 Size·Files가 잘리지 않는다. 음수가 되면
-    /// 최소폭으로 클램프해(가로 스크롤로 처리) 우측 컬럼 잘림을 막는다.
+    /// Sets the Session (flexible) column width to "table available width − fixed
+    /// column sum". Computed against the actual content width (scrollView's
+    /// contentSize, which excludes the .inset style insets and vertical scroller
+    /// width), so Size/Files aren't truncated. If it goes negative, clamp to the
+    /// minimum width (handled by horizontal scroll) to avoid clipping the right columns.
     private func adjustFlexibleColumnWidth() {
         guard isReady,
               let flexColumn = tableView.tableColumn(
@@ -299,7 +302,7 @@ final class ManageViewController: NSViewController {
         let fixedSum = tableView.tableColumns.reduce(CGFloat.zero) { sum, col in
             col === flexColumn ? sum : sum + col.width
         }
-        // 컬럼 사이 간격(intercellSpacing)도 가용폭에서 빠진다.
+        // The gap between columns (intercellSpacing) is also subtracted from the available width.
         let spacing = tableView.intercellSpacing.width * CGFloat(max(0, tableView.tableColumns.count - 1))
         let target = max(flexibleColumnMinWidth, available - fixedSum - spacing)
         if abs(flexColumn.width - target) > 0.5 { flexColumn.width = target }
@@ -380,7 +383,7 @@ final class ManageViewController: NSViewController {
                 try FileManager.default.copyItem(at: src, to: dest.appendingPathComponent(src.lastPathComponent))
             }
         } catch {
-            // 충돌·권한·디스크부족 등 — 다른 액션과 동일하게 사용자에게 알린다.
+            // Conflict/permission/out-of-disk etc. — notify the user, same as other actions.
             showActionError(error)
         }
     }
@@ -449,7 +452,7 @@ final class ManageViewController: NSViewController {
         pendingRestore = outcome.restore
 
         let bar = ManageDynamicBackgroundView()
-        bar.fillColor = .controlBackgroundColor   // 모드 전환 시 updateLayer에서 재해석
+        bar.fillColor = .controlBackgroundColor   // reinterpreted in updateLayer on mode switch
         bar.corner = 9
         bar.strokeWidth = 1
         bar.strokeColor = .separatorColor
@@ -540,8 +543,8 @@ final class ManageViewController: NSViewController {
         let showCache = store.scope == .cache
         cacheHosting.view.isHidden = !showCache
         scrollView.isHidden = showCache
-        // 인스펙터·구분선은 Sessions 탭에서만 — width 0만으로는 0폭 뷰가
-        // 텍스트를 세로로 렌더하므로 isHidden까지 토글한다.
+        // Inspector/separator only on the Sessions tab — width 0 alone makes a
+        // zero-width view render text vertically, so toggle isHidden as well.
         let showInspector = store.scope == .sessions
         inspectorHosting.view.isHidden = !showInspector
         leftSeparator?.isHidden = !showInspector
@@ -576,8 +579,8 @@ final class ManageViewController: NSViewController {
     }
 
     private func updateCollector() {
-        // collector(선택/휴지통)는 정리 가능한 Sessions 탭에서만. All Disk·Cache는
-        // 읽기전용이라 휴지통 버튼이 무의미하다.
+        // The collector (selection/Trash) only on the cleanable Sessions tab. All Disk/Cache
+        // are read-only, so the Trash button is meaningless there.
         let count = store.selectedCount
         if store.scope == .sessions && count > 0 {
             let size = ByteCountFormatter.string(fromByteCount: store.selectedReclaimBytes, countStyle: .file)
@@ -591,7 +594,7 @@ final class ManageViewController: NSViewController {
         }
     }
 
-    /// All Disk 항목은 읽기전용 — 더블클릭으로 Finder에서 보여준다.
+    /// All Disk items are read-only — double-click reveals them in Finder.
     @objc private func rowDoubleClicked() {
         let row = tableView.clickedRow
         guard row >= 0, row < cachedRows.count else { return }
@@ -637,8 +640,9 @@ extension ManageViewController: NSTableViewDataSource, NSTableViewDelegate {
         case "project": cell.toolTip = model.projectPath
         case "status":
             cell.toolTip = model.status.label
-            // 이모지만으로는 VoiceOver·색맹 사용자에게 상태가 전달되지 않으므로
-            // 접근성 라벨로 상태명을 명시한다(모델 주석의 "색 단독 의존 금지" 준수).
+            // Emoji alone doesn't convey status to VoiceOver/color-blind users, so
+            // spell out the status name via the accessibility label (honors the model
+            // comment's "don't rely on color alone").
             cell.textField?.setAccessibilityLabel(model.status.label)
         default:
             cell.toolTip = nil
@@ -704,11 +708,12 @@ extension ManageViewController: NSTableViewDataSource, NSTableViewDelegate {
 
 // MARK: - ManageDynamicBackgroundView
 
-/// 다크↔라이트 모드 전환 시 배경/테두리 색을 다시 칠하는 레이어 백드 뷰.
-/// `.cgColor`는 정적 캡처라 effectiveAppearance 변경에 반응하지 않으므로,
-/// 프로젝트 표준(PillBackgroundView)과 동일하게 `updateLayer()`에서 동적
-/// NSColor를 매번 재해석한다. AppKit이 appearance 변경 시 layer를 무효화하고
-/// `updateLayer()`를 호출하므로 별도 관찰이 필요 없다.
+/// Layer-backed view that repaints its background/border color on dark↔light
+/// mode switches. `.cgColor` is a static capture that doesn't react to
+/// effectiveAppearance changes, so — like the project standard (PillBackgroundView)
+/// — it reinterprets the dynamic NSColor every time in `updateLayer()`. AppKit
+/// invalidates the layer and calls `updateLayer()` on appearance changes, so no
+/// separate observation is needed.
 private final class ManageDynamicBackgroundView: NSView {
     var fillColor: NSColor = .windowBackgroundColor
     var strokeColor: NSColor?

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -24,12 +24,14 @@ final class ManageViewController: NSViewController {
     private let columns: [Column] = [
         Column(id: "status", title: "", width: 32, sort: .status, rightAligned: false, flexible: false),
         Column(id: "project", title: "Project", width: 104, sort: .project, rightAligned: false, flexible: false),
-        Column(id: "session", title: "Session", width: 320, sort: .session, rightAligned: false, flexible: true),
-        Column(id: "created", title: "Created", width: 120, sort: .created, rightAligned: false, flexible: false),
-        Column(id: "updated", title: "Updated", width: 120, sort: .updated, rightAligned: false, flexible: false),
+        Column(id: "session", title: "Session", width: 200, sort: .session, rightAligned: false, flexible: true),
+        Column(id: "created", title: "Created", width: 96, sort: .created, rightAligned: false, flexible: false),
+        Column(id: "updated", title: "Updated", width: 96, sort: .updated, rightAligned: false, flexible: false),
         Column(id: "size", title: "Size", width: 90, sort: .size, rightAligned: true, flexible: false),
         Column(id: "files", title: "Files", width: 60, sort: .files, rightAligned: true, flexible: false),
     ]
+    /// flexible(=session) 컬럼이 줄어들 수 있는 최소폭. 그 이하로는 줄이지 않는다.
+    private let flexibleColumnMinWidth: CGFloat = 200
 
     private let store: ManageStore
     private let sessionResumer = SessionResumer()
@@ -42,7 +44,7 @@ final class ManageViewController: NSViewController {
     private let scrollView = NSScrollView()
     private let tableView = ManageTableView()
     private let statusLabel = NSTextField(labelWithString: "")
-    private let collectorBar = NSView()
+    private let collectorBar = ManageDynamicBackgroundView()
     private let collectorLabel = NSTextField(labelWithString: "")
     private let clearButton = NSButton(title: "Clear Selection", target: nil, action: nil)
     private let trashButton = NSButton(title: "Move to Trash", target: nil, action: nil)
@@ -80,6 +82,12 @@ final class ManageViewController: NSViewController {
         super.viewDidLoad()
         buildUI()
         store.onChange = { [weak self] in self?.refresh() }
+        // load는 viewDidAppear에서 — 윈도우를 닫았다 다시 열어도 디스크/인덱스
+        // 변화를 반영하도록(재오픈 stale 방지).
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
         store.load()
     }
 
@@ -87,6 +95,13 @@ final class ManageViewController: NSViewController {
         super.viewWillDisappear()
         indexingPoll?.invalidate()
         indexingPoll = nil
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        // 윈도우 리사이즈·인스펙터 토글로 테이블 가용폭이 바뀔 때마다 Session 폭을
+        // 다시 맞춘다(고정 6컬럼은 그대로, Session만 늘고 줄어듦).
+        adjustFlexibleColumnWidth()
     }
 
     // MARK: - Build
@@ -129,14 +144,22 @@ final class ManageViewController: NSViewController {
             col.title = column.title
             col.width = column.width
             col.minWidth = column.id == "status" ? 28 : 40
+            if column.id == "status" {
+                // 헤더 텍스트가 빈 컬럼이라 VoiceOver에 의미가 전달되지 않으므로 라벨 부여.
+                col.headerCell.setAccessibilityLabel("Status")
+            }
             if column.sort != nil {
                 col.sortDescriptorPrototype = NSSortDescriptor(key: column.id, ascending: true)
             }
-            // Session만 테이블 리사이즈 시 늘어나게(여유 공간을 Session이 가짐).
-            col.resizingMask = column.flexible ? [.autoresizingMask, .userResizingMask] : .userResizingMask
+            // 자동 리사이즈는 끄고(아래 .noColumnAutoresizing) Session 폭을
+            // viewDidLayout에서 직접 재계산한다. 사용자 수동 드래그만 허용.
+            col.resizingMask = .userResizingMask
             tableView.addTableColumn(col)
         }
-        tableView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+        // 한 컬럼(Session)만 여유 공간을 흡수하는 정책을 명시적 재계산으로 통일한다.
+        // uniform/sequential 같은 전역 자동 리사이즈는 끄고(컬럼 마스크와의 모순 제거)
+        // viewDidLayout에서 Session 폭 = 가용폭 − 고정컬럼합 으로 직접 맞춘다.
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
         tableView.sortDescriptors = [NSSortDescriptor(key: "size", ascending: false)]
         scrollView.documentView = tableView
         scrollView.hasVerticalScroller = true
@@ -185,8 +208,7 @@ final class ManageViewController: NSViewController {
         leftSeparator = leftSep
 
         // collector
-        collectorBar.wantsLayer = true
-        collectorBar.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        collectorBar.fillColor = .windowBackgroundColor   // updateLayer에서 모드별 재해석
         collectorBar.translatesAutoresizingMaskIntoConstraints = false
         collectorLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         clearButton.target = self; clearButton.action = #selector(clearTapped); clearButton.bezelStyle = .rounded
@@ -264,6 +286,25 @@ final class ManageViewController: NSViewController {
     }
     private func makeVerticalSeparator() -> NSView { makeSeparator() }
 
+    /// Session(flexible) 컬럼 폭을 "테이블 가용폭 − 고정컬럼합"으로 맞춘다.
+    /// .inset 스타일 인셋과 세로 스크롤러 폭이 빠진 실제 콘텐츠 폭(scrollView의
+    /// contentSize)을 기준으로 계산하므로 Size·Files가 잘리지 않는다. 음수가 되면
+    /// 최소폭으로 클램프해(가로 스크롤로 처리) 우측 컬럼 잘림을 막는다.
+    private func adjustFlexibleColumnWidth() {
+        guard isReady,
+              let flexColumn = tableView.tableColumn(
+                  withIdentifier: NSUserInterfaceItemIdentifier("session")) else { return }
+        let available = scrollView.contentSize.width
+        guard available > 0 else { return }
+        let fixedSum = tableView.tableColumns.reduce(CGFloat.zero) { sum, col in
+            col === flexColumn ? sum : sum + col.width
+        }
+        // 컬럼 사이 간격(intercellSpacing)도 가용폭에서 빠진다.
+        let spacing = tableView.intercellSpacing.width * CGFloat(max(0, tableView.tableColumns.count - 1))
+        let target = max(flexibleColumnMinWidth, available - fixedSum - spacing)
+        if abs(flexColumn.width - target) > 0.5 { flexColumn.width = target }
+    }
+
     // MARK: - Toolbar actions
 
     @objc private func providerChanged() {
@@ -333,9 +374,14 @@ final class ManageViewController: NSViewController {
         panel.prompt = "Export"
         panel.message = "Choose a folder to copy the session files into."
         guard panel.runModal() == .OK, let dest = panel.url else { return }
-        for path in row.trashTargets {
-            let src = URL(fileURLWithPath: path)
-            try? FileManager.default.copyItem(at: src, to: dest.appendingPathComponent(src.lastPathComponent))
+        do {
+            for path in row.trashTargets {
+                let src = URL(fileURLWithPath: path)
+                try FileManager.default.copyItem(at: src, to: dest.appendingPathComponent(src.lastPathComponent))
+            }
+        } catch {
+            // 충돌·권한·디스크부족 등 — 다른 액션과 동일하게 사용자에게 알린다.
+            showActionError(error)
         }
     }
     private func makeSession(_ row: ManageRowModel) -> Session? {
@@ -402,12 +448,11 @@ final class ManageViewController: NSViewController {
         guard !outcome.trashedPaths.isEmpty || !outcome.failedPaths.isEmpty else { return }
         pendingRestore = outcome.restore
 
-        let bar = NSView()
-        bar.wantsLayer = true
-        bar.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
-        bar.layer?.cornerRadius = 9
-        bar.layer?.borderWidth = 1
-        bar.layer?.borderColor = NSColor.separatorColor.cgColor
+        let bar = ManageDynamicBackgroundView()
+        bar.fillColor = .controlBackgroundColor   // 모드 전환 시 updateLayer에서 재해석
+        bar.corner = 9
+        bar.strokeWidth = 1
+        bar.strokeColor = .separatorColor
         bar.translatesAutoresizingMaskIntoConstraints = false
 
         let label = NSTextField(labelWithString: snackbarText(outcome, attempted: attempted))
@@ -590,8 +635,14 @@ extension ManageViewController: NSTableViewDataSource, NSTableViewDelegate {
         cell.textField?.textColor = (columnId == "created" || columnId == "updated") ? .secondaryLabelColor : .labelColor
         switch columnId {
         case "project": cell.toolTip = model.projectPath
-        case "status":  cell.toolTip = model.status.label
-        default:        cell.toolTip = nil
+        case "status":
+            cell.toolTip = model.status.label
+            // 이모지만으로는 VoiceOver·색맹 사용자에게 상태가 전달되지 않으므로
+            // 접근성 라벨로 상태명을 명시한다(모델 주석의 "색 단독 의존 금지" 준수).
+            cell.textField?.setAccessibilityLabel(model.status.label)
+        default:
+            cell.toolTip = nil
+            cell.textField?.setAccessibilityLabel(nil)
         }
         return cell
     }
@@ -648,5 +699,35 @@ extension ManageViewController: NSTableViewDataSource, NSTableViewDelegate {
         store.sortKey = sort
         store.sortAscending = descriptor.ascending
         refresh()
+    }
+}
+
+// MARK: - ManageDynamicBackgroundView
+
+/// 다크↔라이트 모드 전환 시 배경/테두리 색을 다시 칠하는 레이어 백드 뷰.
+/// `.cgColor`는 정적 캡처라 effectiveAppearance 변경에 반응하지 않으므로,
+/// 프로젝트 표준(PillBackgroundView)과 동일하게 `updateLayer()`에서 동적
+/// NSColor를 매번 재해석한다. AppKit이 appearance 변경 시 layer를 무효화하고
+/// `updateLayer()`를 호출하므로 별도 관찰이 필요 없다.
+private final class ManageDynamicBackgroundView: NSView {
+    var fillColor: NSColor = .windowBackgroundColor
+    var strokeColor: NSColor?
+    var strokeWidth: CGFloat = 0
+    var corner: CGFloat = 0
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var wantsUpdateLayer: Bool { true }
+
+    override func updateLayer() {
+        layer?.backgroundColor = fillColor.cgColor
+        layer?.cornerRadius = corner
+        layer?.borderWidth = strokeWidth
+        layer?.borderColor = strokeColor?.cgColor
     }
 }

--- a/LupenTests/Domain/Manage/DiskSizerTests.swift
+++ b/LupenTests/Domain/Manage/DiskSizerTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("DiskSizer Tests")
+struct DiskSizerTests {
+
+    /// 임시 디렉터리를 만들고 블록으로 정리한다.
+    private func withTempDir(_ body: (URL) throws -> Void) throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-disksizer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try body(dir)
+    }
+
+    @Test("single file size is at least the content size")
+    func singleFile() throws {
+        try withTempDir { dir in
+            let f = dir.appendingPathComponent("a.bin")
+            try Data(repeating: 0x41, count: 5000).write(to: f)
+            #expect(DiskSizer.fileAllocatedSize(f) >= 5000)
+            #expect(DiskSizer.totalAllocatedSize(at: f) >= 5000)
+        }
+    }
+
+    @Test("directory recursively sums all files")
+    func recursiveSum() throws {
+        try withTempDir { dir in
+            let sub = dir.appendingPathComponent("nested")
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            try Data(repeating: 0, count: 4000).write(to: dir.appendingPathComponent("a.bin"))
+            try Data(repeating: 0, count: 4000).write(to: sub.appendingPathComponent("b.bin"))
+            let total = DiskSizer.totalAllocatedSize(at: dir)
+            #expect(total >= 8000)
+        }
+    }
+
+    @Test("missing path is 0")
+    func missingIsZero() {
+        let url = URL(fileURLWithPath: "/nonexistent-\(UUID().uuidString)/x")
+        #expect(DiskSizer.totalAllocatedSize(at: url) == 0)
+    }
+
+    @Test("directory summation stops on cancellation (0)")
+    func cancellation() throws {
+        try withTempDir { dir in
+            try Data(repeating: 0, count: 4000).write(to: dir.appendingPathComponent("a.bin"))
+            let total = DiskSizer.totalAllocatedSize(at: dir, isCancelled: { true })
+            #expect(total == 0)
+        }
+    }
+
+    @Test("childEntries returns only 1-depth children")
+    func childEntries() throws {
+        try withTempDir { dir in
+            try Data(repeating: 0, count: 100).write(to: dir.appendingPathComponent("a.bin"))
+            try Data(repeating: 0, count: 100).write(to: dir.appendingPathComponent("b.bin"))
+            let sub = dir.appendingPathComponent("sub")
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            try Data(repeating: 0, count: 4000).write(to: sub.appendingPathComponent("c.bin"))
+
+            let entries = DiskSizer.childEntries(of: dir).sorted { $0.name < $1.name }
+            #expect(entries.count == 3)
+            #expect(entries.map(\.name) == ["a.bin", "b.bin", "sub"])
+            let subEntry = try #require(entries.first { $0.name == "sub" })
+            #expect(subEntry.isDirectory)
+            #expect(subEntry.sizeBytes >= 4000)   // 자식 크기 포함
+        }
+    }
+}

--- a/LupenTests/Domain/Manage/DiskSizerTests.swift
+++ b/LupenTests/Domain/Manage/DiskSizerTests.swift
@@ -5,7 +5,7 @@ import Foundation
 @Suite("DiskSizer Tests")
 struct DiskSizerTests {
 
-    /// 임시 디렉터리를 만들고 블록으로 정리한다.
+    /// Creates a temporary directory and cleans it up after the block.
     private func withTempDir(_ body: (URL) throws -> Void) throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-disksizer-\(UUID().uuidString)")
@@ -65,7 +65,7 @@ struct DiskSizerTests {
             #expect(entries.map(\.name) == ["a.bin", "b.bin", "sub"])
             let subEntry = try #require(entries.first { $0.name == "sub" })
             #expect(subEntry.isDirectory)
-            #expect(subEntry.sizeBytes >= 4000)   // 자식 크기 포함
+            #expect(subEntry.sizeBytes >= 4000)   // includes child sizes
         }
     }
 }

--- a/LupenTests/Domain/Manage/ManageDeletionPlannerTests.swift
+++ b/LupenTests/Domain/Manage/ManageDeletionPlannerTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageDeletionPlanner Tests")
+struct ManageDeletionPlannerTests {
+
+    private func r(id: String, protection: StorageProtection = .deletable,
+                   classification: StorageClassification = .safe, indexed: Bool = true,
+                   size: Int64 = 100) -> ManageRowModel {
+        ManageRowModel(id: id, provider: .claudeCode, kind: .session, displayTitle: id,
+                       sizeBytes: size, classification: classification, protection: protection, isIndexed: indexed)
+    }
+
+    // MARK: - Friction
+
+    @Test("single safe item → low")
+    func low() { #expect(ManageDeletionPlanner.friction(rows: [r(id: "1")]) == .low) }
+
+    @Test("multiple items → medium")
+    func multipleMedium() {
+        #expect(ManageDeletionPlanner.friction(rows: [r(id: "1"), r(id: "2")]) == .medium)
+    }
+
+    @Test("single caution item → medium")
+    func cautionMedium() {
+        #expect(ManageDeletionPlanner.friction(rows: [r(id: "1", classification: .caution)]) == .medium)
+    }
+
+    @Test("untracked → high")
+    func untrackedHigh() {
+        #expect(ManageDeletionPlanner.friction(rows: [r(id: "1", classification: .caution, indexed: false)]) == .high)
+    }
+
+    @Test("20 or more → high")
+    func bulkCountHigh() {
+        let rows = (0..<20).map { r(id: "\($0)") }
+        #expect(ManageDeletionPlanner.friction(rows: rows) == .high)
+    }
+
+    @Test("1GB or more → high")
+    func bulkBytesHigh() {
+        #expect(ManageDeletionPlanner.friction(rows: [r(id: "1", size: 1_000_000_000)]) == .high)
+    }
+
+    // MARK: - allDeletable
+
+    @Test("all deletable → true")
+    func allDel() { #expect(ManageDeletionPlanner.allDeletable([r(id: "1"), r(id: "2")])) }
+
+    @Test("false if any blocked is mixed in")
+    func blockedFalse() {
+        #expect(!ManageDeletionPlanner.allDeletable([r(id: "1"), r(id: "2", protection: .blocked)]))
+    }
+
+    @Test("false if any locked is mixed in")
+    func lockedFalse() {
+        #expect(!ManageDeletionPlanner.allDeletable([r(id: "1", protection: .locked)]))
+    }
+
+    @Test("empty array → false")
+    func emptyFalse() { #expect(!ManageDeletionPlanner.allDeletable([])) }
+
+    // MARK: - Copy
+
+    @Test("tracked session copy — 'N sessions', trash restore notice, no typing for 2 items")
+    func copyTracked() {
+        let copy = ManageDeletionPlanner.confirmCopy(rows: [r(id: "1"), r(id: "2")])
+        #expect(copy.title.contains("2 sessions"))
+        #expect(copy.confirmButton == "Delete 2 sessions")
+        #expect(copy.requiresTyping == false)
+        #expect(copy.body.contains("restore"))
+    }
+
+    @Test("untracked copy — 'item', typing confirmation")
+    func copyUntracked() {
+        let copy = ManageDeletionPlanner.confirmCopy(rows: [r(id: "1", indexed: false)])
+        #expect(copy.title.contains("1 item"))
+        #expect(copy.requiresTyping)
+        #expect(copy.typingToken == "DELETE")
+    }
+
+    @Test("totalBytes summation")
+    func total() {
+        #expect(ManageDeletionPlanner.totalBytes([r(id: "1", size: 100), r(id: "2", size: 250)]) == 350)
+    }
+}

--- a/LupenTests/Domain/Manage/ManageDeletionPlannerTests.swift
+++ b/LupenTests/Domain/Manage/ManageDeletionPlannerTests.swift
@@ -72,6 +72,15 @@ struct ManageDeletionPlannerTests {
         #expect(copy.body.contains("restore"))
     }
 
+    @Test("single tracked session — singular 'session', no typing")
+    func copySingularSession() {
+        let copy = ManageDeletionPlanner.confirmCopy(rows: [r(id: "1")])
+        #expect(copy.title.contains("1 session"))
+        #expect(!copy.title.contains("sessions"))
+        #expect(copy.confirmButton == "Delete 1 session")
+        #expect(!copy.requiresTyping)
+    }
+
     @Test("untracked copy — 'item', typing confirmation")
     func copyUntracked() {
         let copy = ManageDeletionPlanner.confirmCopy(rows: [r(id: "1", indexed: false)])

--- a/LupenTests/Domain/Manage/ManageModelsTests.swift
+++ b/LupenTests/Domain/Manage/ManageModelsTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+/// 순수 값 타입(ManageStatus·StorageProtection·ManageRowModel)의 표시/정렬/
+/// 파생 로직 검증. UI·정렬이 이 값들에 의존하므로 회귀 시 조용히 깨진다.
+@Suite("ManageModels Tests")
+struct ManageModelsTests {
+
+    // MARK: - ManageStatus
+
+    @Test("emoji is empty only for normal, distinct otherwise")
+    func statusEmoji() {
+        #expect(ManageStatus.normal.emoji == "")
+        #expect(ManageStatus.recentlyActive.emoji == "🕐")
+        #expect(ManageStatus.untracked.emoji == "❓")
+        #expect(ManageStatus.indexing.emoji == "⏳")
+        #expect(ManageStatus.blocked.emoji == "🔒")
+        #expect(ManageStatus.error.emoji == "⚠️")
+    }
+
+    @Test("label matches each case")
+    func statusLabel() {
+        #expect(ManageStatus.normal.label == "Normal")
+        #expect(ManageStatus.recentlyActive.label == "Recently active")
+        #expect(ManageStatus.untracked.label == "Untracked")
+        #expect(ManageStatus.indexing.label == "Indexing")
+        #expect(ManageStatus.blocked.label == "Blocked")
+        #expect(ManageStatus.error.label == "Error")
+    }
+
+    @Test("normal has empty detail; others describe themselves")
+    func statusDetail() {
+        #expect(ManageStatus.normal.detailDescription.isEmpty)
+        #expect(!ManageStatus.blocked.detailDescription.isEmpty)
+        #expect(ManageStatus.untracked.detailDescription.contains("index"))
+        #expect(ManageStatus.error.detailDescription.contains("missing"))
+    }
+
+    @Test("sortOrder is strictly increasing by priority (blocked highest)")
+    func statusSortOrder() {
+        let byPriority: [ManageStatus] = [.blocked, .error, .indexing, .untracked, .recentlyActive, .normal]
+        let orders = byPriority.map(\.sortOrder)
+        #expect(orders == [0, 1, 2, 3, 4, 5])
+        #expect(orders == orders.sorted())   // 단조 증가 — 정렬 근거
+    }
+
+    // MARK: - StorageProtection
+
+    @Test("only deletable can be trashed")
+    func canTrash() {
+        #expect(StorageProtection.deletable.canTrash)
+        #expect(!StorageProtection.blocked.canTrash)
+        #expect(!StorageProtection.locked.canTrash)
+    }
+
+    // MARK: - ManageRowModel
+
+    private func model(path: String?, companion: String? = nil,
+                       files: [String] = ["/a/sess.jsonl"]) -> ManageRowModel {
+        ManageRowModel(id: "s1", provider: .claudeCode, kind: .session, displayTitle: "t",
+                       projectPath: path, filePaths: files, companionDirectory: companion)
+    }
+
+    @Test("projectName falls back to dash for nil/empty path")
+    func projectNameFallback() {
+        #expect(model(path: nil).projectName == "—")
+        #expect(model(path: "").projectName == "—")
+    }
+
+    @Test("projectName uses the last path component")
+    func projectNameLastComponent() {
+        #expect(model(path: "/Users/x/work/foo").projectName == "foo")
+        #expect(model(path: "/Users/x/work/foo/").projectName == "foo")
+    }
+
+    @Test("trashTargets appends the companion directory when present")
+    func trashTargets() {
+        #expect(model(path: "/p", companion: "/a/sess").trashTargets == ["/a/sess.jsonl", "/a/sess"])
+        #expect(model(path: "/p", companion: nil).trashTargets == ["/a/sess.jsonl"])
+    }
+}

--- a/LupenTests/Domain/Manage/ManageModelsTests.swift
+++ b/LupenTests/Domain/Manage/ManageModelsTests.swift
@@ -2,8 +2,9 @@ import Testing
 import Foundation
 @testable import Lupen
 
-/// 순수 값 타입(ManageStatus·StorageProtection·ManageRowModel)의 표시/정렬/
-/// 파생 로직 검증. UI·정렬이 이 값들에 의존하므로 회귀 시 조용히 깨진다.
+/// Verifies the display/sorting/derived logic of the pure value types
+/// (ManageStatus, StorageProtection, ManageRowModel). The UI and sorting depend on
+/// these values, so a regression breaks them silently.
 @Suite("ManageModels Tests")
 struct ManageModelsTests {
 
@@ -42,7 +43,7 @@ struct ManageModelsTests {
         let byPriority: [ManageStatus] = [.blocked, .error, .indexing, .untracked, .recentlyActive, .normal]
         let orders = byPriority.map(\.sortOrder)
         #expect(orders == [0, 1, 2, 3, 4, 5])
-        #expect(orders == orders.sorted())   // 단조 증가 — 정렬 근거
+        #expect(orders == orders.sorted())   // monotonically increasing — basis for sorting
     }
 
     // MARK: - StorageProtection

--- a/LupenTests/Domain/Manage/ManageProviderContextTests.swift
+++ b/LupenTests/Domain/Manage/ManageProviderContextTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageProviderContext Tests")
+struct ManageProviderContextTests {
+
+    @Test("Claude — projects is the session area, parent is home")
+    func claude() {
+        let ctx = ManageProviderContext.claude(projectsDirectory: URL(fileURLWithPath: "/Users/x/.claude/projects"))
+        #expect(ctx.provider == .claudeCode)
+        #expect(ctx.providerHome.path == "/Users/x/.claude")
+        #expect(ctx.sessionAreaRoots.map(\.path) == ["/Users/x/.claude/projects"])
+    }
+
+    @Test("Codex — home and sessions/")
+    func codex() {
+        let ctx = ManageProviderContext.codex(codexHome: URL(fileURLWithPath: "/Users/x/.codex"))
+        #expect(ctx.provider == .codex)
+        #expect(ctx.providerHome.path == "/Users/x/.codex")
+        #expect(ctx.sessionAreaRoots.map(\.path) == ["/Users/x/.codex/sessions"])
+    }
+
+    @Test("classifierScope wires up the same paths")
+    func scope() {
+        let ctx = ManageProviderContext.claude(projectsDirectory: URL(fileURLWithPath: "/h/.claude/projects"))
+        let scope = ctx.classifierScope
+        #expect(scope.providerHome.path == "/h/.claude")
+        #expect(scope.sessionAreaRoots.map(\.path) == ["/h/.claude/projects"])
+    }
+}

--- a/LupenTests/Domain/Manage/ManageReconcilerTests.swift
+++ b/LupenTests/Domain/Manage/ManageReconcilerTests.swift
@@ -34,7 +34,7 @@ struct ManageReconcilerTests {
         #expect(r.kind == .session)
         #expect(r.isIndexed)
         #expect(r.existsOnDisk)
-        #expect(r.sizeBytes == 1000)        // 인덱스 byteSize 근사
+        #expect(r.sizeBytes == 1000)        // approximated from index byteSize
         #expect(r.isEstimatedSize)
         #expect(r.protection == .deletable)
         #expect(r.displayTitle == "hello")
@@ -109,11 +109,11 @@ struct ManageReconcilerTests {
                     ManageReconciler.DiskFile(path: subagent, sizeBytes: 500, modifiedAt: old)]
         let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
                                               classifier: classifier(), isIndexing: false, now: now)
-        #expect(rows.count == 1)        // subagent는 claimed → orphan 아님
+        #expect(rows.count == 1)        // subagent is claimed → not an orphan
         let r = rows[0]
         #expect(r.companionDirectory == "/Users/test/.claude/projects/enc/sess")
         #expect(r.filePaths == [parent])
-        #expect(r.sizeBytes == 1500)    // 부모+서브에이전트 합
+        #expect(r.sizeBytes == 1500)    // parent + subagent total
         #expect(r.fileCount == 2)
         #expect(r.trashTargets == [parent, "/Users/test/.claude/projects/enc/sess"])
     }
@@ -128,7 +128,7 @@ struct ManageReconcilerTests {
         let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
                                               classifier: classifier(), isIndexing: false, now: now)
         #expect(rows[0].status == .error)
-        #expect(rows[0].protection == .deletable)   // 상태만 error, 삭제 자체는 가능
+        #expect(rows[0].protection == .deletable)   // status is error, but deletion is still allowed
     }
 
     @Test("while indexing, even tracked sessions are blocked")
@@ -145,12 +145,12 @@ struct ManageReconcilerTests {
     func indexOnlyRender() {
         let path = "/Users/test/.claude/projects/enc/sess.jsonl"
         let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "enc"), sourceFiles: [src(path, 1000)], aggregate: nil)]
-        // diskFiles에 orphan 후보가 있어도 scanned=false면 무시.
+        // even if diskFiles has an orphan candidate, it is ignored when scanned=false.
         let orphanDisk = [ManageReconciler.DiskFile(path: "/Users/test/.claude/projects/enc/x.jsonl", sizeBytes: 1, modifiedAt: old)]
         let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: orphanDisk,
                                               classifier: classifier(), isIndexing: false, scanned: false, now: now)
-        #expect(rows.count == 1)         // orphan 무시
-        #expect(rows[0].kind == .session) // 디스크 미확인이어도 잔재 아님
+        #expect(rows.count == 1)         // orphan ignored
+        #expect(rows[0].kind == .session) // not an index remnant even though disk is unverified
         #expect(rows[0].existsOnDisk)
     }
 }

--- a/LupenTests/Domain/Manage/ManageReconcilerTests.swift
+++ b/LupenTests/Domain/Manage/ManageReconcilerTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageReconciler Tests")
+struct ManageReconcilerTests {
+
+    private let home = URL(fileURLWithPath: "/Users/test/.claude")
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+    private var old: Date { Date(timeIntervalSince1970: 0) }
+
+    private func classifier(home: URL? = nil, area: String = "projects") -> StorageClassifier {
+        let h = home ?? self.home
+        return StorageClassifier(scope: .init(providerHome: h, sessionAreaRoots: [h.appendingPathComponent(area)]))
+    }
+    private func row(id: String, project: String?, first: String? = "hello", branch: String? = "main",
+                     custom: String? = nil, cached: String? = nil) -> StoreSessionRow {
+        StoreSessionRow(id: id, rawId: id, projectPath: project, endTime: old, cachedTitle: cached,
+                        customTitle: custom, firstPrompt: first, lastGitBranch: branch)
+    }
+    private func src(_ path: String, _ size: Int64, sub: Bool = false) -> StoreSourceFile {
+        StoreSourceFile(path: path, byteSize: size, modifiedAt: old, fingerprint: "fp", isSubagent: sub)
+    }
+
+    @Test("indexed + on disk → tracked session")
+    func tracked() {
+        let path = "/Users/test/.claude/projects/enc/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "enc"), sourceFiles: [src(path, 1000)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 4096, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows.count == 1)
+        let r = rows[0]
+        #expect(r.kind == .session)
+        #expect(r.isIndexed)
+        #expect(r.existsOnDisk)
+        #expect(r.sizeBytes == 1000)        // 인덱스 byteSize 근사
+        #expect(r.isEstimatedSize)
+        #expect(r.protection == .deletable)
+        #expect(r.displayTitle == "hello")
+        #expect(r.branch == "main")
+    }
+
+    @Test("indexed but not on disk → remnant (locked)")
+    func remnant() {
+        let path = "/Users/test/.claude/projects/enc/gone.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "enc"), sourceFiles: [src(path, 1000)], aggregate: nil)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: [],
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows.count == 1)
+        #expect(rows[0].kind == .indexRemnant)
+        #expect(rows[0].protection == .locked)
+        #expect(rows[0].existsOnDisk == false)
+    }
+
+    @Test("jsonl on disk only → untracked orphan")
+    func orphan() {
+        let path = "/Users/test/.claude/projects/enc/orphan.jsonl"
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 2048, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: [], diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows.count == 1)
+        #expect(rows[0].kind == .orphanFile)
+        #expect(rows[0].isIndexed == false)
+        #expect(rows[0].sizeBytes == 2048)
+        #expect(rows[0].displayTitle == "orphan.jsonl")
+        #expect(rows[0].protection == .deletable)
+    }
+
+    @Test("unclaimed non-jsonl file on disk does not create an orphan row")
+    func nonJsonlIgnored() {
+        let disk = [ManageReconciler.DiskFile(path: "/Users/test/.claude/projects/enc/notes.txt", sizeBytes: 10, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: [], diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows.isEmpty)
+    }
+
+    @Test("Claude project_path is decoded and encoded form is preserved")
+    func claudeDecode() {
+        let path = "/Users/test/.claude/projects/x/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "-Users-test-work-foo"), sourceFiles: [src(path, 1)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 1, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows[0].projectPath == "/Users/test/work/foo")
+        #expect(rows[0].encodedProject == "-Users-test-work-foo")
+    }
+
+    @Test("Codex project_path stays as the real path, encoded is nil")
+    func codexPath() {
+        let cHome = URL(fileURLWithPath: "/Users/test/.codex")
+        let path = "/Users/test/.codex/sessions/2026/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "/Users/test/work"), sourceFiles: [src(path, 1)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 1, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .codex, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(home: cHome, area: "sessions"), isIndexing: false, now: now)
+        #expect(rows[0].projectPath == "/Users/test/work")
+        #expect(rows[0].encodedProject == nil)
+    }
+
+    @Test("Claude session with subagents → includes companion directory, parent-only filePaths")
+    func companion() {
+        let parent = "/Users/test/.claude/projects/enc/sess.jsonl"
+        let subagent = "/Users/test/.claude/projects/enc/sess/subagents/agent-1.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(
+            row: row(id: "s1", project: "enc"),
+            sourceFiles: [src(parent, 1000), src(subagent, 500, sub: true)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: parent, sizeBytes: 1000, modifiedAt: old),
+                    ManageReconciler.DiskFile(path: subagent, sizeBytes: 500, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows.count == 1)        // subagent는 claimed → orphan 아님
+        let r = rows[0]
+        #expect(r.companionDirectory == "/Users/test/.claude/projects/enc/sess")
+        #expect(r.filePaths == [parent])
+        #expect(r.sizeBytes == 1500)    // 부모+서브에이전트 합
+        #expect(r.fileCount == 2)
+        #expect(r.trashTargets == [parent, "/Users/test/.claude/projects/enc/sess"])
+    }
+
+    @Test("while indexing, even tracked sessions are blocked")
+    func indexingBlocks() {
+        let path = "/Users/test/.claude/projects/enc/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "enc"), sourceFiles: [src(path, 1)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 1, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(), isIndexing: true, now: now)
+        #expect(rows[0].protection == .blocked)
+    }
+
+    @Test("scanned=false → index only, no remnant detection or orphans")
+    func indexOnlyRender() {
+        let path = "/Users/test/.claude/projects/enc/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(row: row(id: "s1", project: "enc"), sourceFiles: [src(path, 1000)], aggregate: nil)]
+        // diskFiles에 orphan 후보가 있어도 scanned=false면 무시.
+        let orphanDisk = [ManageReconciler.DiskFile(path: "/Users/test/.claude/projects/enc/x.jsonl", sizeBytes: 1, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: orphanDisk,
+                                              classifier: classifier(), isIndexing: false, scanned: false, now: now)
+        #expect(rows.count == 1)         // orphan 무시
+        #expect(rows[0].kind == .session) // 디스크 미확인이어도 잔재 아님
+        #expect(rows[0].existsOnDisk)
+    }
+}

--- a/LupenTests/Domain/Manage/ManageReconcilerTests.swift
+++ b/LupenTests/Domain/Manage/ManageReconcilerTests.swift
@@ -18,8 +18,8 @@ struct ManageReconcilerTests {
         StoreSessionRow(id: id, rawId: id, projectPath: project, endTime: old, cachedTitle: cached,
                         customTitle: custom, firstPrompt: first, lastGitBranch: branch)
     }
-    private func src(_ path: String, _ size: Int64, sub: Bool = false) -> StoreSourceFile {
-        StoreSourceFile(path: path, byteSize: size, modifiedAt: old, fingerprint: "fp", isSubagent: sub)
+    private func src(_ path: String, _ size: Int64, sub: Bool = false, parse: StoreParseState = .pending) -> StoreSourceFile {
+        StoreSourceFile(path: path, byteSize: size, modifiedAt: old, fingerprint: "fp", parseState: parse, isSubagent: sub)
     }
 
     @Test("indexed + on disk → tracked session")
@@ -116,6 +116,19 @@ struct ManageReconcilerTests {
         #expect(r.sizeBytes == 1500)    // 부모+서브에이전트 합
         #expect(r.fileCount == 2)
         #expect(r.trashTargets == [parent, "/Users/test/.claude/projects/enc/sess"])
+    }
+
+    @Test("tracked session with a failed source → error status (still deletable)")
+    func failedSourceIsError() {
+        let path = "/Users/test/.claude/projects/enc/sess.jsonl"
+        let indexed = [ManageReconciler.IndexedSession(
+            row: row(id: "s1", project: "enc"),
+            sourceFiles: [src(path, 1000, parse: .failed)], aggregate: nil)]
+        let disk = [ManageReconciler.DiskFile(path: path, sizeBytes: 1000, modifiedAt: old)]
+        let rows = ManageReconciler.reconcile(provider: .claudeCode, indexed: indexed, diskFiles: disk,
+                                              classifier: classifier(), isIndexing: false, now: now)
+        #expect(rows[0].status == .error)
+        #expect(rows[0].protection == .deletable)   // 상태만 error, 삭제 자체는 가능
     }
 
     @Test("while indexing, even tracked sessions are blocked")

--- a/LupenTests/Domain/Manage/ManageRowFilterTests.swift
+++ b/LupenTests/Domain/Manage/ManageRowFilterTests.swift
@@ -7,10 +7,11 @@ struct ManageRowFilterTests {
 
     private func r(id: String, title: String, size: Int64,
                    activity: Date? = nil, created: Date? = nil,
-                   path: String? = nil, branch: String? = nil, files: Int = 0) -> ManageRowModel {
+                   path: String? = nil, branch: String? = nil, files: Int = 0,
+                   status: ManageStatus = .normal) -> ManageRowModel {
         ManageRowModel(id: id, provider: .claudeCode, kind: .session, displayTitle: title,
                        projectPath: path, branch: branch, createdAt: created, lastActivity: activity,
-                       sizeBytes: size, fileCount: files)
+                       sizeBytes: size, fileCount: files, status: status)
     }
 
     @Test("size descending")
@@ -66,6 +67,18 @@ struct ManageRowFilterTests {
     func filesDescending() {
         let rows = [r(id: "1", title: "x", size: 1, files: 5), r(id: "2", title: "y", size: 1, files: 50)]
         #expect(ManageRowFilter.apply(rows, search: "", sort: .files, ascending: false).map(\.id) == ["2", "1"])
+    }
+
+    @Test("status sort by priority (ascending = most urgent first)")
+    func statusSort() {
+        let rows = [
+            r(id: "normal", title: "n", size: 1, status: .normal),
+            r(id: "blocked", title: "b", size: 1, status: .blocked),
+            r(id: "recent", title: "r", size: 1, status: .recentlyActive),
+        ]
+        // sortOrder: blocked(0) < recentlyActive(4) < normal(5).
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .status, ascending: true).map(\.id) == ["blocked", "recent", "normal"])
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .status, ascending: false).map(\.id) == ["normal", "recent", "blocked"])
     }
 
     @Test("search — title/path/branch, case-insensitive")

--- a/LupenTests/Domain/Manage/ManageRowFilterTests.swift
+++ b/LupenTests/Domain/Manage/ManageRowFilterTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageRowFilter Tests")
+struct ManageRowFilterTests {
+
+    private func r(id: String, title: String, size: Int64,
+                   activity: Date? = nil, created: Date? = nil,
+                   path: String? = nil, branch: String? = nil, files: Int = 0) -> ManageRowModel {
+        ManageRowModel(id: id, provider: .claudeCode, kind: .session, displayTitle: title,
+                       projectPath: path, branch: branch, createdAt: created, lastActivity: activity,
+                       sizeBytes: size, fileCount: files)
+    }
+
+    @Test("size descending")
+    func sizeDescending() {
+        let rows = [r(id: "a", title: "a", size: 100), r(id: "b", title: "b", size: 5000), r(id: "c", title: "c", size: 1000)]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .size, ascending: false).map(\.id) == ["b", "c", "a"])
+    }
+
+    @Test("size ascending")
+    func sizeAscending() {
+        let rows = [r(id: "a", title: "a", size: 100), r(id: "b", title: "b", size: 5000), r(id: "c", title: "c", size: 1000)]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .size, ascending: true).map(\.id) == ["a", "c", "b"])
+    }
+
+    @Test("size sort is numeric, not lexical")
+    func sizeNumericNotLexical() {
+        let rows = [r(id: "big", title: "big", size: 1_000_000), r(id: "small", title: "small", size: 999_999)]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .size, ascending: false).first?.id == "big")
+    }
+
+    @Test("last updated descending (nil last)")
+    func updatedDescending() {
+        let rows = [
+            r(id: "old", title: "o", size: 1, activity: Date(timeIntervalSince1970: 100)),
+            r(id: "new", title: "n", size: 1, activity: Date(timeIntervalSince1970: 9999)),
+            r(id: "nil", title: "x", size: 1, activity: nil),
+        ]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .updated, ascending: false).map(\.id) == ["new", "old", "nil"])
+    }
+
+    @Test("created time ascending")
+    func createdAscending() {
+        let rows = [
+            r(id: "b", title: "b", size: 1, created: Date(timeIntervalSince1970: 500)),
+            r(id: "a", title: "a", size: 1, created: Date(timeIntervalSince1970: 100)),
+        ]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .created, ascending: true).map(\.id) == ["a", "b"])
+    }
+
+    @Test("session name sort (case-insensitive)")
+    func sessionName() {
+        let rows = [r(id: "1", title: "Banana", size: 1), r(id: "2", title: "apple", size: 1), r(id: "3", title: "Cherry", size: 1)]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .session, ascending: true).map(\.displayTitle) == ["apple", "Banana", "Cherry"])
+    }
+
+    @Test("project name sort")
+    func projectName() {
+        let rows = [r(id: "1", title: "x", size: 1, path: "/work/zebra"), r(id: "2", title: "y", size: 1, path: "/work/alpha")]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .project, ascending: true).map(\.id) == ["2", "1"])
+    }
+
+    @Test("file count descending")
+    func filesDescending() {
+        let rows = [r(id: "1", title: "x", size: 1, files: 5), r(id: "2", title: "y", size: 1, files: 50)]
+        #expect(ManageRowFilter.apply(rows, search: "", sort: .files, ascending: false).map(\.id) == ["2", "1"])
+    }
+
+    @Test("search — title/path/branch, case-insensitive")
+    func search() {
+        let rows = [
+            r(id: "1", title: "Refactor auth", size: 1, path: "/work/foo", branch: "main"),
+            r(id: "2", title: "Fix bug", size: 1, path: "/work/bar", branch: "feature/glass"),
+            r(id: "3", title: "Docs", size: 1, path: "/work/auth-svc", branch: "main"),
+        ]
+        #expect(ManageRowFilter.apply(rows, search: "AUTH", sort: .size, ascending: false).map(\.id).sorted() == ["1", "3"])
+        #expect(ManageRowFilter.apply(rows, search: "glass", sort: .size, ascending: false).map(\.id) == ["2"])
+        #expect(ManageRowFilter.apply(rows, search: "zzz", sort: .size, ascending: false).isEmpty)
+    }
+
+    @Test("whitespace-only search keeps everything")
+    func emptySearch() {
+        let rows = [r(id: "1", title: "a", size: 1), r(id: "2", title: "b", size: 1)]
+        #expect(ManageRowFilter.apply(rows, search: "   ", sort: .size, ascending: false).count == 2)
+    }
+}

--- a/LupenTests/Domain/Manage/ManageScanServiceTests.swift
+++ b/LupenTests/Domain/Manage/ManageScanServiceTests.swift
@@ -36,6 +36,34 @@ struct ManageScanServiceTests {
         #expect(files.isEmpty)
     }
 
+    // MARK: - Cancellation
+
+    @Test("ScanCancellationFlag toggles via cancel")
+    func cancellationFlag() {
+        let flag = ScanCancellationFlag()
+        #expect(!flag.isCancelled)
+        flag.cancel()
+        #expect(flag.isCancelled)
+    }
+
+    @Test("scanSessionArea yields nothing when cancelled up front")
+    func scanSessionAreaCancelled() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data(repeating: 0x41, count: 100).write(to: dir.appendingPathComponent("a.jsonl"))
+        let files = await ManageScanService().scanSessionArea(roots: [dir], isCancelled: { true })
+        #expect(files.isEmpty)
+    }
+
+    @Test("scanDiskItems yields nothing when cancelled up front")
+    func scanDiskItemsCancelled() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data(repeating: 0, count: 100).write(to: dir.appendingPathComponent("x.bin"))
+        let entries = await ManageScanService().scanDiskItems(home: dir, isCancelled: { true })
+        #expect(entries.isEmpty)
+    }
+
     @Test("scanDiskItems returns 1-depth items + recursive directory size")
     func diskItems() async throws {
         let dir = try makeTempDir()

--- a/LupenTests/Domain/Manage/ManageScanServiceTests.swift
+++ b/LupenTests/Domain/Manage/ManageScanServiceTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageScanService Tests")
+struct ManageScanServiceTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-scan-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("collect only .jsonl from session area, including nested")
+    func collectsJsonlOnly() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data(repeating: 0x41, count: 1000).write(to: dir.appendingPathComponent("a.jsonl"))
+        try Data(repeating: 0x41, count: 1000).write(to: dir.appendingPathComponent("notes.txt"))
+        try Data(repeating: 0x41, count: 800).write(to: dir.appendingPathComponent("agent.meta.json"))
+        let nested = dir.appendingPathComponent("sess/subagents")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data(repeating: 0x41, count: 500).write(to: nested.appendingPathComponent("b.jsonl"))
+
+        let files = await ManageScanService().scanSessionArea(roots: [dir])
+        let names = Set(files.map { URL(fileURLWithPath: $0.path).lastPathComponent })
+        #expect(names == ["a.jsonl", "b.jsonl"])
+        #expect(files.allSatisfy { $0.sizeBytes > 0 })
+        #expect(files.allSatisfy { $0.modifiedAt != nil })
+    }
+
+    @Test("missing root yields empty result (no crash)")
+    func missingRoot() async {
+        let files = await ManageScanService().scanSessionArea(roots: [URL(fileURLWithPath: "/nope-\(UUID().uuidString)")])
+        #expect(files.isEmpty)
+    }
+
+    @Test("scanDiskItems returns 1-depth items + recursive directory size")
+    func diskItems() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data(repeating: 0, count: 100).write(to: dir.appendingPathComponent("x.bin"))
+        let big = dir.appendingPathComponent("big")
+        try FileManager.default.createDirectory(at: big, withIntermediateDirectories: true)
+        try Data(repeating: 0, count: 5000).write(to: big.appendingPathComponent("y.bin"))
+
+        let entries = await ManageScanService().scanDiskItems(home: dir).sorted { $0.name < $1.name }
+        #expect(entries.count == 2)
+        let bigEntry = try #require(entries.first { $0.name == "big" })
+        #expect(bigEntry.isDirectory)
+        #expect(bigEntry.sizeBytes >= 5000)
+    }
+}

--- a/LupenTests/Domain/Manage/ManageTitleFormatterTests.swift
+++ b/LupenTests/Domain/Manage/ManageTitleFormatterTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageTitleFormatter Tests")
+struct ManageTitleFormatterTests {
+
+    @Test("custom title takes top priority")
+    func customWins() {
+        let t = ManageTitleFormatter.sessionTitle(
+            firstPrompt: "first prompt text", cachedTitle: "auto cached", customTitle: "My Renamed Session"
+        )
+        #expect(t == "My Renamed Session")
+    }
+
+    @Test("no custom → fall back to first prompt")
+    func fallbackToFirstPrompt() {
+        let t = ManageTitleFormatter.sessionTitle(
+            firstPrompt: "hello world", cachedTitle: "auto cached", customTitle: nil
+        )
+        #expect(t == "hello world")
+    }
+
+    @Test("no custom or first → fall back to cachedTitle")
+    func fallbackToCached() {
+        let t = ManageTitleFormatter.sessionTitle(
+            firstPrompt: nil, cachedTitle: "auto cached", customTitle: nil
+        )
+        #expect(t == "auto cached")
+    }
+
+    @Test("none present → fallback text")
+    func emptyFallback() {
+        let t = ManageTitleFormatter.sessionTitle(firstPrompt: nil, cachedTitle: nil, customTitle: nil)
+        #expect(t == "(Untitled session)")
+    }
+
+    @Test("whitespace-only values are treated as empty")
+    func whitespaceTreatedEmpty() {
+        let t = ManageTitleFormatter.sessionTitle(
+            firstPrompt: "   \n  ", cachedTitle: nil, customTitle: "  \t "
+        )
+        #expect(t == "(Untitled session)")
+    }
+
+    @Test("normalize newlines/tabs/repeated spaces into one line")
+    func cleanCollapsesWhitespace() {
+        let cleaned = ManageTitleFormatter.clean("line1\nline2\t\tfoo   bar")
+        #expect(cleaned == "line1 line2 foo bar")
+    }
+
+    @Test("strip code fences")
+    func cleanStripsFences() {
+        let cleaned = ManageTitleFormatter.clean("```swift\nlet x = 1\n```")
+        #expect(cleaned == "swift let x = 1")
+    }
+
+    @Test("truncate with ellipsis when over maxLength")
+    func truncates() {
+        let t = ManageTitleFormatter.truncate("abcdefghij", maxLength: 5)
+        #expect(t == "abcd…")
+    }
+
+    @Test("keep original when at or below maxLength")
+    func noTruncateWhenShort() {
+        #expect(ManageTitleFormatter.truncate("abc", maxLength: 5) == "abc")
+    }
+
+    @Test("long first prompt is truncated in the title")
+    func longPromptTruncatedInTitle() {
+        let long = String(repeating: "x", count: 200)
+        let t = ManageTitleFormatter.sessionTitle(firstPrompt: long, cachedTitle: nil, customTitle: nil, maxLength: 80)
+        #expect(t.count == 80)
+        #expect(t.hasSuffix("…"))
+    }
+}

--- a/LupenTests/Domain/Manage/ManageTrashServiceTests.swift
+++ b/LupenTests/Domain/Manage/ManageTrashServiceTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageTrashService Tests")
+struct ManageTrashServiceTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-trash-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("after trashing the original is gone, and restore brings it back")
+    func trashAndRestore() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("a.jsonl")
+        try Data(repeating: 0x41, count: 200).write(to: file)
+
+        let service = ManageTrashService()
+        let outcome = await service.trash([file.path])
+        #expect(outcome.trashedPaths == [file.path])
+        #expect(outcome.failedPaths.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: file.path) == false)
+        #expect(outcome.restore.count == 1)
+
+        await service.restore(outcome.restore)
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test("missing path is silently skipped (neither success nor failure)")
+    func missingSkipped() async {
+        let outcome = await ManageTrashService().trash(["/nope-\(UUID().uuidString)/x.jsonl"])
+        #expect(outcome.trashedPaths.isEmpty)
+        #expect(outcome.failedPaths.isEmpty)
+    }
+
+    @Test("trash multiple files")
+    func trashMultiple() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let a = dir.appendingPathComponent("a.jsonl")
+        let b = dir.appendingPathComponent("b.jsonl")
+        try Data(repeating: 0, count: 50).write(to: a)
+        try Data(repeating: 0, count: 50).write(to: b)
+
+        let outcome = await ManageTrashService().trash([a.path, b.path])
+        #expect(Set(outcome.trashedPaths) == Set([a.path, b.path]))
+        #expect(FileManager.default.fileExists(atPath: a.path) == false)
+        #expect(FileManager.default.fileExists(atPath: b.path) == false)
+
+        // cleanup: 복원 후 dir 삭제가 깔끔
+        await ManageTrashService().restore(outcome.restore)
+    }
+}

--- a/LupenTests/Domain/Manage/ManageTrashServiceTests.swift
+++ b/LupenTests/Domain/Manage/ManageTrashServiceTests.swift
@@ -51,7 +51,7 @@ struct ManageTrashServiceTests {
         #expect(FileManager.default.fileExists(atPath: a.path) == false)
         #expect(FileManager.default.fileExists(atPath: b.path) == false)
 
-        // cleanup: 복원 후 dir 삭제가 깔끔
+        // cleanup: restoring first keeps the dir removal clean
         await ManageTrashService().restore(outcome.restore)
     }
 }

--- a/LupenTests/Domain/Manage/StorageClassifierTests.swift
+++ b/LupenTests/Domain/Manage/StorageClassifierTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+/// allowlist 분류기 — 세션영역 안만 삭제 가능, auth/config/DB·세션영역 밖·
+/// 인덱싱 중은 차단, 규칙 밖은 잠김. 경우의 수 전반을 검증.
+@Suite("StorageClassifier Tests")
+struct StorageClassifierTests {
+
+    private let home = URL(fileURLWithPath: "/Users/test/.claude")
+    private func makeClassifier(activeWindow: TimeInterval = 600) -> StorageClassifier {
+        StorageClassifier(
+            scope: .init(providerHome: home, sessionAreaRoots: [home.appendingPathComponent("projects")]),
+            activeWindow: activeWindow
+        )
+    }
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+    private var old: Date { Date(timeIntervalSince1970: 0) }
+
+    // MARK: - Session area (deletable)
+
+    @Test("old tracked session jsonl → safe + deletable")
+    func sessionAreaSafe() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/projects/foo/sess.jsonl",
+            isIndexed: true, isIndexing: false, lastModified: old, now: now
+        )
+        #expect(r.classification == .safe)
+        #expect(r.protection == .deletable)
+    }
+
+    @Test("recently modified session → caution (still deletable)")
+    func recentIsCaution() {
+        let recent = now.addingTimeInterval(-60)
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/projects/foo/sess.jsonl",
+            isIndexed: true, isIndexing: false, lastModified: recent, now: now
+        )
+        #expect(r.classification == .caution)
+        #expect(r.protection == .deletable)
+    }
+
+    @Test("untracked (session area) → caution + deletable")
+    func untrackedIsCaution() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/projects/foo/orphan.jsonl",
+            isIndexed: false, isIndexing: false, lastModified: old, now: now
+        )
+        #expect(r.classification == .caution)
+        #expect(r.protection == .deletable)
+    }
+
+    // MARK: - Hard blocks
+
+    @Test("while indexing → everything blocked")
+    func indexingBlocks() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/projects/foo/sess.jsonl",
+            isIndexed: true, isIndexing: true, lastModified: old, now: now
+        )
+        #expect(r.protection == .blocked)
+    }
+
+    @Test("provider home root (outside session area, inside home) → blocked")
+    func providerHomeOutsideSessionArea() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/watchtower/big.bin",
+            isIndexed: false, isIndexing: false, lastModified: old, now: now
+        )
+        #expect(r.protection == .blocked)
+    }
+
+    @Test("fully outside provider home → unclassified, locked")
+    func fullyOutsideIsLocked() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/Documents/random.jsonl",
+            isIndexed: false, isIndexing: false, lastModified: old, now: now
+        )
+        #expect(r.classification == .unclassified)
+        #expect(r.protection == .locked)
+    }
+
+    @Test("sqlite inside session area still hard-blocked")
+    func sqliteInsideStillBlocked() {
+        let r = makeClassifier().classify(
+            path: "/Users/test/.claude/projects/foo/index.sqlite3",
+            isIndexed: false, isIndexing: false, lastModified: old, now: now
+        )
+        #expect(r.protection == .blocked)
+    }
+
+    // MARK: - isHardBlocked unit
+
+    @Test("hard-block filename matching (sqlite/wal/auth/config/credentials)")
+    func hardBlockNames() {
+        #expect(StorageClassifier.isHardBlocked(name: "logs_2.sqlite"))
+        #expect(StorageClassifier.isHardBlocked(name: "state_5.sqlite-wal"))
+        #expect(StorageClassifier.isHardBlocked(name: "index.sqlite3-shm"))
+        #expect(StorageClassifier.isHardBlocked(name: "auth.json"))
+        #expect(StorageClassifier.isHardBlocked(name: "config.toml"))
+        #expect(StorageClassifier.isHardBlocked(name: "credentials.json"))
+        #expect(StorageClassifier.isHardBlocked(name: "refresh.lock"))
+    }
+
+    @Test("normal session files are not hard-blocked")
+    func normalNotBlocked() {
+        #expect(!StorageClassifier.isHardBlocked(name: "sess.jsonl"))
+        #expect(!StorageClassifier.isHardBlocked(name: "rollout-2026.jsonl"))
+        #expect(!StorageClassifier.isHardBlocked(name: "agent-abc.jsonl"))
+    }
+
+    // MARK: - Containment
+
+    @Test("isDescendant is true only for strict descendants")
+    func descendant() {
+        let root = URL(fileURLWithPath: "/a/b")
+        #expect(StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b/c"), of: root))
+        #expect(StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b/c/d.txt"), of: root))
+        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b"), of: root))   // 자기 자신 X
+        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/x"), of: root))
+        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/bc/d"), of: root)) // prefix 오인 X
+    }
+}

--- a/LupenTests/Domain/Manage/StorageClassifierTests.swift
+++ b/LupenTests/Domain/Manage/StorageClassifierTests.swift
@@ -107,6 +107,11 @@ struct StorageClassifierTests {
         #expect(!StorageClassifier.isHardBlocked(name: "sess.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "rollout-2026.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "agent-abc.jsonl"))
+        // prefix 매칭 제거 회귀 방지 — auth/config/credentials로 *시작*만 해도
+        // 정확 일치가 아니면 정상 세션 로그로 취급(삭제 가능).
+        #expect(!StorageClassifier.isHardBlocked(name: "configuration-notes.jsonl"))
+        #expect(!StorageClassifier.isHardBlocked(name: "auth-flow.jsonl"))
+        #expect(!StorageClassifier.isHardBlocked(name: "credentials-summary.jsonl"))
     }
 
     // MARK: - Containment

--- a/LupenTests/Domain/Manage/StorageClassifierTests.swift
+++ b/LupenTests/Domain/Manage/StorageClassifierTests.swift
@@ -2,8 +2,9 @@ import Testing
 import Foundation
 @testable import Lupen
 
-/// allowlist 분류기 — 세션영역 안만 삭제 가능, auth/config/DB·세션영역 밖·
-/// 인덱싱 중은 차단, 규칙 밖은 잠김. 경우의 수 전반을 검증.
+/// Allowlist classifier — only paths inside the session area are deletable;
+/// auth/config/DB, anything outside the session area, and in-progress indexing
+/// are blocked, while anything outside the rules is locked. Exercises the full range of cases.
 @Suite("StorageClassifier Tests")
 struct StorageClassifierTests {
 
@@ -107,8 +108,8 @@ struct StorageClassifierTests {
         #expect(!StorageClassifier.isHardBlocked(name: "sess.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "rollout-2026.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "agent-abc.jsonl"))
-        // prefix 매칭 제거 회귀 방지 — auth/config/credentials로 *시작*만 해도
-        // 정확 일치가 아니면 정상 세션 로그로 취급(삭제 가능).
+        // regression guard against prefix matching — names that merely *start* with
+        // auth/config/credentials are treated as normal session logs (deletable) unless they match exactly.
         #expect(!StorageClassifier.isHardBlocked(name: "configuration-notes.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "auth-flow.jsonl"))
         #expect(!StorageClassifier.isHardBlocked(name: "credentials-summary.jsonl"))
@@ -121,8 +122,8 @@ struct StorageClassifierTests {
         let root = URL(fileURLWithPath: "/a/b")
         #expect(StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b/c"), of: root))
         #expect(StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b/c/d.txt"), of: root))
-        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b"), of: root))   // 자기 자신 X
+        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/b"), of: root))   // not itself
         #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/x"), of: root))
-        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/bc/d"), of: root)) // prefix 오인 X
+        #expect(!StorageClassifier.isDescendant(URL(fileURLWithPath: "/a/bc/d"), of: root)) // no prefix false-positive
     }
 }


### PR DESCRIPTION
## Summary
Adds a **Manage Sessions & Storage** window (⌘⇧M) to browse and clean up Claude Code (`~/.claude`) and Codex (`~/.codex`) sessions by disk usage, with cache inspection and a read-only all-disk view.

## Tabs
- **Sessions** — multi-column table (status / project / session / created / updated / size / files) with a detail inspector
- **Lupen Cache** — index.sqlite3 / WAL / snapshot breakdown, coverage, rebuild & clear snapshots
- **All Disk** — read-only view of the largest items under the provider home

## Deletion safety
- Allowlist classification — only explicitly-safe items are deletable; unclassified is locked
- Hard-block auth/config/state DBs; block while indexing; session-area only
- Trash-only (no permanent delete) + Undo; conservative index reconcile on partial failure

## Highlights
- Tracked / untracked-orphan / index-remnant reconciliation with a status column
- Background FS scan with cancellation; index reads moved off the main actor for responsiveness
- Accessibility labels, dark-mode-safe layer colors, English-only UI

## Tests
160 passing across 10 Manage suites (classifier, reconciler, row filter, deletion planner, trash, scan/cancel, models, title formatter, provider context, disk sizer).