### PR TITLE
perf: fix multi-thousand-step turn UI freeze

### DIFF
--- a/Lupen/Domain/Conversation/Story/ConversationBlock.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationBlock.swift
@@ -162,3 +162,20 @@ struct StatusBlock: ConversationBlock, Equatable {
     var role: BlockRole { .system }
     var plainTextFallback: String { kind.message }
 }
+
+/// Curation cap for very large turns. When a turn has so many blocks that
+/// rendering each as its own card would freeze the UI (multi-thousand-step
+/// codex turns), consecutive runs of supporting (secondary) blocks are folded
+/// into one of these: a collapsed one-line summary that expands to the
+/// per-activity summary lines rendered as a single text view — so the card
+/// count stays in the dozens regardless of step count.
+struct ActivityGroupBlock: ConversationBlock, Equatable {
+    let id: String
+    /// One summary line per folded activity (tool group / thinking).
+    let summaryLines: [String]
+    let isHighlighted: Bool
+    var tier: BlockTier { .secondary }
+    var role: BlockRole { .assistant }
+    var count: Int { summaryLines.count }
+    var plainTextFallback: String { summaryLines.joined(separator: "\n") }
+}

--- a/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
@@ -170,6 +170,61 @@ enum ConversationStoryBuilder {
             ), at: 0)
         }
 
-        return blocks
+        return Self.collapsedIfTooLarge(blocks)
+    }
+
+    // MARK: - Curation cap for very large turns
+
+    /// Above this many blocks, fold the bulk of the turn.
+    private static let maxBlocksBeforeCollapse = 200
+    /// Keep the first block (usually the prompt) as an individual card.
+    private static let keepHead = 1
+    /// Keep the last few blocks (the final answer / status) as individual cards.
+    private static let keepTail = 3
+
+    /// Curation cap for very large turns. Folding only the secondary (tool/
+    /// thinking) runs was not enough — codex turns interleave *thousands* of
+    /// `AssistantTextBlock` replies (primary), which kept exploding the card/
+    /// view count and froze the UI. So above the cap we keep the first block and
+    /// the last few (the final answer/status) as individual cards, and fold
+    /// EVERYTHING in between — tools, thinking, and intermediate replies — into
+    /// one `ActivityGroupBlock` (a collapsed summary, expandable to one text
+    /// view). Full per-step detail stays available in the Raw / Usage tabs.
+    private static func collapsedIfTooLarge(_ blocks: [ConversationBlock]) -> [ConversationBlock] {
+        guard blocks.count > max(maxBlocksBeforeCollapse, keepHead + keepTail + 1) else {
+            return blocks
+        }
+        let head = Array(blocks.prefix(keepHead))
+        let tail = Array(blocks.suffix(keepTail))
+        let middle = Array(blocks[keepHead..<(blocks.count - keepTail)])
+        let group = ActivityGroupBlock(
+            id: "ag:\(middle.first?.id ?? blocks[0].id)",
+            summaryLines: middle.map { summaryLine(for: $0) },
+            isHighlighted: middle.contains { $0.isHighlighted }
+        )
+        return head + [group] + tail
+    }
+
+    private static func summaryLine(for block: ConversationBlock) -> String {
+        switch block {
+        case let group as ToolGroupBlock:
+            let head = group.count == 1 ? group.toolName : "\(group.toolName) ×\(group.count)"
+            let first = group.calls.first?.inputSummary ?? ""
+            return first.isEmpty ? head : "\(head)  \(first)"
+        case let thinking as ThinkingBlock:
+            return "[thinking] \(firstLine(thinking.text))"
+        case let reply as AssistantTextBlock:
+            return "[reply] \(firstLine(reply.markdown))"
+        case let prompt as UserPromptBlock:
+            return "[you] \(prompt.text.map(firstLine) ?? "")"
+        case let status as StatusBlock:
+            return status.kind.message
+        default:
+            return block.plainTextFallback
+        }
+    }
+
+    private static func firstLine(_ text: String) -> String {
+        text.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
     }
 }

--- a/Lupen/Store/SQLiteConversationSource.swift
+++ b/Lupen/Store/SQLiteConversationSource.swift
@@ -217,10 +217,13 @@ struct SQLiteConversationSource: Sendable {
                 ordinalByUuid[locator.uuid] = ordinal
             }
         }
+        // Index locators by uuid once — attaching per step with first(where:)
+        // was O(n²) and froze the UI on multi-thousand-step turns.
+        let locatorByUuid = Dictionary(locators.map { ($0.uuid, $0) }, uniquingKeysWith: { first, _ in first })
         return assembled
             .filter { ordinalByUuid[$0.uuid] != nil }
             .sorted { (ordinalByUuid[$0.uuid] ?? 0) < (ordinalByUuid[$1.uuid] ?? 0) }
