### PR TITLE
Conversation visual hierarchy: quiet cards, refined attachment indicator, legible idle cost

### DIFF
--- a/Lupen/Domain/Conversation/Story/ConversationBlock.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationBlock.swift
@@ -158,6 +158,9 @@ struct StatusBlock: ConversationBlock, Equatable {
     let id: String
     let kind: StatusKind
     let isHighlighted: Bool
+    /// Originating Step uuid; nil for turn-level banners (compacted/orphan).
+    /// Lets selection retargeting treat a status banner as a highlight target.
+    var stepUuid: String? = nil
     var tier: BlockTier { .primary }
     var role: BlockRole { .system }
     var plainTextFallback: String { kind.message }

--- a/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
@@ -56,6 +56,7 @@ enum ConversationStoryBuilder {
             case let b as AssistantTextBlock: covered.insert(b.stepUuid)
             case let b as ThinkingBlock:      covered.insert(b.stepUuid)
             case let b as ToolGroupBlock:     b.calls.forEach { covered.insert($0.stepUuid) }
+            case let b as StatusBlock:        b.stepUuid.map { covered.insert($0) }
             default:                          break
             }
         }
@@ -194,12 +195,12 @@ enum ConversationStoryBuilder {
                 if step.isSyntheticApiError {
                     blocks.append(StatusBlock(
                         id: "st:\(step.uuid)", kind: .apiError(step.text),
-                        isHighlighted: isHL(step.uuid)
+                        isHighlighted: isHL(step.uuid), stepUuid: step.uuid
                     ))
                 } else {
                     blocks.append(StatusBlock(
                         id: "st:\(step.uuid)", kind: .stopped(step.stopReason),
-                        isHighlighted: isHL(step.uuid)
+                        isHighlighted: isHL(step.uuid), stepUuid: step.uuid
                     ))
                 }
 
@@ -207,7 +208,7 @@ enum ConversationStoryBuilder {
                 flushRun()
                 blocks.append(StatusBlock(
                     id: "st:\(step.uuid)", kind: .interrupted,
-                    isHighlighted: isHL(step.uuid)
+                    isHighlighted: isHL(step.uuid), stepUuid: step.uuid
                 ))
             }
         }

--- a/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
@@ -56,7 +56,7 @@ enum ConversationStoryBuilder {
             case let b as AssistantTextBlock: covered.insert(b.stepUuid)
             case let b as ThinkingBlock:      covered.insert(b.stepUuid)
             case let b as ToolGroupBlock:     b.calls.forEach { covered.insert($0.stepUuid) }
-            case let b as StatusBlock:        b.stepUuid.map { covered.insert($0) }
+            case let b as StatusBlock:        if let u = b.stepUuid { covered.insert(u) }
             default:                          break
             }
         }

--- a/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
+++ b/Lupen/Domain/Conversation/Story/ConversationStoryBuilder.swift
@@ -30,6 +30,60 @@ enum ConversationStoryBuilder {
         neighbor: Turn? = nil,
         highlight highlightStepUuid: String? = nil
     ) -> [ConversationBlock] {
+        let raw = assemble(turn: turn, neighbor: neighbor, highlight: highlightStepUuid)
+        var blocks = collapsedIfTooLarge(raw)
+        // Tree selection can land on a Step that maps to no block (a tool result,
+        // a usage-only reply, …). Leaving nothing highlighted would scroll to the
+        // top; instead retarget to the nearest preceding Step that does map, so a
+        // related block lights up.
+        if let wanted = highlightStepUuid, !blocks.contains(where: { $0.isHighlighted }),
+           let fallback = nearestCoveredStep(
+               turn: turn, requested: wanted, covered: coveredSteps(in: raw)
+           ) {
+            blocks = collapsedIfTooLarge(
+                assemble(turn: turn, neighbor: neighbor, highlight: fallback)
+            )
+        }
+        return blocks
+    }
+
+    /// Step uuids that map to a block (so a highlight on them lands somewhere).
+    private static func coveredSteps(in blocks: [ConversationBlock]) -> Set<String> {
+        var covered: Set<String> = []
+        for block in blocks {
+            switch block {
+            case let b as UserPromptBlock:    covered.insert(b.stepUuid)
+            case let b as AssistantTextBlock: covered.insert(b.stepUuid)
+            case let b as ThinkingBlock:      covered.insert(b.stepUuid)
+            case let b as ToolGroupBlock:     b.calls.forEach { covered.insert($0.stepUuid) }
+            default:                          break
+            }
+        }
+        return covered
+    }
+
+    /// Nearest Step that maps to a block: the closest preceding one (the user's
+    /// "pick the nearest element above"), else the closest following, else nil.
+    private static func nearestCoveredStep(
+        turn: Turn, requested: String, covered: Set<String>
+    ) -> String? {
+        let steps = turn.steps
+        guard let idx = steps.firstIndex(where: { $0.uuid == requested }) else { return nil }
+        if let prev = steps[..<idx].last(where: { covered.contains($0.uuid) }) {
+            return prev.uuid
+        }
+        if idx + 1 < steps.count,
+           let next = steps[(idx + 1)...].first(where: { covered.contains($0.uuid) }) {
+            return next.uuid
+        }
+        return nil
+    }
+
+    private static func assemble(
+        turn: Turn,
+        neighbor: Turn?,
+        highlight highlightStepUuid: String?
+    ) -> [ConversationBlock] {
         var blocks: [ConversationBlock] = []
         func isHL(_ uuid: String) -> Bool { highlightStepUuid == uuid }
 
@@ -170,7 +224,7 @@ enum ConversationStoryBuilder {
             ), at: 0)
         }
 
-        return Self.collapsedIfTooLarge(blocks)
+        return blocks
     }
 
     // MARK: - Curation cap for very large turns

--- a/Lupen/Domain/Conversation/TurnPreview.swift
+++ b/Lupen/Domain/Conversation/TurnPreview.swift
@@ -136,6 +136,16 @@ enum TurnPreview {
         return result as String
     }
 
+    /// Collapses any number of image markers (🖼) plus surrounding whitespace
+    /// into clean text with single spaces. The turn/conversation lists render a
+    /// single attachment glyph in the view layer, so the preview text itself
+    /// carries no marker. Pure (no regex) — cheap for per-row use and testable.
+    static func collapsedAttachmentText(_ preview: String) -> String {
+        preview
+            .split(whereSeparator: { $0 == "🖼" || $0.isWhitespace })
+            .joined(separator: " ")
+    }
+
     /// Returns the input only when it's a bare slash command (no whitespace).
     /// "/skill" -> "/skill", "/skill foo" -> nil.
     static func slashOnly(_ text: String) -> String? {

--- a/Lupen/UI/Dashboard/Conversation/CardContainerView.swift
+++ b/Lupen/UI/Dashboard/Conversation/CardContainerView.swift
@@ -12,7 +12,7 @@ import AppKit
 /// but their chrome is turned down so the body text is the clear focal point:
 ///
 /// - Every primary block (prompt / reply / status) sits in a quiet card: a
-///   1-device-pixel hairline border (`DetailStyles.sectionBoxBorderColor`) + a
+///   1-device-pixel hairline border (`DetailStyles.conversationCardBorderColor`) + a
 ///   faint neutral fill, matching the grouped boxes used elsewhere in the pane.
 /// - The reply uses the lightest fill (`sectionBoxFillColor`); the prompt/status
 ///   a touch more (`conversationPromptFillColor`) so the speaker reads from a

--- a/Lupen/UI/Dashboard/Conversation/CardContainerView.swift
+++ b/Lupen/UI/Dashboard/Conversation/CardContainerView.swift
@@ -7,21 +7,28 @@
 
 import AppKit
 
-/// Common shell for every conversation card: a role gutter + a tier-based
-/// surface (background/border/gutter width) + a body slot.
+/// Common shell for every conversation card. Cards are KEPT — they give the
+/// dialogue containment, a single left baseline, and block-level scan anchors —
+/// but their chrome is turned down so the body text is the clear focal point:
 ///
-/// Role (user/assistant/system/subAgent) picks the color; tier
-/// (primary/secondary) picks the strength, so important dialogue (prompts /
-/// final replies = primary) reads more sharply than supporting content
-/// (tools / thinking = secondary). The selected Step card is emphasized with an
-/// accent border. The surface tint is a low-alpha foreground overlay
-/// (labelColor, etc.) so it keeps contrast against the background in both dark
-/// and light modes (fixes the dark-mode sink of the old textBackgroundColor
-/// approach).
+/// - Every primary block (prompt / reply / status) sits in a quiet card: a
+///   1-device-pixel hairline border (`DetailStyles.sectionBoxBorderColor`) + a
+///   faint neutral fill, matching the grouped boxes used elsewhere in the pane.
+/// - The reply uses the lightest fill (`sectionBoxFillColor`); the prompt/status
+///   a touch more (`conversationPromptFillColor`) so the speaker reads from a
+///   subtle asymmetry rather than a role color.
+/// - Role is whispered through the header icon tint only — no full-color gutter.
+/// - Supporting content (thinking·tools = secondary) gets no shell: just an
+///   indented gray line so it recedes.
+/// - The selected Step is marked by an accent-colored border + a faint accent
+///   fill (selection is one-way, tree → card).
+///
+/// Hierarchy comes from turning chrome down (quiet border, neutral fill, grayed
+/// headers), not from removing the card — a frame-less reply lost its left
+/// baseline and containment and read as crude.
 @MainActor
 final class CardContainerView: NSView {
 
-    private let gutter = NSView()
     private let bodyContainer = NSView()
     private let role: BlockRole
     private let tier: BlockTier
@@ -41,38 +48,27 @@ final class CardContainerView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
+    /// Primary blocks (and any selected block) get the card shell: border, fill,
+    /// padding. Supporting blocks render as an indented, shell-less line.
+    private var hasShell: Bool { tier == .primary || highlighted }
+
     private func setup() {
         layer?.cornerRadius = 8
-        // Only body (primary) / selected cards draw a shell (background/border/
-        // gutter). Supporting (secondary: thinking·tools) cards render as an
-        // indented single line with no shell → less noise, body stands out.
-        let showShell = tier == .primary || highlighted
-        layer?.borderWidth = highlighted ? 1.5 : (showShell ? 0.75 : 0)
-
-        gutter.wantsLayer = true
-        gutter.layer?.cornerRadius = 2
-        gutter.isHidden = !showShell
-        gutter.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(gutter)
+        layer?.borderWidth = borderWidth()
 
         bodyContainer.translatesAutoresizingMaskIntoConstraints = false
         addSubview(bodyContainer)
 
-        let verticalInset: CGFloat = showShell ? 12 : 4      // supporting cards are flatter
-        let bodyLeadingInset: CGFloat = showShell ? 0 : 26   // supporting cards are indented
-        NSLayoutConstraint.activate([
-            gutter.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            gutter.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            gutter.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
-            gutter.widthAnchor.constraint(equalToConstant: 4),
+        // Shelled cards carry inner padding; supporting lines indent instead.
+        let vInset: CGFloat = hasShell ? 10 : 4
+        let leadingInset: CGFloat = hasShell ? 14 : 24
+        let trailingInset: CGFloat = hasShell ? 14 : 12
 
-            bodyContainer.leadingAnchor.constraint(
-                equalTo: showShell ? gutter.trailingAnchor : leadingAnchor,
-                constant: showShell ? 10 : bodyLeadingInset
-            ),
-            bodyContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
-            bodyContainer.topAnchor.constraint(equalTo: topAnchor, constant: verticalInset),
-            bodyContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -verticalInset),
+        NSLayoutConstraint.activate([
+            bodyContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingInset),
+            bodyContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -trailingInset),
+            bodyContainer.topAnchor.constraint(equalTo: topAnchor, constant: vInset),
+            bodyContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -vInset),
         ])
     }
 
