### PR TITLE
fix: reliably surface windows from menu-bar clicks via orderFrontRegardless

### DIFF
--- a/Lupen/UI/Dashboard/DashboardWindowController.swift
+++ b/Lupen/UI/Dashboard/DashboardWindowController.swift
@@ -54,48 +54,23 @@ final class DashboardWindowController: NSWindowController, NSWindowDelegate {
             isSetUp = true
         }
 
-        // 6.14 hardening — the menu-bar click intermittently failed to
-        // surface this window (user had to click the Dock icon). Three
-        // ordered fixes, each targeting a known failure mode:
-        //
-        // 1) De-miniaturize first. `makeKeyAndOrderFront` never pulls a
-        //    window out of the Dock, so a minimized dashboard made the
-        //    status-item click a silent no-op — the exact "Dock click
-        //    needed" symptom.
-        if window?.isMiniaturized == true {
-            window?.deminiaturize(nil)
-        }
-
-        // 2) Activate BEFORE ordering. A status-item click does not
-        //    activate the app, and under macOS 14+ cooperative
-        //    activation an order-then-activate sequence can lose the
-        //    race: the window order-fronts on its own Space while the
-        //    app stays inactive, so nothing visibly happens. Activating
-        //    first also lets the system's "switch to a Space with open
-        //    windows for the application" behavior kick in when the
-        //    dashboard lives on another Space.
-        //    NSApp.activate() (macOS 14+ cooperative) does not reliably
-        //    activate from status bar button clicks.
-        //    activate(ignoringOtherApps:) is deprecated but has no
-        //    working replacement for this use case. Used by NetNewsWire,
-        //    Rectangle, and other production apps.
-        NSApp.activate(ignoringOtherApps: true)
-
+        // Surface reliably from the status-item click context. The click
+        // leaves the app inactive, so `bringToFront()`'s `orderFrontRegardless`
+        // is what actually pulls the window forward instead of leaving it
+        // hidden behind the frontmost app. See `NSWindow.bringToFront`.
         showWindow(nil)
-        window?.makeKeyAndOrderFront(nil)
+        window?.bringToFront()
 
-        // 3) Re-front on the next runloop tick, after the cooperative
-        //    activation request has settled. When the first order
-        //    already won this is a harmless no-op; when it lost the
-        //    activation race this is what actually brings the window
-        //    forward.
-        DispatchQueue.main.async { [weak self] in
-            self?.window?.makeKeyAndOrderFront(nil)
-        }
-
-        if autoSelectFirstSessionOnShow,
-           let splitVC = window?.contentViewController as? DashboardSplitViewController {
-            autoSelectAction(splitVC)
+        // Defer auto-selection to the next runloop tick. Running it inline
+        // mutates the outline during the window's first layout pass (right
+        // after makeKeyAndOrderFront) and trips `_NSDetectedLayoutRecursion`;
+        // deferring lets the first layout settle, then claims selection/focus.
+        if autoSelectFirstSessionOnShow {
+            DispatchQueue.main.async { [weak self] in
+                guard let splitVC = self?.window?.contentViewController
+                    as? DashboardSplitViewController else { return }
+                self?.autoSelectAction(splitVC)
+            }
         }
     }
 

--- a/Lupen/UI/Diagnostics/DiagnosticsWindowController.swift
+++ b/Lupen/UI/Diagnostics/DiagnosticsWindowController.swift
@@ -39,7 +39,6 @@ final class DiagnosticsWindowController: NSWindowController, NSWindowDelegate {
     required init?(coder: NSCoder) { fatalError() }
 
     func show() {
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.bringToFront()
     }
 }

--- a/Lupen/UI/Log/LogWindowController.swift
+++ b/Lupen/UI/Log/LogWindowController.swift
@@ -13,8 +13,7 @@ final class LogWindowController {
 
     func showWindow() {
         if let window, window.isVisible {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate()
+            window.bringToFront()
             return
         }
 
@@ -35,8 +34,7 @@ final class LogWindowController {
         win.minSize = NSSize(width: 500, height: 300)
 
         self.window = win
-        win.makeKeyAndOrderFront(nil)
-        NSApp.activate()
+        win.bringToFront()
     }
 }
 

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -48,7 +48,6 @@ final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate
     @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
 
     func show() {
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.bringToFront()
     }
 }

