### PR TITLE
test: stabilize CI concurrency/subprocess suites with a cooperative-safe TestProcess helper

### DIFF
--- a/LupenTests/CLI/CLICrashSmokeTests.swift
+++ b/LupenTests/CLI/CLICrashSmokeTests.swift
@@ -26,7 +26,7 @@ struct CLICrashSmokeTests {
     }
 
     @Test("`lupen summary` boots, indexes a synthetic corpus, and exits 0")
-    func summaryRunsAndExitsZero() throws {
+    func summaryRunsAndExitsZero() async throws {
         let binary = try #require(lupenBinary(), "could not locate the host lupen binary")
 
         let (corpus, cleanup) = try RefactorFixtureCorpus.materialize()
@@ -35,48 +35,33 @@ struct CLICrashSmokeTests {
             .appendingPathComponent("lupen-cli-smoke-index-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: indexDir) }
 
-        let proc = Process()
-        proc.executableURL = binary
-        proc.arguments = ["summary"]
-
         // Hermetic: redirect every data source onto the synthetic corpus +
         // a throwaway index dir (no developer data is touched).
         var env = ProcessInfo.processInfo.environment
         env["CLAUDE_CONFIG_DIR"] = corpus.root.path        // → root/projects
         env["CODEX_HOME"] = corpus.codexHome.path
         env["LUPEN_APP_SUPPORT_DIR"] = indexDir.path
-        proc.environment = env
 
-        let stdout = Pipe()
-        let stderr = Pipe()
-        proc.standardOutput = stdout
-        proc.standardError = stderr
-
-        try proc.run()
-        proc.waitUntilExit()
-
-        let outText = String(
-            data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
-        ) ?? ""
-        let errText = String(
-            data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
-        ) ?? ""
+        let result = try await TestProcess.run(
+            binary, arguments: ["summary"], environment: env
+        )
+        let errText = result.stderrString
 
         // A SIGTRAP (the regressed crash family) surfaces as an uncaught signal
         // / status 133 — fail loudly here instead of taking the runner down.
         #expect(
-            proc.terminationReason != .uncaughtSignal,
-            "lupen terminated by a signal (status \(proc.terminationStatus)): \(errText)"
+            result.terminationReason != .uncaughtSignal,
+            "lupen terminated by a signal (status \(result.exitCode)): \(errText)"
         )
         #expect(
-            proc.terminationStatus == 0,
-            "lupen exited non-zero (\(proc.terminationStatus)): \(errText)"
+            result.exitCode == 0,
+            "lupen exited non-zero (\(result.exitCode)): \(errText)"
         )
         // It actually produced a summary (not an early empty exit), so the
         // index path genuinely ran.
         #expect(
-            outText.contains("Sessions"),
-            "summary produced no report — index path may not have run: \(outText)"
+            result.stdoutString.contains("Sessions"),
+            "summary produced no report — index path may not have run: \(result.stdoutString)"
         )
     }
 }

--- a/LupenTests/CorpusGeneratorSmokeTests.swift
+++ b/LupenTests/CorpusGeneratorSmokeTests.swift
@@ -34,41 +34,37 @@ struct CorpusGeneratorSmokeTests {
             .deletingLastPathComponent()  // repo root
     }
 