-            .map { attachLocator(to: $0, from: locators) }
+            .map { attachLocator(to: $0, using: locatorByUuid) }
     }
 
     /// Steps-table projection: display-grade rows (Codex default; Claude
@@ -233,6 +236,8 @@ struct SQLiteConversationSource: Sendable {
         let payloads = provider == .codex
             ? codexToolPayloads(rows: rows, locators: locators)
             : [:]
+        // Index locators by uuid once — O(1) attach instead of O(n²) first(where:).
+        let locatorByUuid = Dictionary(locators.map { ($0.uuid, $0) }, uniquingKeysWith: { first, _ in first })
         return rows.map { row in
             let payload = payloads[row.uuid]
             var toolCalls: [ToolUseInfo] = []
@@ -268,7 +273,7 @@ struct SQLiteConversationSource: Sendable {
                 requestId: row.requestId,
                 model: row.model
             )
-            return attachLocator(to: step, from: locators)
+            return attachLocator(to: step, using: locatorByUuid)
         }
     }
 
@@ -392,9 +397,9 @@ struct SQLiteConversationSource: Sendable {
     /// through `step.rawJSONLocator` — attach it from the DB locator so
     /// `AppStateStore.rawJSON(for:)` resolves without the legacy
     /// project-path scan (which SQLite mode cannot serve).
-    private func attachLocator(to step: Step, from locators: [StoreTurnLineLocator]) -> Step {
+    private func attachLocator(to step: Step, using locatorByUuid: [String: StoreTurnLineLocator]) -> Step {
         guard step.rawJSONLocator == nil,
-              let locator = locators.first(where: { $0.uuid == step.uuid }),
+              let locator = locatorByUuid[step.uuid],
               let byteOffset = locator.byteOffset
         else { return step }
         // Fingerprint carries size only: DATETIME storage truncates

--- a/Lupen/UI/Dashboard/Conversation/BlockRendererRegistry.swift
+++ b/Lupen/UI/Dashboard/Conversation/BlockRendererRegistry.swift
@@ -11,8 +11,6 @@ import AppKit
 /// add a value here when a new renderer needs one.
 @MainActor
 struct RenderContext {
-    /// Max reading-column width for the body (Q4). Used by Phase C node rendering.
-    var readingWidth: CGFloat = 620
     /// Reveal a file path (image/attachment) in Finder on click. Ported for parity.
     var revealInFinder: (URL) -> Void = { url in
         let path = url.path

--- a/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
@@ -43,6 +43,7 @@ final class ConversationDetailView: NSView {
         registry.register(StatusBannerRenderer())
         registry.register(ToolGroupCardRenderer())
         registry.register(ThinkingCardRenderer())
+        registry.register(ActivityGroupRenderer())
     }
 
     private func setup() {

--- a/Lupen/UI/Dashboard/Conversation/Renderers/ActivityGroupRenderer.swift
+++ b/Lupen/UI/Dashboard/Conversation/Renderers/ActivityGroupRenderer.swift
@@ -1,0 +1,42 @@
+//
+//  ActivityGroupRenderer.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/21.
+//
+
+import AppKit
+
+/// Activity-group card — for very large turns, folds many tool/thinking
+/// activities into one collapsed line ("N activities"). Expanding renders the
+/// per-activity summary lines as a single text view, so the card count and view
+/// cost stay bounded no matter how many steps the turn has (the fix for the
+/// multi-thousand-step freeze).
+@MainActor
+struct ActivityGroupRenderer: BlockRenderer {
+    func makeView(for block: ActivityGroupBlock, context: RenderContext) -> NSView {
+        let disclosure = DisclosureCardView(summary: summary(block)) {
+            let body = ConversationBodyTextView.make()
+            body.setBody(NSAttributedString(
+                string: block.summaryLines.joined(separator: "\n"),
+                attributes: [
+                    .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+            ))
+            return body
+        }
+        let card = CardContainerView(role: .assistant, tier: block.tier, highlighted: block.isHighlighted)
+        card.setBody(disclosure)
+        return card
+    }
+
+    private func summary(_ block: ActivityGroupBlock) -> NSAttributedString {
+        ConversationInlineText.symbolPrefixed(
+            "gearshape.2.fill",
+            text: "\(block.count) activities",
+            font: .systemFont(ofSize: 12, weight: .medium),
+            color: .secondaryLabelColor
+        )
+    }
+}

--- a/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
+++ b/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
@@ -267,6 +267,49 @@ struct ConversationStoryBuilderTests {
         #expect(group?.isHighlighted == true)
     }
 
+    @Test("large turn: long secondary runs fold into one ActivityGroupBlock")
+    func curationCapFoldsLargeRuns() {
+        var steps = [step(.prompt, uuid: "p1", text: "q")]
+        for i in 0..<300 {
+            steps.append(step(.toolCall, uuid: "t\(i)",
+                toolCalls: [toolUse("u\(i)", i.isMultiple(of: 2) ? "Read" : "Bash", path: "/f\(i)")]))
+        }
+        steps.append(step(.reply, uuid: "a1", text: "done"))
+        let blocks = ConversationStoryBuilder.build(turn: turn(steps))
+        // head(prompt) + folded activity group + tail(3) — far fewer than ~302 cards.
+        #expect(blocks.count == 5)
+        #expect(blocks.contains { $0 is ActivityGroupBlock })
+        #expect(blocks.first is UserPromptBlock)
+        #expect(blocks.last is AssistantTextBlock)
+        let group = blocks.compactMap { $0 as? ActivityGroupBlock }.first
+        #expect(group?.summaryLines.count == 298)
+        #expect(group?.tier == .secondary)
+    }
+
+    @Test("large turn: thousands of interleaved replies fold too (not just tools)")
+    func curationCapFoldsInterleavedReplies() {
+        var steps = [step(.prompt, uuid: "p1", text: "q")]
+        for i in 0..<250 {
+            steps.append(step(.reply, uuid: "r\(i)", text: "reply \(i)"))
+            steps.append(step(.toolCall, uuid: "t\(i)", toolCalls: [toolUse("u\(i)", "Read", path: "/f\(i)")]))
+        }
+        steps.append(step(.reply, uuid: "final", text: "final answer"))
+        let blocks = ConversationStoryBuilder.build(turn: turn(steps))
+        // The bulk (incl. intermediate replies) collapses — only head + tail stay as cards.
+        #expect(blocks.count == 5)
+        #expect((blocks.compactMap { $0 as? ActivityGroupBlock }.first?.summaryLines.count ?? 0) > 400)
+    }
+
+    @Test("small turn: stays as individual cards (no folding)")
+    func curationCapKeepsSmallTurns() {
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.toolCall, uuid: "t1", toolCalls: [toolUse("u1", "Read", path: "/a")]),
+            step(.reply, uuid: "a1", text: "done"),
+        ]))
+        #expect(!blocks.contains { $0 is ActivityGroupBlock })
+    }
+
     @Test("빈 Turn → orphan 배너만")
     func emptyTurn() {
         let blocks = ConversationStoryBuilder.build(turn: turn([], id: "empty"))


### PR DESCRIPTION
## Summary
Selecting a turn with thousands of steps (large codex rollouts) froze the
UI for minutes. Two compounding causes, both fixed here.

## Root cause
1. **O(n²) locator attach** — `attachLocator` did `locators.first(where:)`
   per step, so an n-step turn scanned the locator array n times.
2. **Unbounded card/view count** — every block rendered as its own card.
   A multi-thousand-step turn produced thousands of NSViews. Folding only
   the secondary (tool/thinking) runs wasn't enough: codex turns interleave
   *thousands* of intermediate `AssistantTextBlock` replies (primary) that
   kept exploding the view count.

## What's included
- **`SQLiteConversationSource`**: index locators by uuid once into a
  `[String: StoreTurnLineLocator]` and look up O(1) instead of O(n²).
  Behavior preserved (first match on uuid).
- **`ConversationStoryBuilder`**: curation cap — above 200 blocks, keep the
  first block and the last 3 as individual cards, and fold EVERYTHING in
  between (tools, thinking, and intermediate replies) into one
  `ActivityGroupBlock`. Card count stays in single digits regardless of
  step count. Full per-step detail remains in the Raw / Usage tabs.
- **`ActivityGroupBlock` + `ActivityGroupRenderer`**: collapsed "N activities"
  card that expands to per-activity summary lines in a single text view.
- **`RenderContext`**: drop the now-unused `readingWidth` constant.

## Testing
- New unit tests in `ConversationStoryBuilderTests`:
  - long secondary runs fold into one `ActivityGroupBlock`
  - thousands of interleaved replies fold too (not just tools)
  - small turns stay as individual cards (no folding)
- `xcodebuild test` (ConversationStoryBuilderTests) — TEST SUCCEEDED.
- Manually verified: the previously-freezing large turn now opens instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)