--- a/Lupen/UI/Preferences/PreferencesWindowController.swift
+++ b/Lupen/UI/Preferences/PreferencesWindowController.swift
@@ -68,8 +68,7 @@ final class PreferencesWindowController: NSWindowController, NSWindowDelegate {
     required init?(coder: NSCoder) { fatalError() }
 
     func show() {
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.bringToFront()
     }
 
     // MARK: - NSWindowDelegate

--- a/Lupen/UI/Reports/ReportsWindowController.swift
+++ b/Lupen/UI/Reports/ReportsWindowController.swift
@@ -50,7 +50,6 @@ final class ReportsWindowController: NSWindowController, NSWindowDelegate {
     required init?(coder: NSCoder) { fatalError() }
 
     func show() {
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.bringToFront()
     }
 }

--- a/Lupen/UI/Support/NSWindow+BringToFront.swift
+++ b/Lupen/UI/Support/NSWindow+BringToFront.swift
@@ -1,0 +1,34 @@
+//
+//  NSWindow+BringToFront.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/24.
+//
+
+import AppKit
+
+extension NSWindow {
+    /// Reliably surfaces this window to the front from *any* context —
+    /// including an `NSStatusItem` (menu-bar) click, where the app is NOT the
+    /// active application.
+    ///
+    /// A status-item click does not activate the app, and under macOS 14+
+    /// "cooperative activation" a self-`NSApp.activate(...)` from that context
+    /// is frequently ignored: the app stays inactive, so a plain
+    /// `makeKeyAndOrderFront(_:)` leaves the window *behind* the frontmost
+    /// app's windows — the "click logs but nothing appears; a Dock click is
+    /// needed" symptom. (Dock clicks work because the Dock activates the app
+    /// first, then calls `applicationShouldHandleReopen`.)
+    ///
+    /// `orderFrontRegardless()` is the fix: it brings the window to the front
+    /// of its level *even while the app is inactive*, so the window is always
+    /// visible regardless of whether activation succeeded. `activate` is still
+    /// requested first so key-focus follows when the system does grant it.
+    @MainActor
+    func bringToFront() {
+        if isMiniaturized { deminiaturize(nil) }
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+        orderFrontRegardless()
+    }
+}

--- a/Lupen/UI/VerifyCosts/VerifyCostsWindowController.swift
+++ b/Lupen/UI/VerifyCosts/VerifyCostsWindowController.swift
@@ -33,7 +33,6 @@ final class VerifyCostsWindowController: NSWindowController {
     func show() {
         window?.title = store.activeProvider.verificationWindowTitle
         showWindow(nil)
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.bringToFront()
     }
 }

--- a/LupenTests/UI/Dashboard/DashboardWindowControllerTests.swift
+++ b/LupenTests/UI/Dashboard/DashboardWindowControllerTests.swift
@@ -43,7 +43,7 @@ struct DashboardWindowControllerTests {
     }
 
     @Test("showDashboard auto-selects when enabled")
-    func showDashboardAutoSelectsWhenEnabled() {
+    func showDashboardAutoSelectsWhenEnabled() async {
         let (h, cleanup) = makeHarness()
         defer { cleanup() }
         var autoSelectCount = 0
@@ -57,6 +57,14 @@ struct DashboardWindowControllerTests {
         defer { controller.close() }
 
         controller.showDashboard()
+
+        // Auto-selection is deferred to the next main-runloop tick (so it runs
+        // after the window's first layout pass, avoiding _NSDetectedLayoutRecursion).
+        // Drain the main queue once: FIFO ordering guarantees showDashboard's
+        // deferred block runs before this one, so the count is settled here.
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { cont.resume() }
+        }
 
         #expect(autoSelectCount == 1)
     }


### PR DESCRIPTION
## Summary

Fixes the intermittent bug where clicking the menu-bar (status item) icon logged the click and called `showDashboard()`, but the dashboard window never appeared — the user had to click the Dock icon to surface it, and once shown-then-closed it worked fine for a while.

## Root cause

A status-item click does **not** activate the app (`NSApp.isActive == false`). On macOS 14+ "cooperative activation", a self-`NSApp.activate(ignoringOtherApps:)` from that context is frequently ignored, so the app stays inactive and `makeKeyAndOrderFront(_:)` leaves the window **behind** the frontmost app's windows. Dock clicks work because the Dock activates the app first, then calls `applicationShouldHandleReopen` — which routes through the *same* `showDashboard()`. So the difference was never the show code; it was whether the app was active on entry.

The fix that was missing: `orderFrontRegardless()`, which brings a window to the front of its level **even while the app is inactive** — exactly the menu-bar case.

## Changes

- Add `NSWindow.bringToFront()` (`Lupen/UI/Support/NSWindow+BringToFront.swift`): deminiaturize → `activate(ignoringOtherApps:)` → `makeKeyAndOrderFront` → **`orderFrontRegardless()`**.
- Route all seven window show paths through it — Dashboard, Preferences, ManageSessions, Diagnostics, Reports, VerifyCosts, Log — replacing the inconsistent per-controller `activate`/`makeKeyAndOrderFront` sequences (none of which used `orderFrontRegardless`).
- Defer the dashboard's first-session auto-selection to the next runloop tick: running it inline during the window's first layout pass tripped `_NSDetectedLayoutRecursion`. The matching unit test now drains the main queue before asserting.

## Why this approach

`activate → makeKeyAndOrderFront → orderFrontRegardless` is the de-facto standard for surfacing windows from menu-bar apps on macOS 14/15+ (Apple deprecated `activate(ignoringOtherApps:)` with no drop-in replacement for this case, and provides no official recipe). The app is `.regular` (`LSUIElement=NO`, Dock icon always present), so it avoids the activation-policy toggling and timing delays that `.accessory` menu-bar apps need. `orderFrontRegardless()` has no all-Spaces side effect here because `collectionBehavior` is left at its default.

## Testing

- `xcodebuild build-for-testing` — succeeded, no new deprecation warnings.
- `DashboardWindowControllerTests` — passes (auto-select deferral covered).

Window surfacing depends on the window server, so it can't be fully reproduced in unit tests; the activation behavior should be verified by running the app and clicking the status item repeatedly.