@@ -81,18 +77,46 @@ final class CardContainerView: NSView {
         applyColors()
     }
 
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        // The border is a device-pixel width, so its point value depends on the
+        // display scale — reapply when the window moves between displays.
+        layer?.borderWidth = borderWidth()
+    }
+
+    /// 1 device pixel normally; 2 device pixels when selected (the accent border
+    /// is the selection cue, so it reads a touch heavier). 0 for shell-less
+    /// supporting blocks.
+    private func borderWidth() -> CGFloat {
+        guard hasShell else { return 0 }
+        let hairline = DetailStyles.hairlineWidth(for: self)
+        return highlighted ? hairline * 2 : hairline
+    }
+
     /// Recompute layer colors for the current appearance (dark/light).
     private func applyColors() {
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            let showShell = tier == .primary || highlighted
-            layer?.backgroundColor = showShell
-                ? Self.surfaceColor(role: role, tier: tier, highlighted: highlighted).cgColor
-                : NSColor.clear.cgColor
-            layer?.borderColor = (highlighted
-                ? Self.accentColor(for: role).withAlphaComponent(0.7)
-                : NSColor.separatorColor.withAlphaComponent(0.5)).cgColor
-            gutter.layer?.backgroundColor = Self.accentColor(for: role).cgColor
+            layer?.backgroundColor = backgroundFill().cgColor
+            layer?.borderColor = borderColor().cgColor
         }
+    }
+
+    /// Quiet, neutral fills. The reply gets the lightest tint; the prompt/status
+    /// a touch more so the speaker reads from the asymmetry, not a role color.
+    private func backgroundFill() -> NSColor {
+        if highlighted { return Self.accentColor(for: role).withAlphaComponent(0.10) }
+        guard tier == .primary else { return .clear }
+        switch role {
+        case .user, .system:        return DetailStyles.conversationPromptFillColor
+        case .assistant, .subAgent: return DetailStyles.sectionBoxFillColor
+        }
+    }
+
+    /// Neutral hairline normally; the role accent when selected (the one cue that
+    /// marks the tree-selected Step on the otherwise quiet surface).
+    private func borderColor() -> NSColor {
+        if highlighted { return Self.accentColor(for: role) }
+        return hasShell ? DetailStyles.conversationCardBorderColor : .clear
     }
 
     func setBody(_ view: NSView) {
@@ -107,8 +131,8 @@ final class CardContainerView: NSView {
         ])
     }
 
-    /// Role accent color (gutter + emphasis border). systemYellow has poor dark
-    /// contrast, so it is avoided.
+    /// Role accent color (selected border + selected fill + header icon tint).
+    /// systemYellow has poor dark contrast, so it is avoided.
     static func accentColor(for role: BlockRole) -> NSColor {
         switch role {
         case .user:      return .systemTeal
@@ -116,20 +140,5 @@ final class CardContainerView: NSView {
         case .system:    return .systemOrange
         case .subAgent:  return .systemPurple
         }
-    }
-
-    /// Role×tier surface tint. A low-alpha foreground overlay keeps contrast in
-    /// both dark and light modes. primary (prompts·replies) is stronger,
-    /// secondary (tools·thinking) is lighter → hierarchy.
-    static func surfaceColor(role: BlockRole, tier: BlockTier, highlighted: Bool) -> NSColor {
-        if highlighted { return accentColor(for: role).withAlphaComponent(0.12) }
-        let base: NSColor
-        switch role {
-        case .user:      base = .systemTeal
-        case .assistant: base = .labelColor   // neutral foreground — dark = white low-alpha, light = black low-alpha
-        case .system:    base = .systemOrange
-        case .subAgent:  base = .systemPurple
-        }
-        return base.withAlphaComponent(tier == .primary ? 0.09 : 0.04)
     }
 }