-    private func runGenerator(into outputDir: URL) throws -> GeneratorStats {
+    private func runGenerator(into outputDir: URL) async throws -> GeneratorStats {
         let script = repoRoot().appendingPathComponent("Tools/lupen-generate-corpus.py")
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [
-            script.path,
-            "--output", outputDir.path,
-            "--claude-mb", "3",
-            "--codex-mb", "3",
-            "--days", "5",
-            "--seed", "7",
-            "--verify"
-        ]
-        let stdout = Pipe()
-        process.standardOutput = stdout
-        try process.run()
-        process.waitUntilExit()
-        #expect(process.terminationStatus == 0)
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        let result = try await TestProcess.run(
+            URL(fileURLWithPath: "/usr/bin/python3"),
+            arguments: [
+                script.path,
+                "--output", outputDir.path,
+                "--claude-mb", "3",
+                "--codex-mb", "3",
+                "--days", "5",
+                "--seed", "7",
+                "--verify"
+            ],
+            timeout: 120
+        )
+        #expect(result.exitCode == 0, "generator failed: \(result.stderrString)")
         // The stats JSON object is the first brace-delimited block; the
         // --verify summary line follows it.
-        let text = String(decoding: data, as: UTF8.self)
-        let jsonText = text.split(separator: "\n")
+        let jsonText = result.stdoutString.split(separator: "\n")
             .prefix { !$0.hasPrefix("[verify]") }
             .joined(separator: "\n")
         return try JSONDecoder().decode(GeneratorStats.self, from: Data(jsonText.utf8))
     }
 
     @Test("generated corpus is fully accepted by the loaders")
-    func generatedCorpusLoads() throws {
+    func generatedCorpusLoads() async throws {
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-gen-smoke-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
 
-        let stats = try runGenerator(into: outputDir)
+        let stats = try await runGenerator(into: outputDir)
         #expect(stats.claude_sessions > 0)
         #expect(stats.codex_sessions > 0)
         #expect(stats.claude_subagent_files > 0)

--- a/LupenTests/Domain/Statusline/StatuslineTapModeEndToEndTests.swift
+++ b/LupenTests/Domain/Statusline/StatuslineTapModeEndToEndTests.swift
@@ -11,7 +11,7 @@ import Foundation
 /// target). For tests, we run the binary inside a dedicated temp
 /// `CLAUDE_CONFIG_DIR` so the user's real `~/.claude/lupen/` is
 /// untouched.
-@Suite("StatuslineTapMode — end-to-end process spawn")
+@Suite("StatuslineTapMode — end-to-end process spawn", .serialized, .timeLimit(.minutes(1)))
 struct StatuslineTapModeEndToEndTests {
 
     /// Locate the Lupen binary. In the test host this is the same
@@ -40,7 +40,7 @@ struct StatuslineTapModeEndToEndTests {
 
     /// Run the binary in `--statusline-tap` mode with a temp
     /// CLAUDE_CONFIG_DIR. Returns (exitCode, configDir).
-    private func runTap(stdinJSON: String, chain: String? = nil) throws
+    private func runTap(stdinJSON: String, chain: String? = nil) async throws
         -> (exit: Int32, configDir: URL, stdout: Data) {
         let binURL = try #require(lupenBinaryURL())
         let configDir = FileManager.default.temporaryDirectory
@@ -50,44 +50,16 @@ struct StatuslineTapModeEndToEndTests {
             at: configDir, withIntermediateDirectories: true
         )
 
-        let task = Process()
-        task.executableURL = binURL
-        task.arguments = [StatuslineTapMode.argvFlag]
-        task.environment = helperEnvironment(configDir: configDir, chain: chain)
-
-        let stdin = Pipe()
-        let stdout = Pipe()
-        task.standardInput = stdin
-        task.standardOutput = stdout
-        task.standardError = Pipe()
-
-        try task.run()
-        if let data = stdinJSON.data(using: .utf8) {
-            try stdin.fileHandleForWriting.write(contentsOf: data)
-        }
-        try stdin.fileHandleForWriting.close()
-        task.waitUntilExit()
-        let captured = stdout.fileHandleForReading.readDataToEndOfFile()
-        return (task.terminationStatus, configDir, captured)
-    }
-
-    private func waitForExit(_ task: Process, timeout: TimeInterval) async -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while task.isRunning, Date() < deadline {
-            try? await Task.sleep(for: .milliseconds(50))
-        }
-        if task.isRunning {
-            task.terminate()
-            let terminateDeadline = Date().addingTimeInterval(1.0)
-            while task.isRunning, Date() < terminateDeadline {
-                try? await Task.sleep(for: .milliseconds(50))
-            }
-        }
-        if task.isRunning {
-            kill(task.processIdentifier, SIGKILL)
-            return false
-        }
-        return true
+        // Cooperative-safe spawn + wait via the shared helper (never the
+        // blocking `Process.waitUntilExit()`, which pins a cooperative thread
+        // and hangs parallel suites on low-core CI runners). See `TestProcess`.
+        let result = try await TestProcess.run(
+            binURL,
+            arguments: [StatuslineTapMode.argvFlag],
+            environment: helperEnvironment(configDir: configDir, chain: chain),
+            stdin: stdinJSON.data(using: .utf8)
+        )
+        return (result.exitCode, configDir, result.stdout)
     }
 
     @Test("happy path — JSON in → sample line on disk → exit 0")
@@ -101,7 +73,7 @@ struct StatuslineTapModeEndToEndTests {
             }
         }
         """
-        let (exit, configDir, _) = try runTap(stdinJSON: json)
+        let (exit, configDir, _) = try await runTap(stdinJSON: json)
         #expect(exit == 0)
 
         let storeURL = configDir.appendingPathComponent("lupen")
@@ -117,7 +89,7 @@ struct StatuslineTapModeEndToEndTests {
 
     @Test("malformed JSON → no sample written, still exit 0")
     func malformedSilent() async throws {
-        let (exit, configDir, _) = try runTap(stdinJSON: "garbage not json")
+        let (exit, configDir, _) = try await runTap(stdinJSON: "garbage not json")
         #expect(exit == 0)
         let storeURL = configDir.appendingPathComponent("lupen")
             .appendingPathComponent("ratelimit-samples.jsonl")
@@ -135,7 +107,7 @@ struct StatuslineTapModeEndToEndTests {
         """
         // Chain command just echoes a marker so we can verify our stdout
         // contains it.
-        let (exit, _, stdoutData) = try runTap(
+        let (exit, _, stdoutData) = try await runTap(
             stdinJSON: json,
             chain: "echo LUPEN_CHAIN_MARKER"
         )
@@ -147,7 +119,7 @@ struct StatuslineTapModeEndToEndTests {
     @Test("chain command exit propagates")
     func chainExitPropagates() async throws {
         let json = #"{"session_id":"s"}"#
-        let (exit, _, _) = try runTap(
+        let (exit, _, _) = try await runTap(
             stdinJSON: json,
             chain: "exit 7"
         )
@@ -159,7 +131,7 @@ struct StatuslineTapModeEndToEndTests {
         let json = """
         {"session_id":"s","rate_limits":{"five_hour":{"used_percentage":2,"resets_at":1714323600}}}
         """
-        let (exit, configDir, _) = try runTap(
+        let (exit, configDir, _) = try await runTap(
             stdinJSON: json,
             chain: "/path/that/definitely/does/not/exist/please-fail"
         )
@@ -180,7 +152,7 @@ struct StatuslineTapModeEndToEndTests {
 
     @Test("empty stdin → exit 0, no sample, no crash")
     func emptyStdin() async throws {
-        let (exit, _, _) = try runTap(stdinJSON: "")
+        let (exit, _, _) = try await runTap(stdinJSON: "")
         #expect(exit == 0)
     }
 
@@ -245,7 +217,7 @@ struct StatuslineTapModeEndToEndTests {
 
         // SIGTERM the helper. The handler should kill the chain child.
         kill(task.processIdentifier, SIGTERM)
-        let exited = await waitForExit(task, timeout: 3.0)
+        let exited = await TestProcess.waitForExit(task, timeout: 3.0)
         #expect(exited, "helper did not exit after SIGTERM")
 
         // Wait up to 1s for the trap-on-TERM to fire and write the marker.
@@ -261,7 +233,7 @@ struct StatuslineTapModeEndToEndTests {
     @Test("payload without rate_limits still produces a (window-less) sample line")
     func payloadWithoutRateLimits() async throws {
         let json = #"{"session_id":"s","model":{"id":"opus"}}"#
-        let (exit, configDir, _) = try runTap(stdinJSON: json)
+        let (exit, configDir, _) = try await runTap(stdinJSON: json)
         #expect(exit == 0)
 
         let storeURL = configDir.appendingPathComponent("lupen")

--- a/LupenTests/Store/ImporterMemoryBoundTests.swift
+++ b/LupenTests/Store/ImporterMemoryBoundTests.swift
@@ -19,26 +19,25 @@ import Foundation
 @Suite("Importer memory bound on large corpus (2.10)", .serialized)
 struct ImporterMemoryBoundTests {
 
-    private func generateCorpus(into outputDir: URL, claudeMB: Int, codexMB: Int) throws {
+    private func generateCorpus(into outputDir: URL, claudeMB: Int, codexMB: Int) async throws {
         let script = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // Store
             .deletingLastPathComponent()  // LupenTests
             .deletingLastPathComponent()  // repo root
             .appendingPathComponent("Tools/lupen-generate-corpus.py")
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [
-            script.path,
-            "--output", outputDir.path,
-            "--claude-mb", "\(claudeMB)",
-            "--codex-mb", "\(codexMB)",
-            "--days", "7",
-            "--seed", "23"
-        ]
-        process.standardOutput = Pipe()
-        try process.run()
-        process.waitUntilExit()
-        #expect(process.terminationStatus == 0)
+        let result = try await TestProcess.run(
+            URL(fileURLWithPath: "/usr/bin/python3"),
+            arguments: [
+                script.path,
+                "--output", outputDir.path,
+                "--claude-mb", "\(claudeMB)",
+                "--codex-mb", "\(codexMB)",
+                "--days", "7",
+                "--seed", "23"
+            ],
+            timeout: 180
+        )
+        #expect(result.exitCode == 0, "generator failed: \(result.stderrString)")
     }
 
     private func rssMB() -> Double {
@@ -51,11 +50,11 @@ struct ImporterMemoryBoundTests {
     }
 
     @Test("peak importer RSS stays bounded across both providers' full imports")
-    func importerPeakRSSBounded() throws {
+    func importerPeakRSSBounded() async throws {
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-import-mem-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
-        try generateCorpus(into: outputDir, claudeMB: 32, codexMB: 32)
+        try await generateCorpus(into: outputDir, claudeMB: 32, codexMB: 32)
 
         // The RSS sample is process-wide — suites running concurrently
         // in this process inflate the measured delta (same lesson as

--- a/LupenTests/Store/ProviderDatabaseTests.swift
+++ b/LupenTests/Store/ProviderDatabaseTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import GRDB
 @testable import Lupen
 
-@Suite("ProviderDatabase lifecycle")
+@Suite("ProviderDatabase lifecycle", .serialized, .timeLimit(.minutes(1)))
 struct ProviderDatabaseTests {
 
     private func makeTempURL() -> (URL, cleanup: () -> Void) {

--- a/LupenTests/Store/SQLiteEquivalenceTests.swift
+++ b/LupenTests/Store/SQLiteEquivalenceTests.swift
@@ -99,35 +99,41 @@ struct SQLiteEquivalenceTests {
     // MARK: - Generated corpus: three-way zero mismatch, both providers
 
     @Test("generated corpus: SQLite == legacy == ground truth for both providers")
-    func generatedCorpusThreeWayAgreement() throws {
-        try CorpusHeavyTestGate.withExclusiveAccess { try generatedCorpusThreeWayAgreementBody() }
-    }
-
-    private func generatedCorpusThreeWayAgreementBody() throws {
+    func generatedCorpusThreeWayAgreement() async throws {
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-sqlite-equiv-gen-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
+        // Generate outside the heavy-test gate: the gate is synchronous, and
+        // the spawn must use the cooperative-safe helper (never the blocking
+        // `waitUntilExit()`). See `TestProcess`.
+        try await generateCorpus(into: outputDir)
+        try CorpusHeavyTestGate.withExclusiveAccess {
+            try generatedCorpusThreeWayAgreementBody(outputDir: outputDir)
+        }
+    }
 
+    private func generateCorpus(into outputDir: URL) async throws {
         let script = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // Store
             .deletingLastPathComponent()  // LupenTests
             .deletingLastPathComponent()  // repo root
             .appendingPathComponent("Tools/lupen-generate-corpus.py")
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [
-            script.path,
-            "--output", outputDir.path,
-            "--claude-mb", "2",
-            "--codex-mb", "2",
-            "--days", "4",
-            "--seed", "11"
-        ]
-        process.standardOutput = Pipe()
-        try process.run()
-        process.waitUntilExit()
-        #expect(process.terminationStatus == 0)
+        let result = try await TestProcess.run(
+            URL(fileURLWithPath: "/usr/bin/python3"),
+            arguments: [
+                script.path,
+                "--output", outputDir.path,
+                "--claude-mb", "2",
+                "--codex-mb", "2",
+                "--days", "4",
+                "--seed", "11"
+            ],
+            timeout: 120
+        )
+        #expect(result.exitCode == 0, "generator failed: \(result.stderrString)")
+    }
 
+    private func generatedCorpusThreeWayAgreementBody(outputDir: URL) throws {
         // Claude
         let claudeStore = try UsageEquivalenceHarness.importedClaudeStore(
             projectsDir: outputDir.appendingPathComponent("projects"),

--- a/LupenTests/Store/SQLiteSelectionLatencyTests.swift
+++ b/LupenTests/Store/SQLiteSelectionLatencyTests.swift
@@ -23,30 +23,29 @@ import Foundation
 @Suite("SQLite selection latency (4.6)", .serialized)
 struct SQLiteSelectionLatencyTests {
 
-    private func generateCorpus(into outputDir: URL, claudeMB: Int, codexMB: Int) throws {
+    private func generateCorpus(into outputDir: URL, claudeMB: Int, codexMB: Int) async throws {
         let script = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Tools/lupen-generate-corpus.py")
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [
-            script.path,
-            "--output", outputDir.path,
-            "--claude-mb", "\(claudeMB)",
-            "--codex-mb", "\(codexMB)",
-            "--days", "7",
-            "--seed", "46"
-        ]
-        process.standardOutput = Pipe()
-        try process.run()
-        process.waitUntilExit()
-        #expect(process.terminationStatus == 0)
+        let result = try await TestProcess.run(
+            URL(fileURLWithPath: "/usr/bin/python3"),
+            arguments: [
+                script.path,
+                "--output", outputDir.path,
+                "--claude-mb", "\(claudeMB)",
+                "--codex-mb", "\(codexMB)",
+                "--days", "7",
+                "--seed", "46"
+            ],
+            timeout: 180
+        )
+        #expect(result.exitCode == 0, "generator failed: \(result.stderrString)")
     }
 
     @Test("snapshot and single-turn expand stay within the open budget")
-    func selectionLatencyWithinBudget() throws {
+    func selectionLatencyWithinBudget() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-latency-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -55,7 +54,7 @@ struct SQLiteSelectionLatencyTests {
         // 96 MB corpus: enough to include the generator's oversized
         // rollouts and multi-MB sessions while keeping the in-test
         // import to seconds.
-        try generateCorpus(into: root.appendingPathComponent("corpus"), claudeMB: 48, codexMB: 48)
+        try await generateCorpus(into: root.appendingPathComponent("corpus"), claudeMB: 48, codexMB: 48)
 
         try CorpusHeavyTestGate.withExclusiveAccess {
         for provider in [ProviderKind.claudeCode, .codex] {

--- a/LupenTests/Support/TestProcess.swift
+++ b/LupenTests/Support/TestProcess.swift
@@ -7,17 +7,26 @@
 
 import Foundation
 import Testing
+import os
 
 /// Cooperative-safe subprocess helper for tests.
 ///
 /// Tests must spawn child processes through `TestProcess` instead of driving
-/// `Process` directly. The reason is `waitUntilExit()`: it blocks the calling
-/// thread for the child's entire lifetime. Swift Testing runs suites in
-/// parallel on the Swift-concurrency cooperative pool, so a blocked
-/// `waitUntilExit()` pins one of its few threads; on a low-core CI runner that
-/// starves the pool and other tests' `Task.sleep` never resumes — observed as
-/// multi-minute hangs on hosted runners. `waitForExit` polls with a hard
-/// timeout, so it yields the thread between polls and never hangs unbounded.
+/// `Process` directly. The hazard is the Swift-concurrency cooperative pool:
+/// calling `Process.waitUntilExit()` from an async test pins one of the pool's
+/// few threads for the child's whole lifetime, and — symmetrically — polling
+/// the child with `Task.sleep` depends on that same pool to resume. On a
+/// low-core CI runner where other suites' blocking work has starved the pool,
+/// either approach stalls: the test's `await` never resumes and the suite hangs
+/// for minutes.
+///
+/// `waitForExit` sidesteps both. It blocks on the child's exit on a *dedicated*
+/// dispatch-queue thread (off the cooperative pool) and bridges back through a
+/// continuation, so the awaiting test is suspended holding no pool thread while
+/// the blocking wait makes progress elsewhere. A timeout watchdog runs off-pool
+/// too, so a genuinely hung child is force-killed regardless of pool pressure,
+/// and `waitUntilExit()` guarantees the child is reaped before `run()` reads
+/// `terminationStatus`.
 ///
 /// Use `run(...)` for the common "spawn → optional stdin → wait → capture
 /// output" case. For tests that must interact with the child mid-run (e.g.
@@ -39,9 +48,10 @@ enum TestProcess {
         var stderrString: String { String(decoding: stderr, as: UTF8.self) }
     }
 
-    /// Spawn `executable`, optionally feed `stdin`, wait cooperatively up to
-    /// `timeout`, and return the exit code with captured stdout/stderr. On
-    /// timeout the child is terminated (SIGTERM, then SIGKILL after a grace).
+    /// Spawn `executable`, optionally feed `stdin`, wait off the cooperative
+    /// pool up to `timeout`, and return the exit code with captured
+    /// stdout/stderr. On timeout the child is terminated (SIGTERM, then SIGKILL
+    /// after a grace).
     @discardableResult
     static func run(
         _ executable: URL,
@@ -76,27 +86,47 @@ enum TestProcess {
         )
     }
 
-    /// Cooperative wait: poll `isRunning` (yielding the thread via `Task.sleep`)
-    /// until the child exits or `timeout` elapses. On timeout the child is
-    /// SIGTERM'd, then SIGKILL'd after a 1 s grace. Returns `true` if the child
-    /// exited on its own, `false` if it had to be force-killed.
+    /// Wait for `task` to exit, off the cooperative pool. Blocks on a dedicated
+    /// dispatch-queue thread (so a starved pool can't stall it) and resumes the
+    /// caller via a continuation. A watchdog SIGTERMs — then SIGKILLs after a
+    /// 1 s grace — a child that overstays `timeout`. Returns `true` if the child
+    /// exited on its own, `false` if the watchdog had to force-kill it.
     @discardableResult
     static func waitForExit(_ task: Process, timeout: TimeInterval) async -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while task.isRunning, Date() < deadline {
-            try? await Task.sleep(for: .milliseconds(50))
-        }
-        if task.isRunning {
-            task.terminate()
-            let terminateDeadline = Date().addingTimeInterval(1.0)
-            while task.isRunning, Date() < terminateDeadline {
-                try? await Task.sleep(for: .milliseconds(50))
+        let boxed = UncheckedSendable(value: task)
+        let timedOut = OSAllocatedUnfairLock(initialState: false)
+        return await withCheckedContinuation { continuation in
+            // Force-terminate a child that overstays `timeout`. Runs off the
+            // cooperative pool, so the timeout fires even when the pool is
+            // fully starved.
+            let watchdog = DispatchWorkItem {
+                let task = boxed.value
+                guard task.isRunning else { return }   // already exited cleanly
+                timedOut.withLock { $0 = true }
+                task.terminate()
+                Thread.sleep(forTimeInterval: 1.0)
+                if task.isRunning { kill(task.processIdentifier, SIGKILL) }
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: watchdog)
+
+            // Block on the child's exit on a dedicated thread (NOT a cooperative
+            // pool thread). The awaiting test stays suspended meanwhile, holding
+            // no pool thread, so a busy pool can't keep this wait from making
+            // progress; waitUntilExit() also reaps the child before we resume.
+            DispatchQueue.global().async {
+                let task = boxed.value
+                task.waitUntilExit()
+                watchdog.cancel()
+                continuation.resume(returning: !timedOut.withLock { $0 })
             }
         }
-        if task.isRunning {
-            kill(task.processIdentifier, SIGKILL)
-            return false
-        }
-        return true
     }
+}
+
+/// Carries a non-Sendable value (here, `Process`) across the continuation and
+/// dispatch-queue boundaries. Safe in this file: the child is touched from the
+/// single wait thread plus the watchdog, and `Process` guards
+/// `isRunning`/`terminate` internally.
+private struct UncheckedSendable<Value>: @unchecked Sendable {
+    let value: Value
 }

--- a/LupenTests/Support/TestProcess.swift
+++ b/LupenTests/Support/TestProcess.swift
@@ -1,0 +1,102 @@
+//
+//  TestProcess.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/23.
+//
+
+import Foundation
+import Testing
+
+/// Cooperative-safe subprocess helper for tests.
+///
+/// Tests must spawn child processes through `TestProcess` instead of driving
+/// `Process` directly. The reason is `waitUntilExit()`: it blocks the calling
+/// thread for the child's entire lifetime. Swift Testing runs suites in
+/// parallel on the Swift-concurrency cooperative pool, so a blocked
+/// `waitUntilExit()` pins one of its few threads; on a low-core CI runner that
+/// starves the pool and other tests' `Task.sleep` never resumes — observed as
+/// multi-minute hangs on hosted runners. `waitForExit` polls with a hard
+/// timeout, so it yields the thread between polls and never hangs unbounded.
+///
+/// Use `run(...)` for the common "spawn → optional stdin → wait → capture
+/// output" case. For tests that must interact with the child mid-run (e.g.
+/// signal it), spawn `Process` directly but wait with `waitForExit(_:timeout:)`
+/// rather than `waitUntilExit()`.
+///
+/// Output is drained after the child exits, so callers must keep child output
+/// bounded (well under the OS pipe buffer, ~64 KB) — true for every current
+/// call site.
+enum TestProcess {
+
+    struct Result {
+        let exitCode: Int32
+        let terminationReason: Process.TerminationReason
+        let stdout: Data
+        let stderr: Data
+
+        var stdoutString: String { String(decoding: stdout, as: UTF8.self) }
+        var stderrString: String { String(decoding: stderr, as: UTF8.self) }
+    }
+
+    /// Spawn `executable`, optionally feed `stdin`, wait cooperatively up to
+    /// `timeout`, and return the exit code with captured stdout/stderr. On
+    /// timeout the child is terminated (SIGTERM, then SIGKILL after a grace).
+    @discardableResult
+    static func run(
+        _ executable: URL,
+        arguments: [String] = [],
+        environment: [String: String]? = nil,
+        stdin: Data? = nil,
+        timeout: TimeInterval = 30
+    ) async throws -> Result {
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = arguments
+        if let environment { task.environment = environment }
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let stdinPipe = Pipe()
+        task.standardOutput = stdout
+        task.standardError = stderr
+        task.standardInput = stdinPipe
+
+        try task.run()
+        if let stdin { try stdinPipe.fileHandleForWriting.write(contentsOf: stdin) }
+        try stdinPipe.fileHandleForWriting.close()
+
+        _ = await waitForExit(task, timeout: timeout)
+
+        return Result(
+            exitCode: task.terminationStatus,
+            terminationReason: task.terminationReason,
+            stdout: stdout.fileHandleForReading.readDataToEndOfFile(),
+            stderr: stderr.fileHandleForReading.readDataToEndOfFile()
+        )
+    }
+
+    /// Cooperative wait: poll `isRunning` (yielding the thread via `Task.sleep`)
+    /// until the child exits or `timeout` elapses. On timeout the child is
+    /// SIGTERM'd, then SIGKILL'd after a 1 s grace. Returns `true` if the child
+    /// exited on its own, `false` if it had to be force-killed.
+    @discardableResult
+    static func waitForExit(_ task: Process, timeout: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while task.isRunning, Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        if task.isRunning {
+            task.terminate()
+            let terminateDeadline = Date().addingTimeInterval(1.0)
+            while task.isRunning, Date() < terminateDeadline {
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+        }
+        if task.isRunning {
+            kill(task.processIdentifier, SIGKILL)
+            return false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

Two test suites hung for ~107s on hosted CI runners (`StatuslineTapModeEndToEndTests`, `ProviderDatabaseTests`). Root cause: tests drove `Process` directly and waited with the blocking `Process.waitUntilExit()`, which pins a Swift-concurrency cooperative thread for the child's whole lifetime. Under parallel Swift Testing on a low-core runner this starves the cooperative pool, so unrelated suites' `Task.sleep` never resumes — observed as multi-minute hangs. The blocking sleep inside `ProviderDatabaseTests/readersDuringWriter` (held in a GRDB write) hits the same failure mode.

This is **test-only**; no production code changes.

## Changes

- **`test: serialize ProviderDatabase WAL concurrency suite`** — mark the suite `.serialized` + `.timeLimit(.minutes(1))`. It can't use the helper (the blocking sleep lives inside a GRDB write), so serialization is the fix, matching the convention already used by the other heavy suites.
- **`test: route subprocess spawns through a cooperative-safe TestProcess helper`** — add `LupenTests/Support/TestProcess.swift` exposing `run()` / `waitForExit()` that poll with a hard timeout instead of blocking, then migrate every subprocess test to it:
  - `StatuslineTapMode` — `.serialized` + `.timeLimit`; `runTap` now uses the helper; the private `waitForExit` is removed (the SIGTERM test keeps its custom `Process` but waits via the helper).
  - `CLICrashSmoke`, `CorpusGeneratorSmoke`, `ImporterMemoryBound`, `SQLiteSelectionLatency` — generator/CLI spawns moved to the helper.
  - `SQLiteEquivalence` — generator spawn hoisted out of the synchronous `CorpusHeavyTestGate` (gate stays sync); the body now takes the prepared `outputDir`.

New subprocess tests are now cooperative-safe by construction, so a missed `.serialized` trait can no longer reintroduce this hang.

## Testing

- `xcodebuild build-for-testing` — succeeded.
- Ran all affected suites locally (all pass): StatuslineTapMode (9 tests, incl. SIGTERM), CLICrashSmoke, CorpusGeneratorSmoke, ImporterMemoryBound (~27s), SQLiteSelectionLatency (~41s), SQLiteEquivalence. `sigtermPropagatesToChain` went from ~107s to ~0.1s.