### PR TITLE
fix: auto-select first session on cold launch (focus ring + no selection)

### DIFF
--- a/Lupen/UI/Dashboard/DashboardSplitViewController.swift
+++ b/Lupen/UI/Dashboard/DashboardSplitViewController.swift
@@ -156,11 +156,9 @@ final class DashboardSplitViewController: NSSplitViewController {
         sidebarItem.minimumThickness = 200
         sidebarItem.maximumThickness = 400
         sidebarItem.canCollapse = false
-        addSplitViewItem(sidebarItem)
 
         let rightItem = NSSplitViewItem(viewController: rightVC)
         rightItem.minimumThickness = 400
-        addSplitViewItem(rightItem)
 
         // Wire selection: session list -> turn outline -> detail
         sessionListVC.onSessionSelected = { [weak self] session in
@@ -213,6 +211,16 @@ final class DashboardSplitViewController: NSSplitViewController {
         detailVC.onHeaderResizeEnded = { [weak self] in
             self?.handleResizeEnded()
         }
+
+        // Add split items LAST. `addSplitViewItem(sidebarItem)` loads
+        // sessionListVC.view, which triggers its first `reloadData` — and that
+        // reload can auto-select a session and invoke `onSessionSelected`.
+        // Wiring the callbacks above FIRST ensures that early auto-select
+        // actually drives the turn outline; otherwise `onSessionSelected` is
+        // still nil at that point, so the row gets selected but the turn list
+        // never renders until the user clicks a *different* session.
+        addSplitViewItem(sidebarItem)
+        addSplitViewItem(rightItem)
     }
 
     // MARK: - Drag-to-resize handlers

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -75,6 +75,10 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// changed. The next reload with rows for that provider auto-selects a
     /// session so the right pane recovers without another user click.
     private var pendingAutoSelectProvider: ProviderKind?
+    /// Cold-launch guard: `showDashboard` calls `selectFirstSessionIfNeeded`
+    /// before any rows exist, so that eager attempt no-ops. We retry once when
+    /// the first non-empty data arrives. Set true only on a successful select.
+    private var didAutoSelectInitialSession = false
     /// Project keys currently expanded.
     ///
     /// On first launch (no persisted state) this defaults to empty — groups
@@ -1165,6 +1169,10 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                 if restoreSelection(sessionId: candidate.sessionId) {
                     let row = outlineView.row(forItem: candidate)
                     if row >= 0 { outlineView.scrollRowToVisible(row) }
+                    // Claim keyboard focus for the outline so AppKit doesn't
+                    // leave first-responder on the provider-mode popup (stray
+                    // focus ring). Applies to every auto-select path.
+                    if let window = view.window { window.makeFirstResponder(outlineView) }
                     return true
                 }
             }
@@ -1235,6 +1243,18 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                   pendingAutoSelectProvider == activeProvider {
             if selectFirstVisibleSession() {
                 pendingAutoSelectProvider = nil
+            }
+        } else if !restoredSelection,
+                  automaticSessionSelectionEnabled,
+                  !didAutoSelectInitialSession {
+            // Cold launch: `showDashboard` fired `selectFirstSessionIfNeeded`
+            // before any rows existed, so nothing got selected and there was no
+            // retry — leaving a permanent "No Selection". Retry when the first
+            // non-empty data arrives; `selectFirstVisibleSession` claims
+            // keyboard focus for the outline on success, so AppKit doesn't
+            // leave a stray focus ring on the provider-mode popup.
+            if selectFirstVisibleSession() {
+                didAutoSelectInitialSession = true
             }
         } else if !restoredSelection, previousSelectionId != nil {
             onSelectionCleared?()
@@ -2096,7 +2116,18 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
     /// 2. Otherwise, the first session of the first (most-recent activity) group.
     func selectFirstSessionIfNeeded() {
         guard automaticSessionSelectionEnabled else { return }
-        guard outlineView.selectedRow < 0 else { return }
+        guard outlineView.selectedRow < 0 else {
+            // Already auto-selected by the first reloadData — which ran before
+            // the window existed, so its makeFirstResponder was a no-op. The
+            // window is live now (this runs from showDashboard after
+            // makeKeyAndOrderFront), so claim focus for the outline; otherwise
+            // AppKit's key loop leaves first-responder on the provider-mode
+            // popup, showing a stray focus ring.
+            if let window = view.window {
+                window.makeFirstResponder(outlineView)
+            }
+            return
+        }
 
         // Prefer the active session's node if it's in the tree.
         if let activeId = store.activeSession?.id,

--- a/Lupen/UI/Support/CostColor.swift
+++ b/Lupen/UI/Support/CostColor.swift
@@ -18,7 +18,7 @@ enum CostColor {
     /// sits closer to the title's near-white label color, so on a dark row the
     /// cost reads as a gentle highlight rather than a hot orange. Same warm
     /// family as the partial/warning orange; N/A is the slate `unavailable`.
-    nonisolated(unsafe) static let accent = NSColor(name: "CostAccent") { appearance in
+    static let accent = NSColor(name: "CostAccent") { appearance in
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         return isDark
             ? NSColor(srgbRed: 232.0 / 255, green: 185.0 / 255, blue: 126.0 / 255, alpha: 1)
@@ -29,7 +29,7 @@ enum CostColor {
     /// rather than competing with the orange cost figures, and distinct from
     /// the plain dim gray used for sub-$1 amounts. Dynamic per appearance —
     /// lighter slate on dark, deeper slate on light.
-    nonisolated(unsafe) static let unavailable = NSColor(name: "CostUnavailable") { appearance in
+    static let unavailable = NSColor(name: "CostUnavailable") { appearance in
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         return isDark
             ? NSColor(srgbRed: 144.0 / 255, green: 160.0 / 255, blue: 180.0 / 255, alpha: 1)


### PR DESCRIPTION
## Summary
Fix two dashboard cold-launch bugs and clear a build warning.

On a fresh launch the first session's turn list never appeared until the
user clicked a *different* session and came back, and a stray focus ring
sat on the provider-mode popup.

## Root cause
`DashboardSplitViewController` called `addSplitViewItem(sidebarItem)` —
which loads the session list view and triggers its first `reloadData`
(and thus an auto-select) — *before* wiring `onSessionSelected`. At that
moment the callback was still `nil`, so the row got selected but the turn
outline was never driven.

## What's included
- **`DashboardSplitViewController`**: move `addSplitViewItem` calls to the
  end of setup, after all selection callbacks are wired.
- **`SessionListViewController`**: retry the cold-launch auto-select once
  the first non-empty data arrives (`didAutoSelectInitialSession` guard),
  and claim keyboard focus for the outline so AppKit doesn't leave a stray
  focus ring on the provider-mode popup. Focus handling is centralized in
  `selectFirstVisibleSession`.
- **`CostColor`**: drop unnecessary `nonisolated(unsafe)` on two
  `Sendable` `NSColor` constants (resolves two build warnings).

## Testing
- `xcodebuild build` — BUILD SUCCEEDED, no new warnings.
- Manually verified: cold launch now auto-selects the first session,
  renders its turn list immediately, and shows no stray focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)