--- a/Lupen/UI/Dashboard/Conversation/ConversationBodyTextView.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationBodyTextView.swift
@@ -22,6 +22,16 @@ final class ConversationBodyTextView: NSTextView, NSTextViewDelegate {
 
     var onRevealFile: ((URL) -> Void)?
 
+    /// Optional reading-width cap. When set, glyphs wrap at
+    /// `min(bounds.width, maxReadingWidth)` while the *view* still fills the
+    /// container width. Crucial: the cap lives in the text container, NOT in an
+    /// Auto Layout width constraint — a `<=` width constraint on this view would
+    /// propagate up the equality chain and lock the whole pane's max width. The
+    /// container must never be width-constrained by its children.
+    var maxReadingWidth: CGFloat? {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
     static func make() -> ConversationBodyTextView {
         let container = NSTextContainer(
             size: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
@@ -98,9 +108,12 @@ final class ConversationBodyTextView: NSTextView, NSTextViewDelegate {
         guard let textContainer else { return false }
         let width = bounds.width
         guard width > 0 else { return false }
-        if textContainer.containerSize.width != width {
+        // Wrap at the reading-width cap when set, but keep the view following the
+        // real bounds width — so the container is never width-constrained by us.
+        let target = min(width, maxReadingWidth ?? width)
+        if textContainer.containerSize.width != target {
             textContainer.containerSize = NSSize(
-                width: width, height: CGFloat.greatestFiniteMagnitude
+                width: target, height: CGFloat.greatestFiniteMagnitude
             )
         }
         return true

--- a/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
@@ -24,6 +24,10 @@ final class ConversationDetailView: NSView {
     /// time leaves dangling constraints that pile up and break layout on fast
     /// Turn switching.
     private var cardConstraints: [NSLayoutConstraint] = []
+    /// Block ids of the currently rendered turn. Lets `configure` tell "same
+    /// turn, only the selected Step changed" (keep scroll if the target is
+    /// already visible) from "new content" (reveal the target).
+    private var renderedBlockIDs: [String] = []
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -49,7 +53,7 @@ final class ConversationDetailView: NSView {
     private func setup() {
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 10
+        stack.spacing = 12
         stack.edgeInsets = NSEdgeInsets(top: 20, left: 0, bottom: 24, right: 0)
         stack.translatesAutoresizingMaskIntoConstraints = false
         documentView.translatesAutoresizingMaskIntoConstraints = false
@@ -107,6 +111,9 @@ final class ConversationDetailView: NSView {
             stack.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
+        let ids = blocks.map(\.id)
+        let sameContent = ids == renderedBlockIDs
+        renderedBlockIDs = ids
         var highlightedView: NSView?
         var previous: (view: NSView, tier: BlockTier)?
         for block in blocks {
@@ -117,11 +124,18 @@ final class ConversationDetailView: NSView {
             cardConstraints.append(contentsOf: [leading, trailing])
             NSLayoutConstraint.activate([leading, trailing])
             if let previous {
-                // Pack supporting (thinking·tools) cards tightly, and give
-                // breathing room when a body card is adjacent, so it reads as
-                // 'dialogue units' (spacing grouping).
-                let bothSecondary = previous.tier == .secondary && block.tier == .secondary
-                stack.setCustomSpacing(bothSecondary ? 2 : 14, after: previous.view)
+                // Cards carry the block boundaries, so the gaps stay modest: a new
+                // prompt opens a new round-trip (20), supporting lines (thinking·
+                // tools) pack tightly (2), everything else breathes (12).
+                let spacing: CGFloat
+                if block is UserPromptBlock {
+                    spacing = 20
+                } else if previous.tier == .secondary && block.tier == .secondary {
+                    spacing = 2
+                } else {
+                    spacing = 12
+                }
+                stack.setCustomSpacing(spacing, after: previous.view)
             }
             previous = (view, block.tier)
             if block.isHighlighted, highlightedView == nil { highlightedView = view }
@@ -131,18 +145,41 @@ final class ConversationDetailView: NSView {
         documentView.layoutSubtreeIfNeeded()
         stack.layoutSubtreeIfNeeded()
         if let highlightedView {
-            // Bring the selected card near the top (−12) even if partly visible.
-            // Clamp to maxY to avoid over-scroll. scrollToVisible is unsuitable
-            // ('doesn't move if already visible').
-            let rect = highlightedView.convert(highlightedView.bounds, to: documentView)
-            let visibleHeight = scrollView.contentView.bounds.height
-            let documentHeight = max(documentView.bounds.height, stack.fittingSize.height)
-            let maxY = max(0, documentHeight - visibleHeight)
-            let targetY = min(max(0, rect.minY - 12), maxY)
-            scrollView.contentView.scroll(to: NSPoint(x: 0, y: targetY))
-        } else {
+            revealHighlighted(highlightedView, keepIfVisible: sameContent)
+        } else if !sameContent {
+            // New content with no highlighted Step (e.g. whole-Turn view) → top.
             scrollView.contentView.scroll(to: .zero)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
         }
+    }
+
+    /// Scroll only as much as needed to reveal `view`. When `keepIfVisible` (the
+    /// same turn is on screen and only the selected Step changed), a fully
+    /// visible target is left untouched — no jump to the top. Otherwise the
+    /// target is brought into view: minimally for the same turn, or near the top
+    /// for new content.
+    private func revealHighlighted(_ view: NSView, keepIfVisible: Bool) {
+        let rect = view.convert(view.bounds, to: documentView)
+        let clip = scrollView.contentView.bounds
+        let topInset: CGFloat = 12
+        let visibleHeight = clip.height
+        let documentHeight = max(documentView.bounds.height, stack.fittingSize.height)
+        let maxY = max(0, documentHeight - visibleHeight)
+
+        let fullyVisible = rect.minY >= clip.minY && rect.maxY <= clip.maxY
+        if keepIfVisible && fullyVisible { return }
+
+        let targetY: CGFloat
+        if !keepIfVisible || rect.minY < clip.minY || rect.height + topInset >= visibleHeight {
+            // New content, target above the viewport, or taller than the viewport
+            // → align its top (with a small inset).
+            targetY = rect.minY - topInset
+        } else {
+            // Target below the viewport → bring its bottom just into view.
+            targetY = rect.maxY - visibleHeight + topInset
+        }
+        let clamped = min(max(0, targetY), maxY)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: clamped))
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 }

--- a/Lupen/UI/Dashboard/Conversation/ConversationInlineText.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationInlineText.swift
@@ -25,7 +25,7 @@ enum ConversationInlineText {
         color: NSColor
     ) -> NSAttributedString {
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineHeightMultiple = 1.35
+        paragraph.lineHeightMultiple = 1.5
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: font, .foregroundColor: color, .paragraphStyle: paragraph,
         ]
@@ -80,7 +80,14 @@ enum ConversationInlineText {
     /// link) on the base font. Block structure (table/code block/list) is
     /// already split by the caller via `MarkdownParser`, so only inline is
     /// handled here. Falls back to plain text (`body`) on parse failure.
-    static func markdownInline(_ text: String, font: NSFont, color: NSColor) -> NSAttributedString {
+    static func markdownInline(
+        _ text: String,
+        font: NSFont,
+        color: NSColor,
+        lineHeight: CGFloat = 1.5,
+        spacingBefore: CGFloat = 0,
+        headIndent: CGFloat = 0
+    ) -> NSAttributedString {
         var options = AttributedString.MarkdownParsingOptions()
         options.interpretedSyntax = .inlineOnlyPreservingWhitespace
         options.failurePolicy = .returnPartiallyParsedIfPossible
@@ -91,7 +98,10 @@ enum ConversationInlineText {
         let full = NSRange(location: 0, length: result.length)
         result.addAttribute(.foregroundColor, value: color, range: full)
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineHeightMultiple = 1.35
+        paragraph.lineHeightMultiple = lineHeight
+        paragraph.paragraphSpacingBefore = spacingBefore
+        paragraph.headIndent = headIndent
+        paragraph.firstLineHeadIndent = headIndent
         result.addAttribute(.paragraphStyle, value: paragraph, range: full)
         result.enumerateAttribute(.inlinePresentationIntent, in: full) { value, range, _ in
             var resolved = font
@@ -104,6 +114,13 @@ enum ConversationInlineText {
                 }
                 if intent.contains(.code) {
                     resolved = .monospacedSystemFont(ofSize: font.pointSize, weight: .regular)
+                    // Faint background so inline code stays identifiable as code
+                    // once the surrounding text flows chrome-free.
+                    result.addAttribute(
+                        .backgroundColor,
+                        value: NSColor.labelColor.withAlphaComponent(0.08),
+                        range: range
+                    )
                 }
             }
             result.addAttribute(.font, value: resolved, range: range)
@@ -114,11 +131,12 @@ enum ConversationInlineText {
     /// Attributed string with an SF Symbol (not emoji — proper system tint /
     /// dark mode / VoiceOver) prepended to text. Used for card header/summary glyphs.
     static func symbolPrefixed(
-        _ symbolName: String, text: String, font: NSFont, color: NSColor
+        _ symbolName: String, text: String, font: NSFont, color: NSColor,
+        iconColor: NSColor? = nil
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let config = NSImage.SymbolConfiguration(pointSize: font.pointSize, weight: .medium)
-            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
+            .applying(NSImage.SymbolConfiguration(paletteColors: [iconColor ?? color]))
         if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
             .withSymbolConfiguration(config) {
             let attachment = NSTextAttachment()
@@ -137,12 +155,18 @@ enum ConversationInlineText {
 /// Card-top role/meta header ("You", "Assistant · opus-4-8 · $0.37").
 @MainActor
 enum ConversationCardHeader {
-    static func make(_ text: String, color: NSColor, symbol: String? = nil) -> NSTextField {
-        let font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+    static func make(
+        _ text: String, color: NSColor, symbol: String? = nil, iconColor: NSColor? = nil
+    ) -> NSTextField {
+        // medium (not semibold) + monospaced digits: the header recedes behind
+        // the body, while the model·cost meta digits still align. The text color
+        // is supplied by the caller (kept secondary); the icon may keep a faint
+        // role tint via `iconColor`.
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
         let label = DetailStyles.makeChromeLabel(text, font: font, color: color, alignment: .left)
         if let symbol {
             label.attributedStringValue = ConversationInlineText.symbolPrefixed(
-                symbol, text: text, font: font, color: color
+                symbol, text: text, font: font, color: color, iconColor: iconColor
             )
         }
         // Truncate + low compression so a long header (model·cost) doesn't push the card width.

--- a/Lupen/UI/Dashboard/Conversation/Markdown/ConversationMarkdownView.swift
+++ b/Lupen/UI/Dashboard/Conversation/Markdown/ConversationMarkdownView.swift
@@ -38,6 +38,7 @@ final class ConversationMarkdownView: NSStackView {
             guard run.length > 0 else { return }
             let textView = ConversationBodyTextView.make()
             textView.onRevealFile = onRevealFile
+            textView.maxReadingWidth = Self.maxReadingWidth
             textView.setBody(run)
             addArranged(textView)
             run = NSMutableAttributedString()
@@ -65,12 +66,26 @@ final class ConversationMarkdownView: NSStackView {
         view.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
     }
 
+    /// Reading-width cap for body text (NOT code blocks / tables). Enforced
+    /// inside the text view's text container (`ConversationBodyTextView.
+    /// maxReadingWidth`), NEVER via an Auto Layout width constraint: a `<=` width
+    /// constraint on a child propagates up the equality chain and locks the whole
+    /// pane's max width. The text view still follows the container width via
+    /// `addArranged` (`== width`); only the glyph wrapping is capped, leaving
+    /// empty space on the right on very wide panels.
+    static let maxReadingWidth: CGFloat = 700
+
     // MARK: - Text node → attributed
 
     private static func attributed(for node: MarkdownNode) -> NSAttributedString {
         switch node {
         case .heading(let level, let text):
-            return ConversationInlineText.markdownInline(text, font: headingFont(level: level), color: .labelColor)
+            // Tighter line-height + extra space above (not below) so a heading
+            // reads as the head of the block that follows, not floating text.
+            return ConversationInlineText.markdownInline(
+                text, font: headingFont(level: level), color: .labelColor,
+                lineHeight: 1.25, spacingBefore: 8
+            )
         case .paragraph(let text):
             return ConversationInlineText.markdownInline(text, font: bodyFont, color: .labelColor)
         case .bulletList(let items):
@@ -78,8 +93,11 @@ final class ConversationMarkdownView: NSStackView {
         case .orderedList(let items):
             return list(items.enumerated().map { (marker: "\($0.offset + 1).  ", text: $0.element) })
         case .quote(let lines):
+            // No left bar (an earlier design decision); a left indent still keeps
+            // the quote identifiable once the surrounding cards are gone.
             return ConversationInlineText.markdownInline(
-                lines.joined(separator: "\n"), font: bodyFont, color: .secondaryLabelColor
+                lines.joined(separator: "\n"), font: bodyFont, color: .secondaryLabelColor,
+                lineHeight: 1.45, headIndent: 12
             )
         case .codeBlock, .table:
             return NSAttributedString() // handled by a dedicated view; never reached here
@@ -88,7 +106,7 @@ final class ConversationMarkdownView: NSStackView {
 
     private static func list(_ items: [(marker: String, text: String)]) -> NSAttributedString {
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineHeightMultiple = 1.35
+        paragraph.lineHeightMultiple = 1.45
         paragraph.headIndent = 16        // indent the wrapped second line by the marker width (hanging indent)
         paragraph.firstLineHeadIndent = 0
         let result = NSMutableAttributedString()
@@ -112,8 +130,8 @@ final class ConversationMarkdownView: NSStackView {
     static func headingFont(level: Int) -> NSFont {
         let size: CGFloat
         switch level {
-        case 1: size = 18
-        case 2: size = 16
+        case 1: size = 20
+        case 2: size = 17
         case 3: size = 15
         default: size = 14
         }
@@ -139,10 +157,8 @@ final class CodeBlockView: NSView {
 
     private func setup() {
         wantsLayer = true
-        layer?.backgroundColor = NSColor.textBackgroundColor.withAlphaComponent(0.5).cgColor
         layer?.cornerRadius = 6
-        layer?.borderWidth = 0.5
-        layer?.borderColor = NSColor.separatorColor.cgColor
+        applyColors()
 
         let text = ConversationBodyTextView.make()
         text.setBody(NSAttributedString(
@@ -154,9 +170,16 @@ final class CodeBlockView: NSView {
         ))
         addSubview(text)
 
-        let copyButton = NSButton(title: "Copy", target: self, action: #selector(copyCode))
-        copyButton.bezelStyle = .accessoryBarAction
-        copyButton.controlSize = .mini
+        let copyButton: NSButton
+        if let icon = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy") {
+            copyButton = NSButton(image: icon, target: self, action: #selector(copyCode))
+            copyButton.isBordered = false
+            copyButton.contentTintColor = .secondaryLabelColor
+        } else {
+            copyButton = NSButton(title: "Copy", target: self, action: #selector(copyCode))
+            copyButton.bezelStyle = .accessoryBarAction
+        }
+        copyButton.controlSize = .small
         copyButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(copyButton)
 
@@ -168,6 +191,17 @@ final class CodeBlockView: NSView {
             copyButton.topAnchor.constraint(equalTo: topAnchor, constant: 6),
             copyButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ])
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
+
+    private func applyColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = DetailStyles.conversationCodeFillColor.cgColor
+        }
     }
 
     @objc private func copyCode() {
@@ -192,7 +226,7 @@ final class MarkdownTableView: NSView {
     private func setup(headers: [String], rows: [[String]]) {
         wantsLayer = true
         layer?.cornerRadius = 6
-        layer?.borderWidth = 0.5
+        layer?.borderWidth = DetailStyles.hairlineWidth(for: self)
         layer?.borderColor = NSColor.separatorColor.cgColor
 
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
@@ -202,7 +236,7 @@ final class MarkdownTableView: NSView {
             let label = DetailStyles.makeSelectableValueLabel(
                 text,
                 font: .systemFont(ofSize: 12, weight: bold ? .semibold : .regular),
-                color: bold ? .labelColor : .secondaryLabelColor,
+                color: .labelColor,
                 alignment: .left
             )
             label.lineBreakMode = .byTruncatingTail
@@ -227,5 +261,10 @@ final class MarkdownTableView: NSView {
             grid.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             grid.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
         ])
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        layer?.borderWidth = DetailStyles.hairlineWidth(for: self)
     }
 }

--- a/Lupen/UI/Dashboard/Conversation/Markdown/ConversationMarkdownView.swift
+++ b/Lupen/UI/Dashboard/Conversation/Markdown/ConversationMarkdownView.swift
@@ -267,4 +267,13 @@ final class MarkdownTableView: NSView {
         super.viewDidChangeBackingProperties()
         layer?.borderWidth = DetailStyles.hairlineWidth(for: self)
     }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        // Re-resolve the dynamic border color (cgColor snapshots the appearance
+        // at assignment) so a live dark/light switch updates without a rebuild.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.borderColor = NSColor.separatorColor.cgColor
+        }
+    }
 }

--- a/Lupen/UI/Dashboard/Conversation/Renderers/AssistantTextCardRenderer.swift
+++ b/Lupen/UI/Dashboard/Conversation/Renderers/AssistantTextCardRenderer.swift
@@ -21,7 +21,10 @@ struct AssistantTextCardRenderer: BlockRenderer {
         stack.alignment = .leading
         stack.spacing = 4
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.addArrangedSubview(ConversationCardHeader.make(headerText(for: block), color: .controlAccentColor, symbol: "sparkles"))
+        stack.addArrangedSubview(ConversationCardHeader.make(
+            headerText(for: block), color: .secondaryLabelColor, symbol: "sparkles",
+            iconColor: NSColor.controlAccentColor.withAlphaComponent(0.65)
+        ))
 
         let body = ConversationMarkdownView(markdown: block.markdown, onRevealFile: context.revealInFinder)
         stack.addArrangedSubview(body)

--- a/Lupen/UI/Dashboard/Conversation/Renderers/UserPromptCardRenderer.swift
+++ b/Lupen/UI/Dashboard/Conversation/Renderers/UserPromptCardRenderer.swift
@@ -16,7 +16,10 @@ struct UserPromptCardRenderer: BlockRenderer {
         stack.alignment = .leading
         stack.spacing = 4
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.addArrangedSubview(ConversationCardHeader.make("You", color: .systemTeal, symbol: "bubble.left.fill"))
+        stack.addArrangedSubview(ConversationCardHeader.make(
+            "You", color: .secondaryLabelColor, symbol: "bubble.left.fill",
+            iconColor: NSColor.systemTeal.withAlphaComponent(0.65)
+        ))
 
         let font = NSFont.systemFont(ofSize: 13)
         let body = ConversationBodyTextView.make()

--- a/Lupen/UI/Dashboard/Conversation/Renderers/UserPromptCardRenderer.swift
+++ b/Lupen/UI/Dashboard/Conversation/Renderers/UserPromptCardRenderer.swift
@@ -33,8 +33,10 @@ struct UserPromptCardRenderer: BlockRenderer {
             ))
         } else {
             if block.inlineImageCount > 0 {
+                // One indicator regardless of count — the prompt body only signals
+                // "has attachment"; the actual images live in the Attachments tab.
                 attributed.append(ConversationInlineText.imageGlyphPrefix(
-                    count: block.inlineImageCount, font: font, color: .labelColor
+                    count: 1, font: font, color: .labelColor
                 ))
                 attributed.append(NSAttributedString(string: " ", attributes: [.font: font]))
             }

--- a/Lupen/UI/Dashboard/DetailStyles.swift
+++ b/Lupen/UI/Dashboard/DetailStyles.swift
@@ -130,6 +130,64 @@ enum DetailStyles {
         NSColor.separatorColor
     }
 
+    /// Conversation prompt-fill — a neutral low-alpha surface for the user's
+    /// prompt block. Once the cards are stripped this fill is the main speaker
+    /// cue, so it sits a touch stronger than `sectionBoxFillColor` while still
+    /// reading as "a quiet surface". Branched per appearance (same idiom as
+    /// `sectionBoxFillColor`) so dark and light feel equivalent rather than one
+    /// being invisible and the other heavy.
+    static var conversationPromptFillColor: NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return isDark
+                ? NSColor.white.withAlphaComponent(0.05)
+                : NSColor.black.withAlphaComponent(0.04)
+        }
+    }
+
+    /// A crisp 1-device-pixel hairline width for `view`'s current display.
+    ///
+    /// A CALayer `borderWidth` is in points and is rasterized at the layer's
+    /// `contentsScale`, so a hardcoded 0.5pt is exactly one pixel only on Retina
+    /// (2x); on a 1x display it is a half-pixel that antialiases to a fuzzy line.
+    /// `1 / backingScaleFactor` yields one device pixel on any display
+    /// (0.5pt @2x, 1pt @1x). Reapply from `viewDidChangeBackingProperties()`
+    /// because a window can move between displays of different scale.
+    static func hairlineWidth(for view: NSView) -> CGFloat {
+        let scale = view.window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2
+        return 1.0 / scale
+    }
+
+    /// Resting border for conversation cards. `separatorColor` reads too faint
+    /// as a 1px hairline on the dark conversation surface (cards stop being
+    /// distinguishable), so this is a touch more present while staying a quiet
+    /// neutral line. Branched per appearance (same idiom as the fill tokens).
+    static var conversationCardBorderColor: NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return isDark
+                ? NSColor.white.withAlphaComponent(0.20)
+                : NSColor.black.withAlphaComponent(0.14)
+        }
+    }
+
+    /// Code-block surface (fill only — no border, to avoid a nested box-in-box).
+    /// `textBackgroundColor` blended into the card read as nearly invisible
+    /// (white-on-white in light, sunk in dark). This is a distinct shaded well —
+    /// a touch lighter than a dark card, a clear gray on a light card. The light
+    /// value is heavier because a black overlay on a near-white card needs more
+    /// alpha to register than a white overlay on a near-black one.
+    static var conversationCodeFillColor: NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return isDark
+                ? NSColor.white.withAlphaComponent(0.06)
+                : NSColor.black.withAlphaComponent(0.08)
+        }
+    }
+
     // MARK: - Row typography + heights
 
     /// Regular row: `Input Tokens` / `25`.

--- a/Lupen/UI/Dashboard/TurnOutlineViewController.swift
+++ b/Lupen/UI/Dashboard/TurnOutlineViewController.swift
@@ -1889,7 +1889,9 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                         preview,
                         font: headerFont,
                         color: .labelColor,
-                        attachmentColor: .systemBlue
+                        // A notch below the text so the clip reads as a quiet
+                        // indicator, not a competing glyph (label=merges, secondary=too faint).
+                        attachmentColor: Self.attachmentTint
                     )
                 }
                 return Self.prependingCodexSourceLabel(sourceLabel, to: base, font: headerFont)
@@ -1909,8 +1911,8 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                         base = Self.attributedPreview(
                             preview,
                             font: headerFont,
-                            color: .secondaryLabelColor,
-                            attachmentColor: .tertiaryLabelColor
+                            color: Self.interruptedTint,
+                            attachmentColor: Self.interruptedTint
                         )
                     }
                     return Self.prependingCodexSourceLabel(
@@ -1922,7 +1924,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                 }()
                 let withBadge = Self.appendingStatusBadge("⊘ interrupted", to: dimAttributed)
                 let hintedDim = appendShortPromptHint(to: withBadge, for: turn)
-                cell.textField?.attributedStringValue = QueryHighlighter.applied(to: hintedDim, query: highlightQuery)
+                cell.setRichText(QueryHighlighter.applied(to: hintedDim, query: highlightQuery))
                 cell.textField?.alignment = .left
                 cell.textField?.lineBreakMode = .byTruncatingTail
                 cell.toolTip = sourceLabel.map { "Interrupted · Codex source: \($0)" } ?? "Interrupted"
@@ -1940,7 +1942,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                 let cell = makeOrReuseTurnHeaderCell(id: NSUserInterfaceItemIdentifier("TurnCell_prompt_apiError"))
                 let withBadge = Self.appendingStatusBadge("⚠ API error", color: .systemOrange, to: attributed)
                 let hinted = appendShortPromptHint(to: withBadge, for: turn)
-                cell.textField?.attributedStringValue = QueryHighlighter.applied(to: hinted, query: highlightQuery)
+                cell.setRichText(QueryHighlighter.applied(to: hinted, query: highlightQuery))
                 cell.textField?.alignment = .left
                 cell.textField?.lineBreakMode = .byTruncatingTail
                 // Tooltip surfaces the actual error body when available
@@ -1969,7 +1971,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                 let cell = makeOrReuseTurnHeaderCell(id: NSUserInterfaceItemIdentifier("TurnCell_prompt_compacted"))
                 let withBadge = Self.appendingStatusBadge("✂ compacted", to: attributed)
                 let hinted = appendShortPromptHint(to: withBadge, for: turn)
-                cell.textField?.attributedStringValue = QueryHighlighter.applied(to: hinted, query: highlightQuery)
+                cell.setRichText(QueryHighlighter.applied(to: hinted, query: highlightQuery))
                 cell.textField?.alignment = .left
                 cell.textField?.lineBreakMode = .byTruncatingTail
                 let source = sourceLabel.map { " Codex source: \($0)." } ?? ""
@@ -1981,7 +1983,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
             } else {
                 let cell = makeOrReuseTurnHeaderCell(id: NSUserInterfaceItemIdentifier("TurnCell_prompt_header"))
                 let hinted = appendShortPromptHint(to: attributed, for: turn)
-                cell.textField?.attributedStringValue = QueryHighlighter.applied(to: hinted, query: highlightQuery)
+                cell.setRichText(QueryHighlighter.applied(to: hinted, query: highlightQuery))
                 cell.textField?.alignment = .left
                 cell.textField?.lineBreakMode = .byTruncatingTail
                 cell.toolTip = sourceLabel.map { "Codex source: \($0)" }
@@ -2725,7 +2727,8 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
 
     /// Returns an attributed string built from a `TurnPreview` where
     /// the `🖼` emoji placeholder is replaced by an inline SF Symbol
-    /// `photo` attachment so the icon renders in the system text tone
+    /// `paperclip` attachment — the conventional "has attachment" affordance
+    /// (Mail/Finder) — so the icon renders in the muted system text tone
     /// instead of the off-tone color emoji glyph.
     static func attributedPreview(
         _ preview: String,
@@ -2742,25 +2745,51 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
         }
 
         let attachTint = attachmentColor ?? color
+        // Collapse any number of image markers into a single leading glyph — the
+        // list only needs to signal "has attachment", not how many.
+        let textOnly = preview
+            .replacingOccurrences(of: "🖼", with: " ")
+            .replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
         let result = NSMutableAttributedString()
-        let parts = preview.components(separatedBy: "🖼")
-        for (index, part) in parts.enumerated() {
-            if !part.isEmpty {
-                result.append(NSAttributedString(string: part, attributes: baseAttrs))
-            }
-            if index < parts.count - 1 {
-                result.append(photoSymbolAttachment(font: font, color: attachTint))
-            }
+        result.append(attachmentGlyph(font: font, color: attachTint))   // includes a trailing space
+        if !textOnly.isEmpty {
+            result.append(NSAttributedString(string: textOnly, attributes: baseAttrs))
         }
         return result
     }
 
-    /// Inline SF Symbol `photo` attachment scaled/tinted to match the
-    /// surrounding text's font size and color.
-    private static func photoSymbolAttachment(font: NSFont, color: NSColor) -> NSAttributedString {
-        let config = NSImage.SymbolConfiguration(pointSize: font.pointSize, weight: .regular)
+    /// Tint for the inline attachment glyph — a notch below the text (between
+    /// secondaryLabel and label), resolved per-appearance via a dynamic provider.
+    /// `labelColor.withAlphaComponent(...)` loses its dynamic resolution when
+    /// baked into the symbol image (renders the dark-mode value in light mode →
+    /// invisible), so apply the alpha onto concrete white/black instead.
+    private static var attachmentTint: NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.6)
+        }
+    }
+
+    /// Dimmer tint for interrupted ("inactive") rows — a touch fainter than the
+    /// active rows so they recede further. Dynamic provider so it bakes per
+    /// appearance (and the cell still flips it to white on selection).
+    private static var interruptedTint: NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.4)
+        }
+    }
+
+    /// Inline `paperclip` SF Symbol — the conventional "has attachment" glyph.
+    /// Muted, sized just under the text, and optically centered on the text's
+    /// cap-height band (baseline-relative) so it sits level with the line
+    /// instead of riding the descender.
+    private static func attachmentGlyph(font: NSFont, color: NSColor) -> NSAttributedString {
+        // .medium weight so the thin paperclip strokes stay legible at list size.
+        let config = NSImage.SymbolConfiguration(pointSize: font.pointSize, weight: .medium)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
-        guard let image = NSImage(systemSymbolName: "photo", accessibilityDescription: "image")?
+        guard let image = NSImage(systemSymbolName: "paperclip", accessibilityDescription: "attachment")?
             .withSymbolConfiguration(config) else {
             // fallback — plain emoji
             return NSAttributedString(string: "🖼", attributes: [
@@ -2769,23 +2798,19 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
         }
         let attachment = NSTextAttachment()
         attachment.image = image
-        // Baseline tweak — the `photo` symbol's natural anchor is the
-        // top, so nudge it down slightly so it sits on the text baseline.
-        let baselineDescender = font.descender
+        // Center on the cap-height band rather than nudging off the descender,
+        // so the glyph reads as level with the surrounding text.
         attachment.bounds = CGRect(
             x: 0,
-            y: baselineDescender + 1,
+            y: (font.capHeight - image.size.height) / 2,
             width: image.size.width,
             height: image.size.height
         )
-        let str = NSMutableAttributedString(attachment: attachment)
-        // Trailing space so the symbol doesn't crowd the next glyph.
-        let leading = NSAttributedString(string: " ", attributes: [
+        let wrap = NSMutableAttributedString(attachment: attachment)
+        // Thin trailing space so the glyph doesn't crowd the next character.
+        wrap.append(NSAttributedString(string: " ", attributes: [
             .font: font, .foregroundColor: color
-        ])
-        let wrap = NSMutableAttributedString()
-        wrap.append(str)
-        wrap.append(leading)
+        ]))
         return wrap
     }
 
@@ -2874,7 +2899,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
                 cleaned,
                 font: promptFont,
                 color: .labelColor,
-                attachmentColor: .controlAccentColor
+                attachmentColor: Self.attachmentTint
             )
 
         case .reply:
@@ -3542,8 +3567,8 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
     /// Turn header cell — text only, left-aligned, 4pt leading. Text
     /// sits right next to the disclosure triangle to mimic the Mail /
     /// Xcode style.
-    private func makeOrReuseTurnHeaderCell(id: NSUserInterfaceItemIdentifier) -> NSTableCellView {
-        if let reused = outlineView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView {
+    private func makeOrReuseTurnHeaderCell(id: NSUserInterfaceItemIdentifier) -> RecoloringCellView {
+        if let reused = outlineView.makeView(withIdentifier: id, owner: nil) as? RecoloringCellView {
             reused.textField.map(TurnOutlineCellTextLayout.applySingleLineBehavior)
             return reused
         }
@@ -3559,7 +3584,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
         TurnOutlineCellTextLayout.applySingleLineBehavior(to: tf)
         tf.translatesAutoresizingMaskIntoConstraints = false
 
-        let cv = NSTableCellView()
+        let cv = RecoloringCellView()
         cv.identifier = id
         cv.textField = tf
         cv.addSubview(tf)
@@ -4246,6 +4271,67 @@ extension TurnOutlineViewController {
 /// ordinary hierarchy (skill/subagent grouping, not Turn boundary) so
 /// the cyan tint stays even after the Turn-descendant indent guide
 /// experiments were removed.
+/// Cell that recolors its rich text — and any inline image attachment — to the
+/// selection text color while the row is emphasized. NSTableCellView's automatic
+/// selection recoloring silently no-ops once the attributed string contains an
+/// image attachment (the run keeps its baked colors), so attachment rows would
+/// otherwise show dark text + a dark glyph on the blue selection. Storing the
+/// base string and re-tinting on `backgroundStyle` restores the standard look.
+private final class RecoloringCellView: NSTableCellView {
+    private var baseText: NSAttributedString?
+
+    /// Set the cell's text through here (not `textField.attributedStringValue`)
+    /// so the base is captured and re-applied on selection changes.
+    func setRichText(_ attr: NSAttributedString) {
+        baseText = attr
+        applyBackgroundStyle()
+    }
+
+    override var backgroundStyle: NSView.BackgroundStyle {
+        didSet { applyBackgroundStyle() }
+    }
+
+    private func applyBackgroundStyle() {
+        guard let textField, let baseText else { return }
+        textField.attributedStringValue = backgroundStyle == .emphasized
+            ? Self.recoloredForSelection(baseText)
+            : baseText
+    }
+
+    private static func recoloredForSelection(_ s: NSAttributedString) -> NSAttributedString {
+        let color = NSColor.alternateSelectedControlTextColor
+        let result = NSMutableAttributedString(attributedString: s)
+        let full = NSRange(location: 0, length: result.length)
+        result.enumerateAttribute(.foregroundColor, in: full, options: []) { value, range, _ in
+            if value != nil { result.addAttribute(.foregroundColor, value: color, range: range) }
+        }
+        var attachments: [(NSRange, NSTextAttachment)] = []
+        result.enumerateAttribute(.attachment, in: full, options: []) { value, range, _ in
+            if let att = value as? NSTextAttachment, att.image != nil { attachments.append((range, att)) }
+        }
+        for (range, att) in attachments.reversed() {
+            guard let image = att.image else { continue }
+            let newAtt = NSTextAttachment()
+            newAtt.image = tint(image, to: color)
+            newAtt.bounds = att.bounds
+            result.replaceCharacters(in: range, with: NSAttributedString(attachment: newAtt))
+        }
+        return result
+    }
+
+    /// Recolor an image's opaque pixels to `color` (alpha preserved) via
+    /// source-atop compositing.
+    private static func tint(_ image: NSImage, to color: NSColor) -> NSImage {
+        let copy = NSImage(size: image.size)
+        copy.lockFocus()
+        image.draw(in: NSRect(origin: .zero, size: image.size))
+        color.set()
+        NSRect(origin: .zero, size: image.size).fill(using: .sourceAtop)
+        copy.unlockFocus()
+        return copy
+    }
+}
+
 private final class SkillGroupRowView: NSTableRowView {
     override func drawBackground(in dirtyRect: NSRect) {
         super.drawBackground(in: dirtyRect)

--- a/Lupen/UI/Dashboard/TurnOutlineViewController.swift
+++ b/Lupen/UI/Dashboard/TurnOutlineViewController.swift
@@ -2229,9 +2229,11 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
             )
             let cell = makeOrReuseIconCell(id: cellId, iconLeading: isNested ? 20 : 4)
             let attr = attributedStepSummary(for: step)
-            cell.textField?.attributedStringValue = step.kind == .prompt
-                ? QueryHighlighter.applied(to: attr, query: highlightQuery)
-                : attr
+            if step.kind == .prompt {
+                cell.setRichText(QueryHighlighter.applied(to: attr, query: highlightQuery))
+            } else {
+                cell.textField?.attributedStringValue = attr
+            }
             cell.textField?.alignment = .left
             cell.textField?.lineBreakMode = .byTruncatingTail
 
@@ -2747,10 +2749,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
         let attachTint = attachmentColor ?? color
         // Collapse any number of image markers into a single leading glyph — the
         // list only needs to signal "has attachment", not how many.
-        let textOnly = preview
-            .replacingOccurrences(of: "🖼", with: " ")
-            .replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespaces)
+        let textOnly = TurnPreview.collapsedAttachmentText(preview)
         let result = NSMutableAttributedString()
         result.append(attachmentGlyph(font: font, color: attachTint))   // includes a trailing space
         if !textOnly.isEmpty {
@@ -2764,21 +2763,17 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
     /// `labelColor.withAlphaComponent(...)` loses its dynamic resolution when
     /// baked into the symbol image (renders the dark-mode value in light mode →
     /// invisible), so apply the alpha onto concrete white/black instead.
-    private static var attachmentTint: NSColor {
-        NSColor(name: nil) { appearance in
-            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.6)
-        }
+    private static let attachmentTint = NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.6)
     }
 
     /// Dimmer tint for interrupted ("inactive") rows — a touch fainter than the
     /// active rows so they recede further. Dynamic provider so it bakes per
     /// appearance (and the cell still flips it to white on selection).
-    private static var interruptedTint: NSColor {
-        NSColor(name: nil) { appearance in
-            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.4)
-        }
+    private static let interruptedTint = NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.4)
     }
 
     /// Inline `paperclip` SF Symbol — the conventional "has attachment" glyph.
@@ -3634,9 +3629,10 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
     private func makeOrReuseIconCell(
         id: NSUserInterfaceItemIdentifier,
         iconLeading: CGFloat = 4
-    ) -> NSTableCellView {
-        if let reused = outlineView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView {
+    ) -> RecoloringCellView {
+        if let reused = outlineView.makeView(withIdentifier: id, owner: nil) as? RecoloringCellView {
             reused.textField.map(TurnOutlineCellTextLayout.applySingleLineBehavior)
+            reused.clearRichText()
             return reused
         }
         let iv = NSImageView()
@@ -3651,7 +3647,7 @@ final class TurnOutlineViewController: NSViewController, NSOutlineViewDataSource
         TurnOutlineCellTextLayout.applySingleLineBehavior(to: tf)
         tf.translatesAutoresizingMaskIntoConstraints = false
 
-        let cv = NSTableCellView()
+        let cv = RecoloringCellView()
         cv.identifier = id
         cv.imageView = iv
         cv.textField = tf
@@ -4279,12 +4275,23 @@ extension TurnOutlineViewController {
 /// base string and re-tinting on `backgroundStyle` restores the standard look.
 private final class RecoloringCellView: NSTableCellView {
     private var baseText: NSAttributedString?
+    private var emphasizedText: NSAttributedString?
 
     /// Set the cell's text through here (not `textField.attributedStringValue`)
-    /// so the base is captured and re-applied on selection changes.
+    /// so the base + its selection variant are captured once and swapped on
+    /// selection changes (no per-selection recompute/offscreen redraw).
     func setRichText(_ attr: NSAttributedString) {
         baseText = attr
+        emphasizedText = Self.recoloredForSelection(attr)
         applyBackgroundStyle()
+    }
+
+    /// Clear captured text so a reused cell rebound via a plain
+    /// `attributedStringValue` (non-attachment rows) falls back to the default
+    /// selection recoloring instead of a stale base.
+    func clearRichText() {
+        baseText = nil
+        emphasizedText = nil
     }
 
     override var backgroundStyle: NSView.BackgroundStyle {
@@ -4293,9 +4300,8 @@ private final class RecoloringCellView: NSTableCellView {
 
     private func applyBackgroundStyle() {
         guard let textField, let baseText else { return }
-        textField.attributedStringValue = backgroundStyle == .emphasized
-            ? Self.recoloredForSelection(baseText)
-            : baseText
+        textField.attributedStringValue =
+            (backgroundStyle == .emphasized ? (emphasizedText ?? baseText) : baseText)
     }
 
     private static func recoloredForSelection(_ s: NSAttributedString) -> NSAttributedString {
@@ -4305,6 +4311,8 @@ private final class RecoloringCellView: NSTableCellView {
         result.enumerateAttribute(.foregroundColor, in: full, options: []) { value, range, _ in
             if value != nil { result.addAttribute(.foregroundColor, value: color, range: range) }
         }
+        // Drop any search-highlight background so the selected row isn't white-on-yellow.
+        result.removeAttribute(.backgroundColor, range: full)
         var attachments: [(NSRange, NSTextAttachment)] = []
         result.enumerateAttribute(.attachment, in: full, options: []) { value, range, _ in
             if let att = value as? NSTextAttachment, att.image != nil { attachments.append((range, att)) }

--- a/Lupen/UI/StatusBar/StatusBarAttributedTitle.swift
+++ b/Lupen/UI/StatusBar/StatusBarAttributedTitle.swift
@@ -50,16 +50,12 @@ enum StatusBarAttributedTitle {
     ///     off, or a fresh install with nothing indexed yet).
     ///   - placeholder: True during true cold start (no cache, no
     ///     parse yet). Replaces cost with `"..."`.
-    ///   - dimmed: Render the cost run in the secondary label color —
-    ///     the `$0.00` idle state (6.13) keeps a lower visual weight
-    ///     than a real spend total.
     ///   - badge: Parse-diagnostics severity — overlays a small
     ///     coloured dot on the icon's top-right.
     ///   - limit: 5-hour-limit consumption tier — tints the icon's
     ///     ring stroke.
     static func compose(costText: String?,
                         placeholder: Bool,
-                        dimmed: Bool = false,
                         badge: StatusBarIconComposer.BadgeSeverity,
                         limit: StatusBarIconComposer.LimitSeverity) -> Composed {
         // 1. Icon as inline attachment. The image is the *only* visual
@@ -112,9 +108,10 @@ enum StatusBarAttributedTitle {
                 string: t,
                 attributes: [
                     .font: monoFont,
-                    .foregroundColor: dimmed
-                        ? NSColor.secondaryLabelColor
-                        : NSColor.labelColor,
+                    // Always the primary label color so the idle "$0" stays
+                    // legible on the menu bar — secondaryLabel was near-invisible
+                    // over a busy/light wallpaper. Matches the icon's tint.
+                    .foregroundColor: NSColor.labelColor,
                 ]
             )
             result.append(digits)

--- a/Lupen/UI/StatusBar/StatusBarController.swift
+++ b/Lupen/UI/StatusBar/StatusBarController.swift
@@ -13,11 +13,6 @@ final class StatusBarController {
     struct CostDisplayState: Equatable {
         let costText: String?
         let showsPlaceholder: Bool
-        /// Render the cost run in the secondary label color. Used for
-        /// the `$0.00` idle state (6.13): the number's job is "alive
-        /// and tracking, nothing spent", so it shouldn't carry the
-        /// same visual weight as a real total.
-        var isDimmed: Bool = false
     }
 
     private let statusItem: NSStatusItem
@@ -88,7 +83,7 @@ final class StatusBarController {
             _ = store.launchProgress.phase
             _ = store.activeProvider
             _ = store.isRenderingActiveProviderSessions
-            // 6.13 `$0.00` idle state gates on "any indexed sessions" —
+            // 6.13 `$0` idle state gates on "any indexed sessions" —
             // re-render when the first shell projection lands so a fresh
             // install flips from icon-only to the dimmed zero.
             _ = store.sessions.isEmpty
@@ -196,7 +191,6 @@ final class StatusBarController {
         let composed = StatusBarAttributedTitle.compose(
             costText: costDisplay.costText,
             placeholder: costDisplay.showsPlaceholder,
-            dimmed: costDisplay.isDimmed,
             badge: badge,
             limit: limit
         )
@@ -238,7 +232,7 @@ final class StatusBarController {
             return CostDisplayState(costText: nil, showsPlaceholder: false)
         }
         guard cost > 0 else {
-            // Idle day (6.13): a dimmed "$0.00" confirms the app is
+            // Idle day (6.13): a visible "$0" confirms the app is
             // alive and tracking — a bare icon is ambiguous between
             // "nothing spent" and "not working". Gated on the provider
             // having ANY indexed sessions so a fresh install stays
@@ -250,9 +244,8 @@ final class StatusBarController {
                 return CostDisplayState(costText: nil, showsPlaceholder: false)
             }
             return CostDisplayState(
-                costText: compactCurrency ? "$0" : "$0.00",
-                showsPlaceholder: false,
-                isDimmed: true
+                costText: "$0",
+                showsPlaceholder: false
             )
         }
         let costText = compactCurrency

--- a/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
+++ b/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
@@ -267,6 +267,30 @@ struct ConversationStoryBuilderTests {
         #expect(group?.isHighlighted == true)
     }
 
+    @Test("매칭 없는 Step을 선택하면 가장 가까운 위쪽 블록으로 highlight 재타깃")
+    func highlightRetargetsToNearestPreceding() {
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.reply, uuid: "a1", text: "answer"),
+            step(.reply, uuid: "a2"),   // usage-only reply → no block
+        ]), highlight: "a2")
+        // a2 maps to no block → retarget to the nearest preceding block (a1).
+        #expect(blocks.compactMap { $0 as? AssistantTextBlock }.first?.isHighlighted == true)
+        #expect((blocks.first as? UserPromptBlock)?.isHighlighted == false)
+    }
+
+    @Test("재타깃은 인접 StatusBlock도 대상으로 삼는다")
+    func highlightRetargetsToStatusBanner() {
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.interruption, uuid: "i1"),
+            step(.reply, uuid: "a2"),   // usage-only reply → no block
+        ]), highlight: "a2")
+        // Nearest preceding covered Step is the interruption banner, not the prompt.
+        #expect(blocks.compactMap { $0 as? StatusBlock }.first?.isHighlighted == true)
+        #expect((blocks.first as? UserPromptBlock)?.isHighlighted == false)
+    }
+
     @Test("large turn: long secondary runs fold into one ActivityGroupBlock")
     func curationCapFoldsLargeRuns() {
         var steps = [step(.prompt, uuid: "p1", text: "q")]

--- a/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
+++ b/LupenTests/Domain/Conversation/Story/ConversationStoryBuilderTests.swift
@@ -291,6 +291,51 @@ struct ConversationStoryBuilderTests {
         #expect((blocks.first as? UserPromptBlock)?.isHighlighted == false)
     }
 
+    @Test("위쪽에 매칭이 없으면 가장 가까운 아래쪽 블록으로 재타깃")
+    func highlightRetargetsToNearestFollowing() {
+        // Orphan turn (no prompt): the first step is a usage-only reply (no
+        // block), followed by a reply that does produce a block.
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.reply, uuid: "a1"),                  // usage-only → no block
+            step(.reply, uuid: "a2", text: "answer"),  // AssistantTextBlock
+        ], id: "a1"), highlight: "a1")
+        // No covered step precedes a1 → retarget to the nearest following block.
+        #expect(blocks.compactMap { $0 as? AssistantTextBlock }.first?.isHighlighted == true)
+    }
+
+    @Test("매칭 없는 Step은 위쪽 ToolGroup으로도 재타깃")
+    func highlightRetargetsToToolGroup() {
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.toolCall, uuid: "t1", toolCalls: [toolUse("u1", "Read", path: "/a.swift")]),
+            step(.reply, uuid: "r1"),   // usage-only → no block
+        ]), highlight: "r1")
+        #expect(blocks.compactMap { $0 as? ToolGroupBlock }.first?.isHighlighted == true)
+    }
+
+    @Test("존재하지 않는 highlight uuid는 아무것도 highlight하지 않음 (크래시 없음)")
+    func highlightAbsentUuid() {
+        let blocks = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.reply, uuid: "a1", text: "answer"),
+        ]), highlight: "does-not-exist")
+        #expect(blocks.allSatisfy { !$0.isHighlighted })
+    }
+
+    @Test("StatusBlock은 step-level이면 stepUuid를 갖고 turn-level이면 nil")
+    func statusBlockStepUuid() {
+        let stepLevel = ConversationStoryBuilder.build(turn: turn([
+            step(.prompt, uuid: "p1", text: "q"),
+            step(.interruption, uuid: "i1"),
+        ]))
+        #expect((stepLevel.last as? StatusBlock)?.stepUuid == "i1")
+
+        let orphan = ConversationStoryBuilder.build(turn: turn([
+            step(.reply, uuid: "a1", text: "x"),
+        ], id: "a1"))
+        #expect((orphan.first as? StatusBlock)?.stepUuid == nil)
+    }
+
     @Test("large turn: long secondary runs fold into one ActivityGroupBlock")
     func curationCapFoldsLargeRuns() {
         var steps = [step(.prompt, uuid: "p1", text: "q")]

--- a/LupenTests/Domain/Conversation/TurnPreviewTests.swift
+++ b/LupenTests/Domain/Conversation/TurnPreviewTests.swift
@@ -6,6 +6,32 @@ import Foundation
 struct TurnPreviewTests {
     typealias F = ConversationTestFactory
 
+    // MARK: - collapsedAttachmentText (single-glyph collapse)
+
+    @Test("여러 이미지 마커는 정리된 텍스트로 합쳐짐 (글리프는 뷰가 1개만 렌더)")
+    func collapseMultipleMarkers() {
+        #expect(TurnPreview.collapsedAttachmentText("🖼 🖼 hello") == "hello")
+        #expect(TurnPreview.collapsedAttachmentText("🖼🖼🖼 hello world") == "hello world")
+    }
+
+    @Test("텍스트 사이의 마커는 제거되고 단일 공백으로 정리")
+    func collapseInterspersed() {
+        #expect(TurnPreview.collapsedAttachmentText("🖼 a 🖼 b") == "a b")
+        #expect(TurnPreview.collapsedAttachmentText("a  🖼  b") == "a b")
+    }
+
+    @Test("이미지 전용 프리뷰는 빈 텍스트로 합쳐짐")
+    func collapseImageOnly() {
+        #expect(TurnPreview.collapsedAttachmentText("🖼") == "")
+        #expect(TurnPreview.collapsedAttachmentText("🖼 🖼") == "")
+    }
+
+    @Test("마커 없는 입력은 공백 정규화 후 통과")
+    func collapseNoMarkers() {
+        #expect(TurnPreview.collapsedAttachmentText("hello world") == "hello world")
+        #expect(TurnPreview.collapsedAttachmentText("  hello   world  ") == "hello world")
+    }
+
     // MARK: - Basic
 
     @Test("short prompt returned as-is")

--- a/LupenTests/UI/StatusBar/StatusBarIconComposerTests.swift
+++ b/LupenTests/UI/StatusBar/StatusBarIconComposerTests.swift
@@ -255,10 +255,10 @@ struct StatusBarIconComposerTests {
         #expect(settled.showsPlaceholder == false)
     }
 
-    @Test("zero cost shows a dimmed $0.00 once the provider has indexed sessions")
+    @Test("zero cost shows a visible $0 once the provider has indexed sessions")
     @MainActor
     func zeroCostShowsDimmedZero() {
-        // 6.13: a visible "$0.00" confirms alive-and-tracking; a bare
+        // 6.13: a visible "$0" confirms alive-and-tracking; a bare
         // icon is ambiguous between "idle" and "broken".
         let state = StatusBarController.costDisplayState(
             showTodayCostInMenuBar: true,
@@ -268,8 +268,7 @@ struct StatusBarIconComposerTests {
             compactCurrency: false,
             hasIndexedSessions: true
         )
-        #expect(state.costText == "$0.00")
-        #expect(state.isDimmed == true)
+        #expect(state.costText == "$0")
         #expect(state.showsPlaceholder == false)
 
         // Compact mode renders whole-dollar zero. Deliberately NOT the
@@ -284,7 +283,6 @@ struct StatusBarIconComposerTests {
             hasIndexedSessions: true
         )
         #expect(compact.costText == "$0")
-        #expect(compact.isDimmed == true)
     }
 
     @Test("zero cost stays icon-only on a fresh install (no indexed sessions)")
@@ -302,7 +300,7 @@ struct StatusBarIconComposerTests {
         #expect(state.showsPlaceholder == false)
     }
 
-    @Test("positive cost never dims, regardless of session presence")
+    @Test("positive cost shows the amount, regardless of session presence")
     @MainActor
     func positiveCostNeverDims() {
         let state = StatusBarController.costDisplayState(
@@ -314,7 +312,6 @@ struct StatusBarIconComposerTests {
             hasIndexedSessions: true
         )
         #expect(state.costText == "$12.34")
-        #expect(state.isDimmed == false)
     }
 
     @Test("diagnostic badge respects severity and preferences")


### PR DESCRIPTION
## What this changes

Reworks the Conversation tab and turn list so the **dialogue leads and the chrome recedes**, plus a couple of adjacent legibility fixes. Previously every block sat in an equally-weighted bordered card and the role headers were as loud as the body, so the actual prompt/reply didn't stand out.

- **Quiet cards** — the card frame is kept (containment + a single left baseline are worth more than a frame-less reply, which read as crude in testing), but its weight is turned down: a 1-device-pixel neutral hairline border, a faint neutral fill (reply lightest, prompt a touch more), role color only on the header icon, no color gutter. Selection = accent border (2px) + faint accent fill.
- **Body readability** — body line-height 1.5, heading hierarchy (size + space-above), reading-width cap, table/inline-code legibility.
- **Selection behavior** — selecting a Step no longer always jumps to the top: a fully-visible target is left alone, otherwise it scrolls the minimum to reveal it. When the selected Step maps to no block (e.g. a tool result), the highlight retargets to the nearest preceding block instead of highlighting nothing.
- **Turn-list attachment indicator** — the busy inline `photo` glyph → a quiet `paperclip`; any number of attachments collapses to a single indicator; attachment rows now recolor correctly on selection.
- **Menu-bar idle cost** — the idle `$0` was rendered in `secondaryLabelColor` (near-invisible over a light/busy wallpaper); now primary label color, shown as `$0` rather than `$0.00`.

Non-obvious decisions a reviewer should know:
- **Reading-width is enforced inside the NSTextView text container, NOT via an Auto Layout width constraint.** A `<=` width constraint on a child propagates up the equality chain and locks the whole pane's max width — the container must never be width-constrained by its children.
- **Borders use a device-pixel hairline** (`1 / backingScaleFactor`, reapplied on `viewDidChangeBackingProperties`) so they stay crisp on non-Retina displays (0.5pt is a half-pixel there).
- **`RecoloringCellView`** exists because an inline image attachment disables NSTableCellView's automatic selection recoloring for the whole row; the cell recolors text + glyph to the selection color itself.

## How it was verified

- `xcodebuild test` — 189 tests pass locally (ConversationStoryBuilder, TurnPreview, ConversationRendererSmoke, ConversationBlockFallback, StatusBarIconComposer, I18nGuard).
- Added domain tests: highlight-retarget fallbacks (nearest-preceding / following / StatusBlock target / absent-uuid), `StatusBlock.stepUuid` population, `TurnPreview.collapsedAttachmentText`.
- Manually verified across **dark + light** during iteration: quiet cards, selection highlight (clip & non-clip rows), code/table blocks, reading-width on wide windows, pane resize (no width lock), single attachment indicator, menu-bar `$0`.
- Independent code review pass (correctness/regression/perf/tests) on the full branch diff — no blocker/high findings.

> Note: this is UI-heavy; screenshots were shared live during iteration. Please attach the before/after captures from that thread to satisfy the screenshot rule.

## Checklist

- [x] `xcodebuild test` passes locally (189 tests)
- [ ] UI changes include a screenshot or screen recording — *to be attached from the iteration thread*
- [x] New features add tests (domain) or list a manual-verification procedure (UI) — domain tests added; UI verified manually (above)
- [ ] Vocabulary matches [`docs/CONVERSATION-MODEL.md`](../docs/CONVERSATION-MODEL.md) — *author to confirm; uses existing turn/step/block terms*
- [x] No hard-coded `/Users/<name>/…` paths or other personal data (I18nGuard `noPersonalHomePathsInTestSources` passes)
- Cost-affecting: N/A — the menu-bar change is display-only (no cost calculation touched).

## Related issues

No tracked issue — UI polish of the Conversation tab driven by hands-on design review (quiet cards → refined attachment indicator → selection correctness → menu-bar idle cost).
