### PR TITLE
fix: Codex Verify Usage accuracy + CLI SIGTRAP crash (+ tests)

### DIFF
--- a/Lupen/CLI/Commands/VerifyCommand.swift
+++ b/Lupen/CLI/Commands/VerifyCommand.swift
@@ -82,6 +82,9 @@ struct CLIVerifyReport {
         let viewCostUSD: Double?
         let truthCostUSD: Double?
         let kinds: [String]
+        /// True when the session has at least one error-severity finding
+        /// (cost / token / coverage drift). Warning-only rows do not gate CI.
+        let hasError: Bool
 
         var delta: Double? {
             guard let view = viewCostUSD, let truth = truthCostUSD else { return nil }
@@ -91,19 +94,27 @@ struct CLIVerifyReport {
 
     let provider: ProviderKind
     let verifiedSessionCount: Int
-    /// Diverging sessions only.
+    /// Diverging sessions (error and warning severities both).
     let rows: [Row]
     let pendingCount: Int
     let issueCount: Int
 
-    var hasDrift: Bool { !rows.isEmpty }
+    /// Sessions with real accounting drift — what the table and exit code key on.
+    var errorRows: [Row] { rows.filter(\.hasError) }
+    /// Sessions whose only findings are warnings (unknown pricing / zero-usage).
+    var warningOnlyRows: [Row] { rows.filter { !$0.hasError } }
+
+    /// Exit-4 gate: only error-severity drift fails the build. Warnings
+    /// (estimation limits) are reported but do not break CI.
+    var hasDrift: Bool { !errorRows.isEmpty }
 
     /// Group divergences by session into mismatch rows (pure: no store).
     static func build(divergences: [GroundTruthVerifier.Divergence]) -> [Row] {
-        var bySession: [String: (view: Double?, truth: Double?, kinds: Set<String>)] = [:]
+        var bySession: [String: (view: Double?, truth: Double?, kinds: Set<String>, hasError: Bool)] = [:]
         for divergence in divergences {
-            var entry = bySession[divergence.sessionId] ?? (nil, nil, [])
+            var entry = bySession[divergence.sessionId] ?? (nil, nil, [], false)
             entry.kinds.insert(kindLabel(divergence.kind))
+            if divergence.severity == .error { entry.hasError = true }
             if case .costMismatch(let view, let truth) = divergence.kind {
                 entry.view = view
                 entry.truth = truth
@@ -111,7 +122,7 @@ struct CLIVerifyReport {
             bySession[divergence.sessionId] = entry
         }
         var rows = bySession.map { sessionId, entry in
-            Row(sessionId: sessionId, viewCostUSD: entry.view, truthCostUSD: entry.truth, kinds: entry.kinds.sorted())
+            Row(sessionId: sessionId, viewCostUSD: entry.view, truthCostUSD: entry.truth, kinds: entry.kinds.sorted(), hasError: entry.hasError)
         }
         rows.sort { lhs, rhs in
             let lhsDelta = abs(lhs.delta ?? 0), rhsDelta = abs(rhs.delta ?? 0)
@@ -155,7 +166,7 @@ struct CLIVerifyReport {
         CLIOutput.line("\(provider.cliLabel) · cost verification")
         CLIOutput.line()
 
-        if rows.isEmpty {
+        if errorRows.isEmpty {
             if verifiedSessionCount == 0 {
                 CLIOutput.line("No sessions found to verify.")
             } else {
@@ -170,7 +181,7 @@ struct CLIVerifyReport {
                     .init("Δ", align: .right),
                     .init("MISMATCH"),
                 ],
-                rows: rows.map { row in
+                rows: errorRows.map { row in
                     [
                         CLITopReport.shortID(row.sessionId),
                         row.viewCostUSD.map(CLIFormat.money) ?? "—",
@@ -182,9 +193,12 @@ struct CLIVerifyReport {
             )
             CLIOutput.line(table.render(color: color))
             CLIOutput.line()
-            CLIOutput.line("✗ \(rows.count) of \(verifiedSessionCount) session(s) diverge from the recomputed truth.")
+            CLIOutput.line("✗ \(errorRows.count) of \(verifiedSessionCount) session(s) diverge from the recomputed truth.")
         }
 
+        if !warningOnlyRows.isEmpty {
+            CLIOutput.note("\(warningOnlyRows.count) session(s) with warnings only (unknown pricing / zero-usage) — not counted as drift; open Verify Costs for detail.")
+        }
         if pendingCount > 0 {
             CLIOutput.note("\(pendingCount) session(s) still importing — rerun after indexing settles.")
         }
@@ -198,11 +212,14 @@ struct CLIVerifyReport {
             "provider": provider.rawValue,
             "verifiedSessions": verifiedSessionCount,
             "drift": hasDrift,
+            "errorSessions": errorRows.count,
+            "warningSessions": warningOnlyRows.count,
             "pending": pendingCount,
             "issues": issueCount,
             "mismatches": rows.map { row in
                 [
                     "sessionId": row.sessionId,
+                    "severity": row.hasError ? "error" : "warning",
                     "viewCostUsd": row.viewCostUSD as Any? ?? NSNull(),
                     "truthCostUsd": row.truthCostUSD as Any? ?? NSNull(),
                     "costDelta": row.delta as Any? ?? NSNull(),
@@ -214,10 +231,11 @@ struct CLIVerifyReport {
 
     var csv: String {
         CLICSV.render(
-            header: ["sessionId", "viewCostUsd", "truthCostUsd", "costDelta", "kinds"],
+            header: ["sessionId", "severity", "viewCostUsd", "truthCostUsd", "costDelta", "kinds"],
             rows: rows.map { row in
                 [
                     row.sessionId,
+                    row.hasError ? "error" : "warning",
                     row.viewCostUSD.map { String(format: "%.6f", $0) } ?? "",
                     row.truthCostUSD.map { String(format: "%.6f", $0) } ?? "",
                     row.delta.map { String(format: "%.6f", $0) } ?? "",

--- a/Lupen/Data/Models/ParsedLine.swift
+++ b/Lupen/Data/Models/ParsedLine.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-/// Classified JSONL line in the legacy pipeline — either an assistant
-/// `RawEntry` (billable) or auxiliary user/system metadata.
+/// Classified JSONL line — either an assistant `RawEntry` (billable) or
+/// auxiliary user/system metadata. Produced by `JSONLParser` and consumed by
+/// `AuxiliaryLinker`; held only in memory.
 ///
-/// Serialized into `ParseSnapshot.allAuxiliaryLines`. Bump
-/// `SnapshotSchema.currentVersion` whenever a case is added or removed.
+/// The old `Codable` conformance (serialized into the now-removed
+/// `ParseSnapshot`) was dropped in the SQLite-first refactor — nothing
+/// encodes/decodes this type anymore.
 enum ParsedLine: Sendable, Equatable {
     case assistant(RawEntry)
     case user(UserAux)
     case system(SystemAux)
 
-    struct UserAux: Sendable, Equatable, Codable {
+    struct UserAux: Sendable, Equatable {
         let uuid: String
         let parentUuid: String?
         let sessionId: String
@@ -18,51 +20,12 @@ enum ParsedLine: Sendable, Equatable {
         let text: String
     }
 
-    struct SystemAux: Sendable, Equatable, Codable {
+    struct SystemAux: Sendable, Equatable {
         let uuid: String
         let sessionId: String
         let timestamp: String
         let systemPrompt: String?
         let toolDefinitionsJSON: Data?
         let rawPayload: Data?
-    }
-}
-
-extension ParsedLine: Codable {
-
-    private enum Kind: String, Codable {
-        case assistant, user, system
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind, assistant, user, system
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        let kind = try c.decode(Kind.self, forKey: .kind)
-        switch kind {
-        case .assistant:
-            self = .assistant(try c.decode(RawEntry.self, forKey: .assistant))
-        case .user:
-            self = .user(try c.decode(UserAux.self, forKey: .user))
-        case .system:
-            self = .system(try c.decode(SystemAux.self, forKey: .system))
-        }
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var c = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .assistant(let entry):
-            try c.encode(Kind.assistant, forKey: .kind)
-            try c.encode(entry, forKey: .assistant)
-        case .user(let ua):
-            try c.encode(Kind.user, forKey: .kind)
-            try c.encode(ua, forKey: .user)
-        case .system(let sa):
-            try c.encode(Kind.system, forKey: .kind)
-            try c.encode(sa, forKey: .system)
-        }
     }
 }

--- a/Lupen/Domain/LoggerService.swift
+++ b/Lupen/Domain/LoggerService.swift
@@ -63,13 +63,30 @@ final class LoggerService {
 
     // MARK: - Singleton
 
-    nonisolated static let shared = { MainActor.assumeIsolated { LoggerService() } }()
+    nonisolated static let shared = LoggerService()
 
-    private init() {
+    /// Intentionally empty and `nonisolated` so the singleton can be created
+    /// from whatever thread first touches `shared`. Under the CLI that is a
+    /// background indexing queue, not the main actor — the previous
+    /// `MainActor.assumeIsolated` trapped there (`lupen summary` crashed
+    /// 100%). The main-actor-isolated stored properties (`@Observable` makes
+    /// even in-init assignment go through isolated setters) keep their
+    /// declared defaults here; persisted filter state and file logging are
+    /// restored lazily on the first `log()` via `bootstrapIfNeeded()`, which
+    /// always runs on the main actor.
+    nonisolated init() {}
+
+    /// One-time, main-actor restore of persisted filter state + file logging.
+    /// Deferred out of `init` because `init` must stay `nonisolated` for a
+    /// safe background first-touch. Every `log()` entry point is main-actor
+    /// isolated, so touching the isolated properties here is safe.
+    private var didBootstrap = false
+    private func bootstrapIfNeeded() {
+        guard !didBootstrap else { return }
+        didBootstrap = true
+        // `loadFilterState` sets `fileLoggingEnabled`, whose `didSet` starts
+        // file logging when enabled — no separate start call needed.
         loadFilterState()
-        if fileLoggingEnabled {
-            startFileLogging()
-        }
     }
 
     // MARK: - Nonisolated entry point for background threads
@@ -113,6 +130,7 @@ final class LoggerService {
         line: Int = #line,
         skipOSLog: Bool = false
     ) {
+        bootstrapIfNeeded()
         let source = URL(fileURLWithPath: file).lastPathComponent
         let entry = LogEntry(
             level: level,
@@ -286,6 +304,8 @@ final class LoggerService {
         UserDefaults.standard.set(searchText, forKey: Keys.searchText)
     }
 
+    /// Restores persisted filter state. Called once from `bootstrapIfNeeded()`
+    /// on the main actor (never from the `nonisolated init`).
     private func loadFilterState() {
         if let rawValues = UserDefaults.standard.stringArray(forKey: Keys.enabledLevels) {
             enabledLevels = Set(rawValues.compactMap { LogLevel(rawValue: $0) })

--- a/Lupen/Domain/LoggerService.swift
+++ b/Lupen/Domain/LoggerService.swift
@@ -98,25 +98,20 @@ final class LoggerService {
         file: String = #file,
         line: Int = #line
     ) {
-        if Thread.isMainThread {
-            MainActor.assumeIsolated {
-                self.log(level, message, context: context, file: file, line: line)
-            }
-            return
-        }
-        // Background thread: emit OSLog synchronously so Console.app
-        // (`subsystem:com.momoraul.lupen`) shows the event without waiting
-        // for the main-queue hop. Then hop to main to store the entry
-        // in the in-app Logs window and file log. The main-queue
-        // `log()` call uses `skipOSLog: true` to avoid a second
-        // os_log emission — without that flag every background log
-        // showed up twice in Console.app (parse / cache / ParsePerf
-        // were the most visible victims).
+        // Build the entry once, here, so its timestamp reflects the call site
+        // and OSLog + the in-app store share the exact same record. Emit to
+        // OSLog synchronously (thread-safe) for immediate Console.app
+        // visibility, then hop to the main actor to record it in the Logs
+        // window / file. There is deliberately NO `MainActor.assumeIsolated`
+        // and no main-thread fast path: assuming "main thread == main actor
+        // executor" traps on the CLI's background index queue (and on any
+        // non-main executor), which was the root of the `lupen` SIGTRAP.
+        // This path is safe to call from any thread or executor.
         let source = URL(fileURLWithPath: file).lastPathComponent
         let entry = LogEntry(level: level, message: message, context: context, source: source, line: line)
         Self.emitToOSLog(entry: entry, context: context)
         DispatchQueue.main.async { [self] in
-            self.log(level, message, context: context, file: file, line: line, skipOSLog: true)
+            store(entry)
         }
     }
 
@@ -127,10 +122,8 @@ final class LoggerService {
         _ message: String,
         context: String? = nil,
         file: String = #file,
-        line: Int = #line,
-        skipOSLog: Bool = false
+        line: Int = #line
     ) {
-        bootstrapIfNeeded()
         let source = URL(fileURLWithPath: file).lastPathComponent
         let entry = LogEntry(
             level: level,
@@ -139,24 +132,22 @@ final class LoggerService {
             source: source,
             line: line
         )
+        store(entry)
+        Self.emitToOSLog(entry: entry, context: context)
+    }
 
+    /// Records an already-built entry into the in-app log + file. Main-actor
+    /// isolated — the single sink shared by `log()` (direct main-thread calls)
+    /// and the main hop of `logFromAnyThread`. OSLog emission is the caller's
+    /// job, so the background path can emit synchronously off-main (for
+    /// immediate Console visibility) before hopping here, without a duplicate.
+    private func store(_ entry: LogEntry) {
+        bootstrapIfNeeded()
         entries.append(entry)
-
         if entries.count > Self.maxEntries {
             entries.removeFirst(entries.count - Self.maxEntries)
         }
-
         writeToFile(entry)
-
-        // Emit to OSLog (DEBUG + Release) unless the caller already
-        // did so (e.g. the background path in `logFromAnyThread`
-        // emits synchronously before hopping to main, then calls this
-        // with `skipOSLog = true` to avoid a duplicate emission).
-        // LoggerService is the single fan-out point — every consumer
-        // (in-app, file, OSLog) reads from it.
-        if !skipOSLog {
-            Self.emitToOSLog(entry: entry, context: context)
-        }
     }
 
     /// Shared OSLog fan-out — used by both `log()` (main-thread path)

--- a/Lupen/Domain/Snapshot/GroundTruth.swift
+++ b/Lupen/Domain/Snapshot/GroundTruth.swift
@@ -4,6 +4,16 @@ import Foundation
 /// for the design rationale.
 enum GroundTruth {
 
+    /// Severity of a verification finding. `error` means real accounting
+    /// drift (cost / token / coverage); `warning` means an estimation
+    /// limit or informational note (unknown pricing, zero-usage events)
+    /// that does NOT undermine the numbers. The Verify Costs window and
+    /// `lupen verify` use this to separate "must fix" from "FYI".
+    enum Severity: Sendable, Equatable {
+        case warning
+        case error
+    }
+
     /// Raw record for one line carrying a `usage` block.
     ///
     /// To check whether the view dropped this line, look up by `uuid`:

--- a/Lupen/Domain/Snapshot/GroundTruthVerifier.swift
+++ b/Lupen/Domain/Snapshot/GroundTruthVerifier.swift
@@ -43,6 +43,32 @@ enum GroundTruthVerifier {
         let sessionId: String
         let kind: Kind
 
+        /// Maps each divergence kind to a severity — the single source of
+        /// truth for Verify Costs / `lupen verify`. Real cost / token /
+        /// coverage drift is an `error`; estimation limits (unknown pricing)
+        /// and informational notes (zero-usage events) are `warning`.
+        var severity: GroundTruth.Severity {
+            switch kind {
+            case .costMismatch,
+                 .inputTokenMismatch,
+                 .outputTokenMismatch,
+                 .reasoningOutputTokenMismatch,
+                 .cacheCreationInputMismatch,
+                 .cacheReadMismatch,
+                 .cacheCreation1hMismatch,
+                 .cacheCreation5mMismatch,
+                 .requestCountMismatch,
+                 .missingPickedRequestId,
+                 .sessionMissingInView,
+                 .sourceRejected,
+                 .parserRejectedLine:
+                return .error
+            case .missingUsageEvent,
+                 .unknownPricing:
+                return .warning
+            }
+        }
+
         var humanDescription: String {
             switch kind {
             case .costMismatch(let v, let t):

--- a/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
+++ b/Lupen/Domain/Snapshot/ProviderUsageVerifier.swift
@@ -270,7 +270,6 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
         var currentModel = metadata.model
         var currentTurnId: String?
         var generatedTurnOrdinal = 0
-        var skippedDuplicateCumulativeCount = 0
         var unknownPricingKeys: Set<String> = []
         var hasSeenLiveEventUserMessage = false
         let requestIdPrefix = sourceDiscriminator.map {
@@ -290,16 +289,20 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
 
             if entry.type == "response_item",
                payload.type == "message",
-               payload.role == "user",
-               payload.turnId == nil {
+               payload.role == "user" {
                 let text = normalized(payload.messageText)
-                if !eventUserMessages.isEmpty && !eventUserMessages.contains(text) {
+                if payload.turnId == nil,
+                   !eventUserMessages.isEmpty && !eventUserMessages.contains(text) {
                     continue
                 }
-                // Generated ids are a fallback for context-less files —
-                // a live `turn_context` id keeps owning the turn (the
-                // loader attributes usage to it across user messages).
-                if currentTurnId == nil {
+                // Mirror CodexUsageAggregator's turn tracking exactly so the
+                // verifier reproduces the importer's requestId for every line.
+                // A live turnId owns the turn; generated ids are the
+                // context-less fallback (the loader attributes usage to a
+                // live id across user messages).
+                if let turnId = Self.nonEmpty(payload.turnId) {
+                    currentTurnId = turnId
+                } else if currentTurnId == nil {
                     generatedTurnOrdinal += 1
                     currentTurnId = generatedTurnId(generatedTurnOrdinal)
                 }
@@ -316,22 +319,37 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
                 continue
             }
 
+            // Turn terminators reset the turn so the next user message opens a
+            // fresh generated turn — matches the importer (Aggregator). Without
+            // this, every line after the first turn collapses onto generated-1
+            // and reads as a spurious "missing billable requestId".
+            if Self.isTurnTerminator(entry, payload) {
+                currentTurnId = nil
+                continue
+            }
+
             guard entry.type == "event_msg", payload.type == "token_count" else {
                 continue
             }
 
-            let duplicateCountBefore = skippedDuplicateCumulativeCount
-            guard let usage = resolveUsage(
-                payload.info,
-                previousTotal: &previousTotal,
-                skippedDuplicates: &skippedDuplicateCumulativeCount
-            ) else {
-                if skippedDuplicateCumulativeCount == duplicateCountBefore {
-                    issues.append(GroundTruth.ReportIssue(
-                        sessionId: groupSessionId,
-                        kind: .missingUsageEvent(lineNumber: recordLineNumber)
-                    ))
-                }
+            let usage: CodexTokenUsage
+            switch resolveUsage(payload.info, previousTotal: &previousTotal) {
+            case .usable(let resolved):
+                usage = resolved
+            case .duplicate:
+                // total == previousTotal: an already-counted cumulative
+                // snapshot. Skip silently — not a divergence.
+                continue
+            case .zeroUsage:
+                // A zero-token token_count is a normal Codex artefact
+                // (session start / empty turn). It carries no cost and is
+                // not a defect — do not report it as a divergence.
+                continue
+            case .noUsage:
+                issues.append(GroundTruth.ReportIssue(
+                    sessionId: groupSessionId,
+                    kind: .missingUsageEvent(lineNumber: recordLineNumber)
+                ))
                 continue
             }
 
@@ -388,18 +406,31 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
         return lines
     }
 
+    /// Outcome of resolving one `token_count` event, distinguishing the
+    /// reasons usage may be absent so the caller can tell a normal artefact
+    /// (`zeroUsage`) from a genuine read failure (`noUsage`).
+    private enum UsageResolution {
+        /// Non-zero tokens to attribute to a billable line.
+        case usable(CodexTokenUsage)
+        /// `total == previousTotal`: an already-counted cumulative snapshot.
+        case duplicate
+        /// `info` present but all tokens are zero — a normal Codex artefact
+        /// (session start / empty turn), not a defect.
+        case zeroUsage
+        /// `info` missing or no usable token shape — a genuine read failure.
+        case noUsage
+    }
+
     private static func resolveUsage(
         _ info: CodexEntry.Info?,
-        previousTotal: inout CodexTokenUsage?,
-        skippedDuplicates: inout Int
-    ) -> CodexTokenUsage? {
-        guard let info else { return nil }
+        previousTotal: inout CodexTokenUsage?
+    ) -> UsageResolution {
+        guard let info else { return .noUsage }
 
         if let total = info.totalTokenUsage,
            let previousTotal,
            total == previousTotal {
-            skippedDuplicates += 1
-            return nil
+            return .duplicate
         }
 
         let usage: CodexTokenUsage?
@@ -429,8 +460,8 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
         if let total = info.totalTokenUsage {
             previousTotal = total
         }
-        guard let usage, !usage.isZero else { return nil }
-        return usage
+        guard let usage else { return .noUsage }
+        return usage.isZero ? .zeroUsage : .usable(usage)
     }
 
     private func computeCost(
@@ -529,6 +560,24 @@ struct CodexUsageVerifier: ProviderUsageVerifier {
 
     private static func generatedTurnId(_ ordinal: Int) -> String {
         "generated-\(ordinal)"
+    }
+
+    /// Trimmed turnId or nil when empty — mirrors CodexUsageAggregator so a
+    /// live turnId on a user message owns the turn identically on both sides.
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    /// A turn boundary — resets the current turn so the next user message
+    /// opens a fresh generated turn. Copied from CodexUsageAggregator to keep
+    /// the verifier's requestId generation in lockstep with the importer.
+    private static func isTurnTerminator(_ entry: CodexEntry, _ payload: CodexEntry.Payload) -> Bool {
+        if entry.type == "turn_aborted" || entry.type == "task_complete" {
+            return true
+        }
+        return entry.type == "event_msg"
+            && (payload.type == "turn_aborted" || payload.type == "task_complete")
     }
 
     private static func eventUserMessageTexts(in entries: [CodexEntry]) -> Set<String> {

--- a/Lupen/Domain/Snapshot/VerifyCostsResult.swift
+++ b/Lupen/Domain/Snapshot/VerifyCostsResult.swift
@@ -105,12 +105,24 @@ struct ProviderVerificationResult: Sendable {
         let viewOutputTokens: Int?
         let viewReasoningOutputTokens: Int?
         let hasUnknownPricing: Bool
-        let matchesView: Bool   // false if any divergence for this session
-        let divergenceCount: Int
+        /// Findings that undermine the numbers (cost / token / coverage).
+        let errorCount: Int
+        /// Estimation/informational findings (unknown pricing, zero-usage).
+        let warningCount: Int
         let inViewAndTruth: Bool
         /// Index import incomplete (6.8) — comparisons skipped; shown
-        /// as "Pending" instead of ✓/✗.
+        /// as "Pending" instead of ✓/⚠/✗.
         var indexPending: Bool = false
+
+        /// Clean = no errors AND no warnings. Name kept for call sites that
+        /// only care whether the row is fully green.
+        var matchesView: Bool { errorCount == 0 && warningCount == 0 }
+        /// Total findings of any severity (for the detail pane / Markdown).
+        var divergenceCount: Int { errorCount + warningCount }
+        /// Accounting drift present — the ✗ (red) state.
+        var hasError: Bool { errorCount > 0 }
+        /// Only warnings present — the ⚠ (orange) state.
+        var hasWarningsOnly: Bool { errorCount == 0 && warningCount > 0 }
 
         var costMatchesExact: Bool {
             guard let delta = costDelta else { return false }
@@ -131,10 +143,15 @@ struct ProviderVerificationResult: Sendable {
             return Dictionary(uniqueKeysWithValues: rows.map { ($0.sessionId, $0) })
         }()
 
-        // Count divergences per sessionId across all kinds.
-        var divergenceCountBySession: [String: Int] = [:]
+        // Tally findings per sessionId, split by severity, so a row can be
+        // classified as clean / warning-only / error.
+        var errorCountBySession: [String: Int] = [:]
+        var warningCountBySession: [String: Int] = [:]
         for d in divergences {
-            divergenceCountBySession[d.sessionId, default: 0] += 1
+            switch d.severity {
+            case .error: errorCountBySession[d.sessionId, default: 0] += 1
+            case .warning: warningCountBySession[d.sessionId, default: 0] += 1
+            }
         }
         let unknownPricingSessionIds = Set(report.issues.compactMap { issue -> String? in
             if case .unknownPricing = issue.kind { return issue.sessionId }
@@ -150,8 +167,10 @@ struct ProviderVerificationResult: Sendable {
             let viewRequestCount = viewSession != nil ? (aggregate?.requestCount ?? 0) : nil
             let viewCost: Double? = viewSession != nil ? (aggregate?.costUSD ?? 0) : nil
             let costDelta = viewCost.map { $0 - truth.dedupedTotalCostUSD }
-            let divCount = divergenceCountBySession[rowSessionId, default: 0]
-                + (rowSessionId == sid ? 0 : divergenceCountBySession[sid, default: 0])
+            let errorCount = errorCountBySession[rowSessionId, default: 0]
+                + (rowSessionId == sid ? 0 : errorCountBySession[sid, default: 0])
+            let warningCount = warningCountBySession[rowSessionId, default: 0]
+                + (rowSessionId == sid ? 0 : warningCountBySession[sid, default: 0])
             rollups.append(SessionRollup(
                 sessionId: rowSessionId,
                 rawLineCount: truth.rawLineCount,
@@ -169,8 +188,8 @@ struct ProviderVerificationResult: Sendable {
                 viewOutputTokens: viewSession != nil ? (aggregate?.outputTokens ?? 0) : nil,
                 viewReasoningOutputTokens: viewSession != nil ? (aggregate?.reasoningOutputTokens ?? 0) : nil,
                 hasUnknownPricing: unknownPricingSessionIds.contains(sid) || unknownPricingSessionIds.contains(scopedSid),
-                matchesView: divCount == 0,
-                divergenceCount: divCount,
+                errorCount: errorCount,
+                warningCount: warningCount,
                 inViewAndTruth: viewSession != nil,
                 indexPending: pendingSessionIds.contains(rowSessionId)
                     || pendingSessionIds.contains(sid)
@@ -186,7 +205,10 @@ struct ProviderVerificationResult: Sendable {
         for session in store.sessions where !truthIds.contains(session.id) {
             let aggregate = aggregatesBySessionId[session.id]
             let viewCost = aggregate?.costUSD ?? 0
-            let divCount = divergenceCountBySession[session.id, default: 0]
+            // A view cost with no ground-truth counterpart is real drift → error.
+            let errorCount = errorCountBySession[session.id, default: 0]
+                + (viewCost == 0 ? 0 : 1)
+            let warningCount = warningCountBySession[session.id, default: 0]
             rollups.append(SessionRollup(
                 sessionId: session.id,
                 rawLineCount: 0,
@@ -204,8 +226,8 @@ struct ProviderVerificationResult: Sendable {
                 viewOutputTokens: aggregate?.outputTokens ?? 0,
                 viewReasoningOutputTokens: aggregate?.reasoningOutputTokens ?? 0,
                 hasUnknownPricing: unknownPricingSessionIds.contains(session.id),
-                matchesView: viewCost == 0 && divCount == 0,
-                divergenceCount: divCount + (viewCost == 0 ? 0 : 1),
+                errorCount: errorCount,
+                warningCount: warningCount,
                 inViewAndTruth: false,
                 indexPending: pendingSessionIds.contains(session.id)
             ))

--- a/Lupen/UI/VerifyCosts/VerifyCostsViewController.swift
+++ b/Lupen/UI/VerifyCosts/VerifyCostsViewController.swift
@@ -9,17 +9,51 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
 
     private let store: AppStateStore
 
+    /// Severity-based result filter for the table. `all` shows every row;
+    /// `warningsAndErrors` hides clean rows (the old "show only mismatches");
+    /// `errors` shows only accounting drift. Pending rows stay visible under
+    /// every filter — they're unresolved attention items, not clean rows.
+    enum FilterLevel: Int, CaseIterable {
+        case all
+        case warningsAndErrors
+        case errors
+
+        /// Short segment label. The "Warnings" tab also includes errors —
+        /// spelled out in `tooltip` to keep the control compact.
+        var label: String {
+            switch self {
+            case .all: return "All"
+            case .warningsAndErrors: return "Warnings"
+            case .errors: return "Errors"
+            }
+        }
+
+        /// Hover tooltip clarifying what each segment surfaces.
+        var tooltip: String {
+            switch self {
+            case .all: return "Show every session"
+            case .warningsAndErrors: return "Show sessions with warnings or errors"
+            case .errors: return "Show only sessions with errors"
+            }
+        }
+    }
+
     // State
     private var result: VerifyCostsResult?
     private var rollups: [VerifyCostsResult.SessionRollup] = []
     private var filtered: [VerifyCostsResult.SessionRollup] = []
-    private var showOnlyMismatches: Bool = false
+    private var filterLevel: FilterLevel = .all
     private var isRunning: Bool = false
 
     // UI
     private let runButton = NSButton(title: "Run", target: nil, action: nil)
     private let copyButton = NSButton(title: "Copy", target: nil, action: nil)
-    private let mismatchFilterCheckbox = NSButton(checkboxWithTitle: "Show only mismatches", target: nil, action: nil)
+    private let filterControl = NSSegmentedControl(
+        labels: FilterLevel.allCases.map(\.label),
+        trackingMode: .selectOne,
+        target: nil,
+        action: nil
+    )
     private let summaryLabel = NSTextField(labelWithString: "")
     private let statusLabel = NSTextField(labelWithString: "")
     private let progressIndicator = NSProgressIndicator()
@@ -56,9 +90,13 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
         copyButton.isEnabled = false
         copyButton.toolTip = "Copy visible results (Markdown) to clipboard"
 
-        mismatchFilterCheckbox.target = self
-        mismatchFilterCheckbox.action = #selector(mismatchFilterToggled)
-        mismatchFilterCheckbox.state = .off
+        filterControl.target = self
+        filterControl.action = #selector(filterLevelChanged)
+        filterControl.segmentStyle = .rounded
+        filterControl.selectedSegment = filterLevel.rawValue
+        for level in FilterLevel.allCases {
+            filterControl.setToolTip(level.tooltip, forSegment: level.rawValue)
+        }
 
         progressIndicator.style = .spinning
         progressIndicator.controlSize = .small
@@ -76,7 +114,7 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
         summaryLabel.lineBreakMode = .byTruncatingTail
         summaryLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        let toolbarStack = NSStackView(views: [runButton, copyButton, progressIndicator, statusLabel, NSView(), mismatchFilterCheckbox, summaryLabel])
+        let toolbarStack = NSStackView(views: [runButton, copyButton, progressIndicator, statusLabel, NSView(), filterControl, summaryLabel])
         toolbarStack.orientation = .horizontal
         toolbarStack.alignment = .centerY
         toolbarStack.spacing = 10
@@ -228,7 +266,7 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
         let markdown = Self.buildMarkdownReport(
             result: result,
             rollups: filtered,
-            showingOnlyMismatches: showOnlyMismatches
+            filterLevel: filterLevel
         )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -243,8 +281,8 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
         }
     }
 
-    @objc private func mismatchFilterToggled() {
-        showOnlyMismatches = mismatchFilterCheckbox.state == .on
+    @objc private func filterLevelChanged() {
+        filterLevel = FilterLevel(rawValue: filterControl.selectedSegment) ?? .all
         applyFilter()
         tableView.reloadData()
         // Copy reflects the currently visible rollups, so its enabled
@@ -253,30 +291,39 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
     }
 
     private func applyFilter() {
-        if showOnlyMismatches {
-            // Pending rows stay visible under the filter — they're
-            // unresolved attention items, just not accounting failures.
-            filtered = rollups.filter { !$0.matchesView || $0.indexPending }
-        } else {
+        // Pending rows stay visible under every filter — they're unresolved
+        // attention items, not clean rows.
+        switch filterLevel {
+        case .all:
             filtered = rollups
+        case .warningsAndErrors:
+            filtered = rollups.filter { !$0.matchesView || $0.indexPending }
+        case .errors:
+            filtered = rollups.filter { $0.hasError || $0.indexPending }
         }
     }
 
     private func updateSummary(for result: VerifyCostsResult) {
         let pending = rollups.filter(\.indexPending).count
-        let failing = rollups.filter { !$0.matchesView && !$0.indexPending }.count
-        let clean = rollups.count - failing - pending
+        let errors = rollups.filter { $0.hasError && !$0.indexPending }.count
+        let warnings = rollups.filter { $0.hasWarningsOnly && !$0.indexPending }.count
+        let clean = rollups.count - errors - warnings - pending
         summaryLabel.stringValue = Self.summaryText(
-            clean: clean, failing: failing, pending: pending, result: result
+            clean: clean, warnings: warnings, errors: errors, pending: pending, result: result
         )
-        if failing == 0, pending == 0 {
-            statusLabel.stringValue = "All \(result.provider.descriptor.shortDisplayName) sessions match independent ground truth."
+        let shortName = result.provider.descriptor.shortDisplayName
+        if errors == 0, warnings == 0, pending == 0 {
+            statusLabel.stringValue = "All \(shortName) sessions match independent ground truth."
             statusLabel.textColor = .systemGreen
-        } else if failing == 0 {
-            statusLabel.stringValue = "No mismatches — \(pending) session(s) still indexing; re-run once the backfill settles."
+        } else if errors == 0 {
+            // Only warnings (estimation limits) and/or pending — nothing drifted.
+            var note = "No errors"
+            if warnings > 0 { note += " — \(warnings) warning(s)" }
+            if pending > 0 { note += "\(warnings > 0 ? "," : " —") \(pending) still indexing" }
+            statusLabel.stringValue = note + "."
             statusLabel.textColor = .secondaryLabelColor
         } else {
-            statusLabel.stringValue = "\(failing) \(result.provider.descriptor.shortDisplayName) session(s) differ from independent ground truth."
+            statusLabel.stringValue = "\(errors) \(shortName) session(s) differ from independent ground truth."
             statusLabel.textColor = .systemOrange
         }
     }
@@ -382,14 +429,19 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
             }
             label.alignment = .right
         case .match:
+            label.alignment = .center
             if rollup.indexPending {
                 label.stringValue = "⋯ indexing"
-                label.alignment = .center
                 label.textColor = .secondaryLabelColor
+            } else if rollup.hasError {
+                label.stringValue = "✗ \(rollup.errorCount)"
+                label.textColor = .systemRed
+            } else if rollup.hasWarningsOnly {
+                label.stringValue = "⚠ \(rollup.warningCount)"
+                label.textColor = .systemOrange
             } else {
-                label.stringValue = rollup.matchesView ? "✓" : "✗ \(rollup.divergenceCount)"
-                label.alignment = .center
-                label.textColor = rollup.matchesView ? .systemGreen : .systemOrange
+                label.stringValue = "✓"
+                label.textColor = .systemGreen
             }
         }
 
@@ -449,24 +501,25 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
     nonisolated static func buildMarkdownReport(
         result: VerifyCostsResult,
         rollups: [VerifyCostsResult.SessionRollup],
-        showingOnlyMismatches: Bool
+        filterLevel: FilterLevel
     ) -> String {
         let pending = rollups.filter(\.indexPending).count
-        let failing = rollups.filter { !$0.matchesView && !$0.indexPending }.count
-        let clean = rollups.count - failing - pending
+        let errors = rollups.filter { $0.hasError && !$0.indexPending }.count
+        let warnings = rollups.filter { $0.hasWarningsOnly && !$0.indexPending }.count
+        let clean = rollups.count - errors - warnings - pending
         var out: [String] = []
         out.append("# \(Self.reportTitle(for: result.provider))")
         out.append("")
         out.append("Provider: \(result.provider.descriptor.displayName)")
         out.append("")
-        out.append(Self.summaryText(clean: clean, failing: failing, pending: pending, result: result))
+        out.append(Self.summaryText(clean: clean, warnings: warnings, errors: errors, pending: pending, result: result))
         if result.provider == .codex {
             out.append("")
             out.append("Codex cost note: dollar totals are estimated from local token counts and Lupen's pricing table. Unknown-pricing usage remains visible, but its dollar cost is not included.")
         }
-        if showingOnlyMismatches {
+        if filterLevel != .all {
             out.append("")
-            out.append("_Filter: only mismatches shown below._")
+            out.append("_Filter: \(filterLevel.label) shown below._")
         }
         out.append("")
         if result.provider == .codex {
@@ -513,13 +566,15 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
 
     nonisolated static func summaryText(
         clean: Int,
-        failing: Int,
+        warnings: Int,
+        errors: Int,
         pending: Int = 0,
         result: VerifyCostsResult
     ) -> String {
-        let counts = pending > 0
-            ? String(format: "Clean %d · Pending %d · Mismatch %d", clean, pending, failing)
-            : String(format: "Clean %d · Mismatch %d", clean, failing)
+        var counts = "Clean \(clean)"
+        if warnings > 0 { counts += " · Warning \(warnings)" }
+        counts += " · Error \(errors)"
+        if pending > 0 { counts += " · Pending \(pending)" }
         var parts = [
             counts + String(
                 format: " · Scan %.1fs · Verify %.2fs",
@@ -553,9 +608,7 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
             let delta = Self.formatDeltaForDisplay(r.costDelta).text
             // Pending mirrors the table's "⋯ indexing" — a bare ✓ on a
             // skipped session read as "verified clean" in the export.
-            let match = r.indexPending
-                ? "⋯ indexing"
-                : (r.matchesView ? "✓" : "✗ \(r.divergenceCount)")
+            let match = Self.matchCell(for: r)
             out.append(
                 "| \(r.sessionId) | \(r.rawLineCount) | \(r.dedupedLineCount) | \(view) | "
                 + String(format: "$%.4f", r.truthCostUSD)
@@ -621,14 +674,28 @@ final class VerifyCostsViewController: NSViewController, NSTableViewDataSource, 
         return value.map { String(format: "$%.4f", $0) } ?? "—"
     }
 
+    /// 3-state cell for the Markdown "Match" column (Claude). Mirrors the
+    /// table's ✓ / ⚠ / ✗ / pending rendering.
+    nonisolated private static func matchCell(
+        for rollup: VerifyCostsResult.SessionRollup
+    ) -> String {
+        if rollup.indexPending { return "⋯ indexing" }
+        if rollup.matchesView { return "✓" }
+        if rollup.hasError { return "✗ \(rollup.errorCount)" }
+        return "⚠ \(rollup.warningCount)"
+    }
+
     nonisolated private static func codexStatusText(
         for rollup: VerifyCostsResult.SessionRollup
     ) -> String {
+        if rollup.indexPending { return "⋯ indexing" }
         if rollup.matchesView { return "✓" }
+        if rollup.hasError { return "✗ \(rollup.errorCount)" }
+        // Warnings only — unknown pricing is the common Codex case.
         if rollup.hasUnknownPricing {
-            return "✗ \(rollup.divergenceCount) pricing"
+            return "⚠ \(rollup.warningCount) pricing"
         }
-        return "✗ \(rollup.divergenceCount)"
+        return "⚠ \(rollup.warningCount)"
     }
 
     private func idleStatusText(for provider: ProviderKind) -> String {

--- a/LupenTests/CLI/CLICrashSmokeTests.swift
+++ b/LupenTests/CLI/CLICrashSmokeTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+/// End-to-end guard that the `lupen` CLI boots, indexes, and exits cleanly on a
+/// synthetic, fully-isolated corpus — exercising the real argument-parsing →
+/// indexing → summary path in a *separate process*.
+///
+/// On the SIGTRAP crash this suite was born from: that crash was a **timing
+/// race** — it fired only when the background index queue was the first to
+/// touch the `LoggerService.shared` singleton, ahead of the main thread. A
+/// small synthetic corpus indexes too fast to reproduce that race
+/// deterministically, so this subprocess test does NOT reliably reproduce the
+/// crash (it passes even against the pre-fix code). The **deterministic** guard
+/// for that crash lives in `LoggerServiceConcurrencyTests`
+/// (`initializesOffMainActor` won't even compile against a main-actor init).
+/// This suite stays valuable as a general "the CLI still boots and exits 0"
+/// regression guard.
+@Suite("CLI end-to-end smoke (subprocess)")
+struct CLICrashSmokeTests {
+
+    /// The host app binary doubles as the `lupen` CLI (see `main.swift`).
+    /// Under an app-hosted unit test, `Bundle.main` is that app.
+    private func lupenBinary() -> URL? {
+        Bundle.main.executableURL
+    }
+
+    @Test("`lupen summary` boots, indexes a synthetic corpus, and exits 0")
+    func summaryRunsAndExitsZero() throws {
+        let binary = try #require(lupenBinary(), "could not locate the host lupen binary")
+
+        let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
+        defer { cleanup() }
+        let indexDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-cli-smoke-index-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: indexDir) }
+
+        let proc = Process()
+        proc.executableURL = binary
+        proc.arguments = ["summary"]
+
+        // Hermetic: redirect every data source onto the synthetic corpus +
+        // a throwaway index dir (no developer data is touched).
+        var env = ProcessInfo.processInfo.environment
+        env["CLAUDE_CONFIG_DIR"] = corpus.root.path        // → root/projects
+        env["CODEX_HOME"] = corpus.codexHome.path
+        env["LUPEN_APP_SUPPORT_DIR"] = indexDir.path
+        proc.environment = env
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        try proc.run()
+        proc.waitUntilExit()
+
+        let outText = String(
+            data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+        ) ?? ""
+        let errText = String(
+            data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+        ) ?? ""
+
+        // A SIGTRAP (the regressed crash family) surfaces as an uncaught signal
+        // / status 133 — fail loudly here instead of taking the runner down.
+        #expect(
+            proc.terminationReason != .uncaughtSignal,
+            "lupen terminated by a signal (status \(proc.terminationStatus)): \(errText)"
+        )
+        #expect(
+            proc.terminationStatus == 0,
+            "lupen exited non-zero (\(proc.terminationStatus)): \(errText)"
+        )
+        // It actually produced a summary (not an early empty exit), so the
+        // index path genuinely ran.
+        #expect(
+            outText.contains("Sessions"),
+            "summary produced no report — index path may not have run: \(outText)"
+        )
+    }
+}

--- a/LupenTests/CLI/VerifyReportTests.swift
+++ b/LupenTests/CLI/VerifyReportTests.swift
@@ -31,9 +31,44 @@ struct VerifyReportTests {
         #expect(rows[0].truthCostUSD == 4)
         #expect(rows[0].delta == 1)
         #expect(rows[0].kinds == ["cost", "output"])  // sorted, deduped
+        #expect(rows[0].hasError)  // cost/token mismatches are errors
         #expect(rows[1].sessionId == "s2")
         #expect(rows[1].delta == nil)
         #expect(rows[1].kinds == ["requestCount"])
+        #expect(rows[1].hasError)
+    }
+
+    @Test("warning-only divergences do not gate CI (hasDrift=false)")
+    func warningsDoNotGate() {
+        let divergences = [
+            Divergence(sessionId: "s1", kind: .unknownPricing(model: "x")),
+            Divergence(sessionId: "s2", kind: .missingUsageEvent(lineNumber: 5)),
+        ]
+        let rows = CLIVerifyReport.build(divergences: divergences)
+        #expect(rows.allSatisfy { !$0.hasError })
+        let report = CLIVerifyReport(
+            provider: .codex, verifiedSessionCount: 2, rows: rows,
+            pendingCount: 0, issueCount: 2
+        )
+        #expect(report.hasDrift == false)
+        #expect(report.errorRows.isEmpty)
+        #expect(report.warningOnlyRows.count == 2)
+    }
+
+    @Test("a session mixing warning + error counts as drift")
+    func mixedSeverityIsDrift() {
+        let divergences = [
+            Divergence(sessionId: "s1", kind: .unknownPricing(model: "x")),
+            Divergence(sessionId: "s1", kind: .costMismatch(viewUSD: 5, truthUSD: 4)),
+        ]
+        let rows = CLIVerifyReport.build(divergences: divergences)
+        #expect(rows.count == 1)
+        #expect(rows[0].hasError)
+        let report = CLIVerifyReport(
+            provider: .codex, verifiedSessionCount: 1, rows: rows,
+            pendingCount: 0, issueCount: 1
+        )
+        #expect(report.hasDrift)
     }
 
     @Test("hasDrift and json/csv shapes")
@@ -44,7 +79,7 @@ struct VerifyReportTests {
 
         let drift = CLIVerifyReport(
             provider: .claudeCode, verifiedSessionCount: 3,
-            rows: [.init(sessionId: "s1", viewCostUSD: 5, truthCostUSD: 4, kinds: ["cost"])],
+            rows: [.init(sessionId: "s1", viewCostUSD: 5, truthCostUSD: 4, kinds: ["cost"], hasError: true)],
             pendingCount: 1, issueCount: 2
         )
         #expect(drift.hasDrift)
@@ -52,15 +87,17 @@ struct VerifyReportTests {
         #expect(JSONSerialization.isValidJSONObject(json))
         #expect(json["drift"] as? Bool == true)
         #expect(json["verifiedSessions"] as? Int == 3)
+        #expect(json["errorSessions"] as? Int == 1)
         #expect(json["pending"] as? Int == 1)
         let mismatches = json["mismatches"] as? [[String: Any]]
         #expect(mismatches?.count == 1)
         #expect(mismatches?[0]["sessionId"] as? String == "s1")
+        #expect(mismatches?[0]["severity"] as? String == "error")
         #expect(mismatches?[0]["costDelta"] as? Double == 1)
 
         let lines = drift.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        #expect(lines[0] == "sessionId,viewCostUsd,truthCostUsd,costDelta,kinds")
-        #expect(lines[1] == "s1,5.000000,4.000000,1.000000,cost")
+        #expect(lines[0] == "sessionId,severity,viewCostUsd,truthCostUsd,costDelta,kinds")
+        #expect(lines[1] == "s1,error,5.000000,4.000000,1.000000,cost")
     }
 
     @Test("a session with only token/count divergences yields a nil-cost row")
@@ -75,17 +112,18 @@ struct VerifyReportTests {
         #expect(rows[0].truthCostUSD == nil)
         #expect(rows[0].delta == nil)
         #expect(rows[0].kinds == ["output", "requestCount"])
+        #expect(rows[0].hasError)
     }
 
     @Test("csv renders nil cost cells as empty fields")
     func csvNilCells() {
         let report = CLIVerifyReport(
             provider: .claudeCode, verifiedSessionCount: 1,
-            rows: [.init(sessionId: "s", viewCostUSD: nil, truthCostUSD: nil, kinds: ["output", "requestCount"])],
+            rows: [.init(sessionId: "s", viewCostUSD: nil, truthCostUSD: nil, kinds: ["output", "requestCount"], hasError: true)],
             pendingCount: 0, issueCount: 0
         )
         let lines = report.csv.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        #expect(lines[1] == "s,,,,output;requestCount")
+        #expect(lines[1] == "s,error,,,,output;requestCount")
     }
 
     @Test("mismatchSummary keeps short lists, truncates long ones")
@@ -93,6 +131,30 @@ struct VerifyReportTests {
         #expect(CLIVerifyReport.mismatchSummary(["cost"]) == "cost")
         #expect(CLIVerifyReport.mismatchSummary(["a", "b", "c"]) == "a, b, c")
         #expect(CLIVerifyReport.mismatchSummary(["a", "b", "c", "d", "e"]) == "a, b, c +2 more")
+    }
+
+    @Test("divergence severity: cost/token/coverage drift = error; estimation = warning")
+    func divergenceSeverityMapping() {
+        func sev(_ kind: Divergence.Kind) -> GroundTruth.Severity {
+            Divergence(sessionId: "s", kind: kind).severity
+        }
+        // Errors — anything that undermines the numbers.
+        #expect(sev(.costMismatch(viewUSD: 1, truthUSD: 0)) == .error)
+        #expect(sev(.inputTokenMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.outputTokenMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.reasoningOutputTokenMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.cacheCreationInputMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.cacheReadMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.cacheCreation1hMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.cacheCreation5mMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.requestCountMismatch(view: 1, truth: 0)) == .error)
+        #expect(sev(.missingPickedRequestId(requestId: "r")) == .error)
+        #expect(sev(.sessionMissingInView(sessionId: "s")) == .error)
+        #expect(sev(.sourceRejected(reason: "x")) == .error)
+        #expect(sev(.parserRejectedLine(category: "c", lineNumber: 1, detail: "d")) == .error)
+        // Warnings — estimation limits / informational only.
+        #expect(sev(.missingUsageEvent(lineNumber: 1)) == .warning)
+        #expect(sev(.unknownPricing(model: "m")) == .warning)
     }
 
     @Test("kindLabel covers the divergence kinds used in output")

--- a/LupenTests/Domain/Codex/CodexUsageVerifierTests.swift
+++ b/LupenTests/Domain/Codex/CodexUsageVerifierTests.swift
@@ -261,4 +261,112 @@ struct CodexUsageVerifierTests {
         }
     }
 
+    @Test("zero-token token_count is a normal artefact, not a missing-usage divergence")
+    func zeroTokenEventIsNotReportedMissing() throws {
+        try withTempCodexHome { home in
+            // A token_count whose total/last are all zero — Codex emits these
+            // at session start / on empty turns. It carries no cost and must
+            // not be flagged (regression: it used to surface as "no usable
+            // token usage" and turn the whole session ✗).
+            let file = try writeCodexSession(home: home, lines: [
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:02Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex","total_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":0},"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":0}}}}"#
+            ])
+
+            let result = try verifiedStore(home: home, files: [file])
+
+            // Zero-token events produce no billable line, so the session has
+            // no truth entry at all — and crucially no missing-usage issue.
+            #expect(result.report.usageLines.isEmpty)
+            #expect(result.report.perSession["codex:verify-codex"] == nil)
+            #expect(result.divergences.isEmpty)
+            #expect(!result.divergences.contains { diff in
+                if case .missingUsageEvent = diff.kind { return true }
+                return false
+            })
+        }
+    }
+
+    @Test("info present but no token shape is still reported as missing usage")
+    func infoWithoutTokenShapeIsMissing() throws {
+        try withTempCodexHome { home in
+            // `info` exists (model only) but no total/last usage — a genuine
+            // read failure, distinct from the all-zero artefact above.
+            let file = try writeCodexSession(home: home, lines: [
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:02Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex"}}}"#
+            ])
+
+            let result = try verifiedStore(home: home, files: [file])
+
+            let missing = result.divergences.filter { diff in
+                if case .missingUsageEvent = diff.kind { return true }
+                return false
+            }
+            #expect(missing.count == 1)
+            #expect(missing.first?.severity == .warning)
+        }
+    }
+
+    @Test("generated-turn session: verifier reproduces the importer's requestIds")
+    func generatedTurnRequestIdsMatchImporter() throws {
+        try withTempCodexHome { home in
+            // No turn_context turnId → generated turn ids. A turn_aborted
+            // terminator resets the turn so the second user message opens
+            // generated-2. The verifier must mirror this (Fix: terminator
+            // handling) or every post-first-turn line reads as a spurious
+            // "missing billable requestId".
+            let file = try writeCodexSession(home: home, lines: [
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:01Z","payload":{"type":"user_message","message":"first"}}"#,
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:02Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex","total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110}}}}"#,
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:03Z","payload":{"type":"turn_aborted","reason":"interrupted"}}"#,
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:04Z","payload":{"type":"user_message","message":"second"}}"#,
+                #"{"type":"event_msg","timestamp":"2026-05-25T01:00:05Z","payload":{"type":"token_count","info":{"model":"gpt-5.3-codex","total_token_usage":{"input_tokens":160,"cached_input_tokens":0,"output_tokens":20,"reasoning_output_tokens":0,"total_tokens":180}}}}"#
+            ])
+
+            let result = try verifiedStore(home: home, files: [file])
+
+            #expect(result.report.perSession["codex:verify-codex"]?.dedupedLineCount == 2)
+            #expect(!result.divergences.contains { diff in
+                if case .missingPickedRequestId = diff.kind { return true }
+                return false
+            })
+            #expect(result.divergences.isEmpty)
+        }
+    }
+
+    @MainActor
+    @Test("rollups() classifies an unknown-pricing session as a warning row, not an error")
+    func rollupsClassifyUnknownPricingAsWarning() throws {
+        try withTempCodexHome { home in
+            let model = "gpt-future-codex"
+            let file = try writeCodexSession(
+                home: home, model: model, lines: [standardUsageLine(model: model)]
+            )
+            let store = try importedStore(home: home)
+            let report = CodexUsageVerifier().computeReport(files: [file])
+            let verification = CodexUsageVerifier().verify(report: report, againstSQLite: store)
+
+            let result = VerifyCostsResult(
+                provider: .codex,
+                startedAt: Date(timeIntervalSince1970: 0),
+                completedAt: Date(timeIntervalSince1970: 1),
+                scanElapsed: 0, verifyElapsed: 0, filesScanned: 1,
+                report: report,
+                divergences: verification.divergences,
+                viewSessionIds: [],
+                pendingSessionIds: verification.pendingSessionIds
+            )
+
+            // Exercise the real rollups() severity tally (Fix 3). View columns
+            // are empty (no store sessions) but the error/warning split comes
+            // entirely from the divergences, which is what we assert.
+            let rollups = result.rollups(withStore: AppStateStore())
+            let row = try #require(rollups.first { $0.sessionId == "codex:verify-codex" })
+            #expect(row.warningCount >= 1)
+            #expect(row.errorCount == 0)
+            #expect(row.hasWarningsOnly)
+            #expect(!row.hasError)
+            #expect(!row.matchesView)
+        }
+    }
+
 }

--- a/LupenTests/Domain/Conversation/ToolResultInfoTests.swift
+++ b/LupenTests/Domain/Conversation/ToolResultInfoTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ToolResultInfo")
+struct ToolResultInfoTests {
+
+    // MARK: - abbreviatedContent(limit:)
+
+    @Test("a single short line is returned verbatim")
+    func shortLine() {
+        let r = ToolResultInfo(toolUseId: "t", content: "hello world")
+        #expect(r.abbreviatedContent(limit: 120) == "hello world")
+    }
+
+    @Test("multiline content keeps only the first line")
+    func multilineKeepsFirstLine() {
+        let r = ToolResultInfo(toolUseId: "t", content: "first line\nsecond\nthird")
+        #expect(r.abbreviatedContent() == "first line")
+    }
+
+    @Test("a first line longer than the limit is truncated with an ellipsis")
+    func truncatesLongFirstLine() {
+        let r = ToolResultInfo(toolUseId: "t", content: String(repeating: "a", count: 200))
+        let out = r.abbreviatedContent(limit: 10)
+        #expect(out == String(repeating: "a", count: 10) + "…")
+        #expect(out.count == 11) // 10 chars + ellipsis
+    }
+
+    @Test("a first line exactly at the limit is verbatim (boundary, <=)")
+    func exactLimitIsVerbatim() {
+        let s = String(repeating: "b", count: 10)
+        let r = ToolResultInfo(toolUseId: "t", content: s)
+        #expect(r.abbreviatedContent(limit: 10) == s) // no ellipsis at == limit
+    }
+
+    @Test("empty content abbreviates to empty")
+    func emptyContent() {
+        let r = ToolResultInfo(toolUseId: "t", content: "")
+        #expect(r.abbreviatedContent() == "")
+    }
+
+    @Test("a long first line before a newline is still truncated by the limit")
+    func longFirstLineBeforeNewline() {
+        let r = ToolResultInfo(
+            toolUseId: "t", content: String(repeating: "x", count: 50) + "\nrest"
+        )
+        #expect(r.abbreviatedContent(limit: 20) == String(repeating: "x", count: 20) + "…")
+    }
+
+    // MARK: - encode content-cap round-trip
+
+    private func roundTrip(_ r: ToolResultInfo) throws -> ToolResultInfo {
+        let data = try JSONEncoder().encode(r)
+        return try JSONDecoder().decode(ToolResultInfo.self, from: data)
+    }
+
+    @Test("under-cap content round-trips verbatim (with all fields)")
+    func underCapRoundTrip() throws {
+        let r = ToolResultInfo(toolUseId: "tu", content: "small output", isError: true)
+        let back = try roundTrip(r)
+        #expect(back == r)
+        #expect(back.content == "small output")
+        #expect(back.toolUseId == "tu")
+        #expect(back.isError == true)
+    }
+
+    @Test("over-cap content is truncated with the marker on encode")
+    func overCapTruncates() throws {
+        let big = String(repeating: "Z", count: ToolResultInfo.encodedContentCapBytes + 500)
+        let r = ToolResultInfo(toolUseId: "tu", content: big)
+        let back = try roundTrip(r)
+
+        #expect(back.content != big)
+        #expect(back.content.hasSuffix(ToolResultInfo.truncationMarker))
+        #expect(back.content.hasPrefix(String(repeating: "Z", count: 100))) // head preserved
+        #expect(back.toolUseId == "tu")
+        // The retained head is clamped to the cap (Character count).
+        let head = String(back.content.dropLast(ToolResultInfo.truncationMarker.count))
+        #expect(head.count == ToolResultInfo.encodedContentCapBytes)
+    }
+
+    @Test("content exactly at the cap is NOT truncated (boundary, > triggers)")
+    func exactCapIsVerbatim() throws {
+        let s = String(repeating: "Q", count: ToolResultInfo.encodedContentCapBytes)
+        let r = ToolResultInfo(toolUseId: "tu", content: s)
+        let back = try roundTrip(r)
+        #expect(back.content == s)
+    }
+}

--- a/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
+++ b/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+/// Regression guard for the CLI crash where `lupen summary` trapped 100%.
+///
+/// `LoggerService.shared` is a `nonisolated static let`, so its one-time
+/// initializer runs on whichever thread first touches it. Under the CLI that
+/// is the background index queue (`io.lupen.provider-index.*`), not the main
+/// actor. The pre-fix initializer ran `MainActor.assumeIsolated` (inside the
+/// `shared` closure), which calls `dispatch_assert_queue` and **traps with
+/// SIGTRAP** when the current executor is not the main actor — exactly the
+/// observed crash (`ConversationAssembler.resolvedStepForStorage` →
+/// `LoggerService.shared` first-touch on the index queue).
+///
+/// A `static-let` singleton can't be re-initialized per test, so a
+/// background first-touch can't be reproduced deterministically inside a
+/// shared test process. Instead these tests pin the property the fix
+/// establishes: `LoggerService` must be constructible and usable off the main
+/// actor. If someone reverts `init` to a main-actor isolated initializer,
+/// `initializesOffMainActor` stops compiling (a main-actor init can't be
+/// called from this non-isolated closure), blocking the regression.
+@Suite("LoggerService — off-main-actor safety")
+struct LoggerServiceConcurrencyTests {
+
+    @Test("constructs and logs from a background thread (nonisolated init)")
+    func initializesOffMainActor() async {
+        let ok = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                // The CLI crash happened precisely here: a non-main first
+                // touch. A nonisolated init makes this safe; a main-actor
+                // init would not even compile in this closure.
+                #expect(!Thread.isMainThread)
+                let logger = LoggerService()
+                logger.logFromAnyThread(
+                    .info, "off-main init smoke", context: "LoggerServiceTest"
+                )
+                cont.resume(returning: true)
+            }
+        }
+        #expect(ok)
+    }
+
+    @Test("shared singleton is reachable from a background thread")
+    func sharedSingletonUsableFromBackground() async {
+        // Mirrors the importer's exact call shape:
+        // `LoggerService.shared.logFromAnyThread(...)` from the index queue.
+        let ok = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                LoggerService.shared.logFromAnyThread(
+                    .warning, "shared off-main", context: "LoggerServiceTest"
+                )
+                cont.resume(returning: true)
+            }
+        }
+        #expect(ok)
+    }
+
+    @Test("concurrent first-touch from many background threads is safe")
+    func concurrentBackgroundConstruction() async {
+        // Stress the nonisolated init under contention: many threads building
+        // their own instance at once must not trap or race.
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<16 {
+                group.addTask {
+                    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                        DispatchQueue.global().async {
+                            let logger = LoggerService()
+                            logger.logFromAnyThread(
+                                .debug, "concurrent \(i)", context: "LoggerServiceTest"
+                            )
+                            cont.resume()
+                        }
+                    }
+                }
+            }
+        }
+        #expect(Bool(true))
+    }
+}

--- a/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
+++ b/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
@@ -77,4 +77,57 @@ struct LoggerServiceConcurrencyTests {
         }
         #expect(Bool(true))
     }
+
+    @MainActor
+    @Test("logFromAnyThread on the main thread defers to the main queue (no sync assumeIsolated path)")
+    func logFromMainThreadDefersEntries() async {
+        let logger = LoggerService()
+        logger.logFromAnyThread(.info, "deferred", context: "LoggerServiceTest")
+        // Post-fix: always hops via main.async, so the entry is NOT recorded
+        // synchronously. Pre-fix the main-thread fast path called log()
+        // synchronously (via MainActor.assumeIsolated) and it would be present
+        // here — this is the behavioral guard that the sync trap path is gone.
+        // (Filter by message because bootstrap may add a "Log file started"
+        // entry when file logging is enabled.)
+        #expect(!logger.entries.contains { $0.message == "deferred" })
+        // Let the queued main hop run; the entry then lands.
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(logger.entries.contains { $0.message == "deferred" })
+    }
+
+    @Test("logFromAnyThread from a background thread eventually records the entry")
+    func logFromBackgroundReachesEntries() async {
+        let logger = LoggerService()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                logger.logFromAnyThread(.warning, "from bg", context: "LoggerServiceTest")
+                cont.resume()
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(100))  // wait for the main hop
+        let hit = await MainActor.run { logger.entries.contains { $0.message == "from bg" } }
+        #expect(hit)
+    }
+
+    @Test("entry timestamp reflects the call site, not the deferred main hop")
+    func entryTimestampAtCallSite() async throws {
+        let logger = LoggerService()
+        let before = Date()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                logger.logFromAnyThread(.info, "ts", context: "LoggerServiceTest")
+                cont.resume()
+            }
+        }
+        let afterCall = Date()
+        // The main hop runs well after the call; if the entry were rebuilt in
+        // the hop (the old two-entry path) its timestamp would be ~100ms later.
+        try? await Task.sleep(for: .milliseconds(100))
+        let ts = try #require(await MainActor.run {
+            logger.entries.first { $0.message == "ts" }?.timestamp
+        })
+        #expect(ts >= before)
+        #expect(ts <= afterCall.addingTimeInterval(0.02))
+    }
 }

--- a/LupenTests/Domain/Snapshot/VerifyCostsMarkdownReportTests.swift
+++ b/LupenTests/Domain/Snapshot/VerifyCostsMarkdownReportTests.swift
@@ -12,8 +12,8 @@ struct VerifyCostsMarkdownReportTests {
 
     private static func rollup(
         sessionId: String,
-        matches: Bool,
-        divergenceCount: Int = 0,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
         truthCostUSD: Double = 100.0,
         viewCostUSD: Double? = 100.0,
         costDelta: Double? = 0.0,
@@ -40,8 +40,8 @@ struct VerifyCostsMarkdownReportTests {
             viewOutputTokens: truthOutputTokens,
             viewReasoningOutputTokens: truthReasoningOutputTokens,
             hasUnknownPricing: hasUnknownPricing,
-            matchesView: matches,
-            divergenceCount: divergenceCount,
+            errorCount: errorCount,
+            warningCount: warningCount,
             inViewAndTruth: true
         )
     }
@@ -88,25 +88,24 @@ struct VerifyCostsMarkdownReportTests {
         )
     }
 
-    @Test("report header includes Clean / Mismatch / timings")
+    @Test("report header includes Clean / Error / timings")
     func header() {
         let r = Self.emptyResult()
-        let rollups = [Self.rollup(sessionId: "s1", matches: true)]
+        let rollups = [Self.rollup(sessionId: "s1")]
         let md = VerifyCostsViewController.buildMarkdownReport(
-            result: r, rollups: rollups, showingOnlyMismatches: false
+            result: r, rollups: rollups, filterLevel: .all
         )
         #expect(md.contains("# Verify Costs"))
-        #expect(md.contains("Clean 1 · Mismatch 0 · Scan 15.7s · Verify 0.01s"))
+        #expect(md.contains("Clean 1 · Error 0 · Scan 15.7s · Verify 0.01s"))
     }
 
-    @Test("Codex report header includes unknown pricing count and cost note")
+    @Test("Codex unknown pricing is a warning, not an error")
     func codexHeaderIncludesUnknownPricingCount() {
         let sid = "codex:unknown-pricing"
         let r = Self.codexResultWithUnknownPricing(sessionId: sid)
         let row = Self.rollup(
             sessionId: sid,
-            matches: false,
-            divergenceCount: 1,
+            warningCount: 1,
             truthCostUSD: 0,
             viewCostUSD: 0,
             costDelta: 0,
@@ -118,18 +117,19 @@ struct VerifyCostsMarkdownReportTests {
         )
 
         let md = VerifyCostsViewController.buildMarkdownReport(
-            result: r, rollups: [row], showingOnlyMismatches: false
+            result: r, rollups: [row], filterLevel: .all
         )
 
         #expect(md.contains("# Verify Usage"))
         #expect(md.contains("Unknown pricing 1"))
         #expect(md.contains("Codex cost note: dollar totals are estimated"))
         #expect(md.contains("| Session | Raw | Dedup | App | Input | Cached | Output | Reasoning | Est. Cost | App Est. Cost | Δ | Status |"))
-        #expect(md.contains("| codex:unknown-pricing | 2438 | 1080 | 1080 | 1234 | 567 | 89 | 12 | N/A | N/A | N/A | ✗ 1 pricing |"))
+        // Unknown pricing now renders as a ⚠ warning, not a ✗ error.
+        #expect(md.contains("| codex:unknown-pricing | 2438 | 1080 | 1080 | 1234 | 567 | 89 | 12 | N/A | N/A | N/A | ⚠ 1 pricing |"))
         #expect(md.contains("unknown pricing for model 'gpt-future-codex'"))
     }
 
-    @Test("Codex report includes parser issue categories")
+    @Test("Codex report includes parser issue categories (error severity)")
     func codexReportIncludesParserIssueCategories() {
         let sid = "codex:parser-issue"
         let result = VerifyCostsResult(
@@ -168,8 +168,7 @@ struct VerifyCostsMarkdownReportTests {
         )
         let row = Self.rollup(
             sessionId: sid,
-            matches: false,
-            divergenceCount: 1,
+            errorCount: 1,
             truthCostUSD: 0,
             viewCostUSD: 0,
             costDelta: 0
@@ -178,7 +177,7 @@ struct VerifyCostsMarkdownReportTests {
         let md = VerifyCostsViewController.buildMarkdownReport(
             result: result,
             rollups: [row],
-            showingOnlyMismatches: false
+            filterLevel: .all
         )
 
         #expect(md.contains("Parser issues 1"))
@@ -190,29 +189,29 @@ struct VerifyCostsMarkdownReportTests {
         let r = Self.emptyResult()
         let row = Self.rollup(
             sessionId: "425e64f5-677e-4327-9e2f-a845176811f9",
-            matches: false,
-            divergenceCount: 1,
+            errorCount: 1,
             truthCostUSD: 253.672399,
             viewCostUSD: 253.639262,
             costDelta: -0.033138
         )
         let md = VerifyCostsViewController.buildMarkdownReport(
-            result: r, rollups: [row], showingOnlyMismatches: true
+            result: r, rollups: [row], filterLevel: .warningsAndErrors
         )
         #expect(md.contains("| 425e64f5-677e-4327-9e2f-a845176811f9 | 2438 | 1080 | 1080 | $253.6724 | $253.6393 | $-0.0331 | ✗ 1 |"))
     }
 
-    @Test("filter note appears only when showingOnlyMismatches")
+    @Test("filter note appears only when the filter is not 'all'")
     func filterNote() {
         let r = Self.emptyResult()
-        let mds = [
-            VerifyCostsViewController.buildMarkdownReport(
-                result: r, rollups: [], showingOnlyMismatches: false),
-            VerifyCostsViewController.buildMarkdownReport(
-                result: r, rollups: [], showingOnlyMismatches: true)
-        ]
-        #expect(!mds[0].contains("only mismatches"))
-        #expect(mds[1].contains("only mismatches shown below"))
+        let mdAll = VerifyCostsViewController.buildMarkdownReport(
+            result: r, rollups: [], filterLevel: .all)
+        let mdWarn = VerifyCostsViewController.buildMarkdownReport(
+            result: r, rollups: [], filterLevel: .warningsAndErrors)
+        let mdErr = VerifyCostsViewController.buildMarkdownReport(
+            result: r, rollups: [], filterLevel: .errors)
+        #expect(!mdAll.contains("_Filter:"))
+        #expect(mdWarn.contains("Warnings shown below"))
+        #expect(mdErr.contains("Errors shown below"))
     }
 
     @Test("mismatched row emits a Divergences detail block")
@@ -235,14 +234,13 @@ struct VerifyCostsMarkdownReportTests {
         )
         let rollups = [Self.rollup(
             sessionId: sid,
-            matches: false,
-            divergenceCount: 1,
+            errorCount: 1,
             truthCostUSD: 253.672399,
             viewCostUSD: 253.639262,
             costDelta: -0.033138
         )]
         let md = VerifyCostsViewController.buildMarkdownReport(
-            result: result, rollups: rollups, showingOnlyMismatches: true
+            result: result, rollups: rollups, filterLevel: .warningsAndErrors
         )
         #expect(md.contains("## Divergences"))
         #expect(md.contains("### \(sid)"))
@@ -257,10 +255,34 @@ struct VerifyCostsMarkdownReportTests {
         let r = Self.emptyResult()
         let md = VerifyCostsViewController.buildMarkdownReport(
             result: r,
-            rollups: [Self.rollup(sessionId: "s1", matches: true)],
-            showingOnlyMismatches: false
+            rollups: [Self.rollup(sessionId: "s1")],
+            filterLevel: .all
         )
         #expect(!md.contains("## Divergences"))
+    }
+
+    // MARK: - SessionRollup 3-state
+
+    @Test("rollup 3-state: clean / warning-only / error from error+warning counts")
+    func rollupThreeState() {
+        let clean = Self.rollup(sessionId: "s", errorCount: 0, warningCount: 0)
+        #expect(clean.matchesView)
+        #expect(!clean.hasError)
+        #expect(!clean.hasWarningsOnly)
+        #expect(clean.divergenceCount == 0)
+
+        let warnOnly = Self.rollup(sessionId: "s", errorCount: 0, warningCount: 2)
+        #expect(!warnOnly.matchesView)
+        #expect(!warnOnly.hasError)
+        #expect(warnOnly.hasWarningsOnly)
+        #expect(warnOnly.divergenceCount == 2)
+
+        // Errors dominate even when warnings are also present.
+        let mixed = Self.rollup(sessionId: "s", errorCount: 1, warningCount: 3)
+        #expect(!mixed.matchesView)
+        #expect(mixed.hasError)
+        #expect(!mixed.hasWarningsOnly)
+        #expect(mixed.divergenceCount == 4)
     }
 
     // MARK: - formatDeltaForDisplay
@@ -298,10 +320,10 @@ struct VerifyCostsMarkdownReportTests {
     func markdownDeltaCleanRows() {
         let r = Self.emptyResult()
         // Exactly-zero delta on a matched row.
-        let row = Self.rollup(sessionId: "s1", matches: true,
+        let row = Self.rollup(sessionId: "s1",
                               truthCostUSD: 100.0, viewCostUSD: 100.0, costDelta: 0.0)
         let md = VerifyCostsViewController.buildMarkdownReport(
-            result: r, rollups: [row], showingOnlyMismatches: false
+            result: r, rollups: [row], filterLevel: .all
         )
         // Row should contain the em-dash in the delta column, not "$+0.0000".
         #expect(md.contains(" — | ✓ |"), "matched row must use em-dash in delta column")


### PR DESCRIPTION
## ⚠️ Includes an urgent crash fix
The `lupen` CLI crashed 100% for multiple users (SIGTRAP on launch). Fixed here.

## 1. CLI crash (SIGTRAP) — LoggerService
`LoggerService.shared` is a `nonisolated static let` whose initializer ran
`MainActor.assumeIsolated`. When the background index queue was the first to
touch it (always the case under the CLI), the assertion trapped.
- `init` is now an empty `nonisolated init`; filter-state restore + file logging
  move to a lazy bootstrap on the first `log()` (main-actor isolated).
- `logFromAnyThread` drops its `Thread.isMainThread → assumeIsolated` fast path
  entirely and always hops via `DispatchQueue.main.async` through a single
  `store()` sink, building the entry once at the call site.
- No `MainActor.assumeIsolated` remains, so it is safe from any thread/executor.

## 2. Codex Verify Usage accuracy
- Stop reporting zero-token `token_count` events as `missingUsageEvent` false
  positives.
- Fix the generated-turn `requestId` mismatch (verifier now mirrors the importer:
  turn-terminator reset + user-message turnId), e.g. 795 spurious "missing
  billable requestId" → 0.
- Add divergence severity (error/warning); unknown-pricing and missing-usage are
  warnings. The Verify Costs filter becomes All / Warnings / Errors, and CLI
  `verify` gates exit 4 on errors only.

## 3. Tests + cleanup
- Regression/guard tests for all of the above, including a deterministic
  off-main `LoggerService` guard and a CLI subprocess smoke test.
- `ToolResultInfo` boundary tests; removed dead `ParsedLine` Codable
  (its `ParseSnapshot` target was removed in the SQLite-first refactor).

## Verification
- Full suite green (1955 tests), Release + Debug builds succeed.
- `lupen summary` now runs to completion (was a 100% crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)