### PR TITLE
feat: add System/Light/Dark appearance setting

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -300,6 +300,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         startObservingProviderMode()
 
+        // Apply the persisted appearance override before any window or the
+        // status item is built, then keep NSApp.appearance in sync as the
+        // Preferences picker changes it.
+        applyAppearance()
+        startObservingAppearance()
+
         statusBarController = StatusBarController(
             store: store,
             settings: settings,
@@ -560,6 +566,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.updateProviderSpecificMenuTitles()
                 self?.syncStoreToActiveProvider()
                 self?.startObservingProviderMode()
+            }
+        }
+    }
+
+    /// Mirror the user's appearance override onto `NSApp.appearance`. `nil`
+    /// (the `.system` case) hands appearance back to macOS; `.light`/`.dark`
+    /// pin every window to that appearance. Windows redraw themselves on the
+    /// change; the menu-bar item's baked, non-template icon does not, so we
+    /// recompose it explicitly afterwards (no-op until the controller exists).
+    private func applyAppearance() {
+        let appearance: NSAppearance?
+        switch settings.appearanceMode {
+        case .system: appearance = nil
+        case .light:  appearance = NSAppearance(named: .aqua)
+        case .dark:   appearance = NSAppearance(named: .darkAqua)
+        }
+        NSApp.appearance = appearance
+        statusBarController?.refreshForAppearanceChange()
+    }
+
+    /// Re-apply on every change to `settings.appearanceMode` and re-arm the
+    /// one-shot observation (same pattern as `startObservingProviderMode`).
+    private func startObservingAppearance() {
+        withObservationTracking {
+            _ = settings.appearanceMode
+        } onChange: { [weak self] in
+            DispatchQueue.main.async {
+                self?.applyAppearance()
+                self?.startObservingAppearance()
             }
         }
     }

--- a/Lupen/Cache/AppSettingsStorage.swift
+++ b/Lupen/Cache/AppSettingsStorage.swift
@@ -8,6 +8,8 @@ import Foundation
 /// older builds — missing keys fall back to `.default`.
 struct AppSettingsData: Codable, Equatable, Sendable {
     var sessionListLayout: SessionListLayoutMode
+    /// App-wide appearance override. `.system` follows macOS (default).
+    var appearanceMode: AppearanceMode
     var activeProvider: ProviderKind
     var pinnedSessionIds: [String]
     var claudeCodeRootPath: String?
@@ -72,6 +74,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         #endif
         return AppSettingsData(
             sessionListLayout: .flat,
+            appearanceMode: .system,
             activeProvider: .claudeCode,
             pinnedSessionIds: [],
             claudeCodeRootPath: nil,
@@ -89,6 +92,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
 
     init(
         sessionListLayout: SessionListLayoutMode,
+        appearanceMode: AppearanceMode = .system,
         activeProvider: ProviderKind = .claudeCode,
         pinnedSessionIds: [String],
         claudeCodeRootPath: String? = nil,
@@ -103,6 +107,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         statuslinePrefs: StatuslinePrefsData = .default
     ) {
         self.sessionListLayout = sessionListLayout
+        self.appearanceMode = appearanceMode
         self.activeProvider = activeProvider
         self.pinnedSessionIds = Self.normalizePinnedSessionIds(
             pinnedSessionIds,
@@ -128,6 +133,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case sessionListLayout
+        case appearanceMode
         case activeProvider
         case pinnedSessionIds
         case claudeCodeRootPath
@@ -148,6 +154,10 @@ struct AppSettingsData: Codable, Equatable, Sendable {
             SessionListLayoutMode.self,
             forKey: .sessionListLayout
         ) ?? AppSettingsData.default.sessionListLayout
+        self.appearanceMode = try c.decodeIfPresent(
+            AppearanceMode.self,
+            forKey: .appearanceMode
+        ) ?? AppSettingsData.default.appearanceMode
         let activeProviderRaw = try c.decodeIfPresent(String.self, forKey: .activeProvider)
         self.activeProvider = activeProviderRaw.flatMap(ProviderKind.init(rawValue:))
             ?? AppSettingsData.default.activeProvider
@@ -349,6 +359,7 @@ struct AppSettingsStorage: Sendable {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             let normalized = AppSettingsData(
                 sessionListLayout: data.sessionListLayout,
+                appearanceMode: data.appearanceMode,
                 activeProvider: data.activeProvider,
                 pinnedSessionIds: data.pinnedSessionIds.sorted(),
                 claudeCodeRootPath: data.claudeCodeRootPath,

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -26,6 +26,30 @@ enum SessionListLayoutMode: String, Codable, CaseIterable, Sendable {
     }
 }
 
+/// User-chosen app appearance override.
+///
+/// `system` follows the macOS Appearance setting (the default and prior
+/// behaviour); `light`/`dark` pin Lupen to that appearance regardless of the
+/// system. Applied app-wide via `NSApp.appearance` (see AppDelegate), so every
+/// window and the menu-bar item track it. The raw string is the persistence
+/// key in `app_settings.json` — renaming a case is a file-format break.
+///
+/// The `NSAppearance` mapping lives in the App layer (AppKit), not here, to
+/// keep this Domain type free of UI-framework dependencies.
+enum AppearanceMode: String, Codable, CaseIterable, Sendable {
+    case system
+    case light
+    case dark
+
+    var localizedTitle: String {
+        switch self {
+        case .system: return "System"
+        case .light:  return "Light"
+        case .dark:   return "Dark"
+        }
+    }
+}
+
 /// App-wide user preferences that outlive a single window lifetime.
 ///
 /// `@Observable` so SwiftUI forms, AppKit menus, and the sidebar can share a
@@ -45,6 +69,16 @@ final class AppSettings {
     var sessionListLayout: SessionListLayoutMode {
         didSet {
             guard oldValue != sessionListLayout else { return }
+            schedulePersist()
+        }
+    }
+
+    /// App-wide appearance override. Observed by `AppDelegate`, which mirrors
+    /// it onto `NSApp.appearance` and recomposes the menu-bar item, so picking
+    /// Light/Dark applies to every window and the status item promptly.
+    var appearanceMode: AppearanceMode {
+        didSet {
+            guard oldValue != appearanceMode else { return }
             schedulePersist()
         }
     }
@@ -187,6 +221,7 @@ final class AppSettings {
         self.storage = storage
         let loaded = storage.load()
         self.sessionListLayout = loaded.sessionListLayout
+        self.appearanceMode = loaded.appearanceMode
         self.activeProvider = loaded.activeProvider
         self.pinnedSessionIds = Set(loaded.pinnedSessionIds)
         self.claudeCodeRootPath = loaded.claudeCodeRootPath
@@ -314,6 +349,7 @@ final class AppSettings {
     private func currentSnapshot() -> AppSettingsData {
         AppSettingsData(
             sessionListLayout: sessionListLayout,
+            appearanceMode: appearanceMode,
             activeProvider: activeProvider,
             pinnedSessionIds: Array(pinnedSessionIds).sorted(),
             claudeCodeRootPath: claudeCodeRootPath,

--- a/Lupen/UI/Preferences/PreferencesForm.swift
+++ b/Lupen/UI/Preferences/PreferencesForm.swift
@@ -56,6 +56,23 @@ struct PreferencesForm: View {
             }
 
             Section {
+                Picker("Appearance", selection: $settings.appearanceMode) {
+                    ForEach(AppearanceMode.allCases, id: \.self) { mode in
+                        Text(mode.localizedTitle).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            } header: {
+                Text("Appearance")
+            } footer: {
+                Text("System follows your macOS appearance. Light or Dark pins Lupen to that appearance regardless of the system setting.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section {
                 Picker("Mode", selection: $settings.activeProvider) {
                     ForEach(ProviderRegistry.all) { provider in
                         Text(provider.displayName).tag(provider.kind)

--- a/Lupen/UI/StatusBar/StatusBarController.swift
+++ b/Lupen/UI/StatusBar/StatusBarController.swift
@@ -44,6 +44,16 @@ final class StatusBarController {
         self.onButtonClick = handler
     }
 
+    /// Recompose the status item after an app-appearance override flip
+    /// (`NSApp.appearance`). Windows redraw themselves on an appearance
+    /// change, but the menu-bar icon is a non-template image whose palette is
+    /// baked into a static `NSTextAttachment` at compose time, so it needs an
+    /// explicit recompose. Called by `AppDelegate` right after it sets
+    /// `NSApp.appearance`, so the new appearance is already in effect here.
+    func refreshForAppearanceChange() {
+        applyAttributedTitle()
+    }
+
     // MARK: - Button Setup
 
     private func configureButton() {

--- a/LupenTests/Cache/AppSettingsStorageTests.swift
+++ b/LupenTests/Cache/AppSettingsStorageTests.swift
@@ -29,6 +29,7 @@ struct AppSettingsStorageTests {
         // Users who prefer groups can switch via ⌘1 or Settings…
         #expect(loaded.sessionListLayout == .flat)
         #expect(loaded.activeProvider == .claudeCode)
+        #expect(loaded.appearanceMode == .system)
         #expect(loaded.pinnedSessionIds.isEmpty)
     }
 
@@ -37,6 +38,7 @@ struct AppSettingsStorageTests {
         let (storage, _) = makeStorage()
         let data = AppSettingsData(
             sessionListLayout: .flat,
+            appearanceMode: .dark,
             activeProvider: .codex,
             pinnedSessionIds: ["sid-1", "sid-2", "sid-3"],
             claudeCodeRootPath: "/tmp/claude",
@@ -51,6 +53,7 @@ struct AppSettingsStorageTests {
         storage.save(data)
         let loaded = storage.load()
         #expect(loaded.sessionListLayout == .flat)
+        #expect(loaded.appearanceMode == .dark)
         #expect(loaded.activeProvider == .codex)
         #expect(loaded.pinnedSessionIds == [
             scoped("sid-1", provider: .codex),
@@ -260,5 +263,41 @@ struct AppSettingsStorageTests {
         let loaded = storage.load()
         #expect(loaded.pinnedSessionIds.count == 1000)
         #expect(loaded.pinnedSessionIds == ids.map { scoped($0) })
+    }
+
+    @Test("legacy file without an appearanceMode key migrates to .system")
+    func legacyFileWithoutAppearanceMigratesToSystem() throws {
+        let (storage, url) = makeStorage()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // Pre-appearance file: no `appearanceMode` key at all.
+        let json = """
+        {
+          "sessionListLayout": "flat",
+          "pinnedSessionIds": []
+        }
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        #expect(storage.load().appearanceMode == .system)
+    }
+
+    @Test("every appearanceMode round-trips through JSON")
+    func appearanceModeRoundTrip() {
+        for mode in AppearanceMode.allCases {
+            let (storage, _) = makeStorage()
+            storage.save(AppSettingsData(
+                sessionListLayout: .flat,
+                appearanceMode: mode,
+                pinnedSessionIds: [],
+                showTodayCostInMenuBar: true,
+                openDashboardOnLaunch: false,
+                startAtLogin: false,
+                showParseWarningBadge: false,
+                showParseErrorBadge: false
+            ))
+            #expect(storage.load().appearanceMode == mode)
+        }
     }
 }

--- a/LupenTests/Store/CodexOversizedPieceMemoryTests.swift
+++ b/LupenTests/Store/CodexOversizedPieceMemoryTests.swift
@@ -154,8 +154,8 @@ struct CodexOversizedPieceMemoryTests {
     }
 
     @Test("lightweight projection bounds a lone large rollout's peak far below its size, numbers exact")
-    func loneLargePieceBounded() throws {
-        try CorpusHeavyTestGate.withExclusiveAccess {
+    func loneLargePieceBounded() async throws {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
             let fixture = try makeBigStandalone()
             defer { fixture.cleanup() }
             let fileMB = Double(fixture.fileBytes) / 1_048_576.0
@@ -175,7 +175,7 @@ struct CodexOversizedPieceMemoryTests {
             var lightBest = Double.greatestFiniteMagnitude
             var lightInput = 0, lightOutput = 0
             for attempt in 0..<3 {
-                if attempt > 0 { Thread.sleep(forTimeInterval: 1.0) }
+                if attempt > 0 { try await Task.sleep(for: .seconds(1)) }
                 let light = try importPeakDelta(home: fixture.home, threshold: 1 << 20)
                 lightBest = min(lightBest, light.peakMB)
                 lightInput = light.inputTokens
@@ -206,8 +206,8 @@ struct CodexOversizedPieceMemoryTests {
     }
 
     @Test("lightweight projection bounds a large SUBAGENT child's peak too, numbers exact")
-    func loneLargeSubagentBounded() throws {
-        try CorpusHeavyTestGate.withExclusiveAccess {
+    func loneLargeSubagentBounded() async throws {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
             let fixture = try makeBigSubagentGroup()
             defer { fixture.cleanup() }
             let childMB = Double(fixture.childBytes) / 1_048_576.0
@@ -230,7 +230,7 @@ struct CodexOversizedPieceMemoryTests {
             var lightBest = Double.greatestFiniteMagnitude
             var lightInput = 0, lightOutput = 0
             for attempt in 0..<3 {
-                if attempt > 0 { Thread.sleep(forTimeInterval: 1.0) }
+                if attempt > 0 { try await Task.sleep(for: .seconds(1)) }
                 let light = try importPeakDelta(home: fixture.home, threshold: 1 << 20, rawId: "p-root")
                 lightBest = min(lightBest, light.peakMB)
                 lightInput = light.inputTokens

--- a/LupenTests/Store/CodexStreamingImportTests.swift
+++ b/LupenTests/Store/CodexStreamingImportTests.swift
@@ -201,7 +201,7 @@ struct CodexStreamingImportTests {
     // MARK: - The gate test
 
     @Test("jumbo group imports with footprint bounded below the group total, numbers exact")
-    func jumboGroupBoundedAndExact() throws {
+    func jumboGroupBoundedAndExact() async throws {
         let fixture = try Self.makeJumboCorpus()
         defer { fixture.cleanup() }
         let totalMB = Double(fixture.totalBytes) / 1_048_576.0
@@ -225,11 +225,11 @@ struct CodexStreamingImportTests {
             }
         }
 
-        try CorpusHeavyTestGate.withExclusiveAccess {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
         for attempt in 0..<3 {
             if attempt > 0 {
                 try? database?.close()
-                Thread.sleep(forTimeInterval: 1.0)
+                try await Task.sleep(for: .seconds(1))
             }
             let scratch = FileManager.default.temporaryDirectory
                 .appendingPathComponent("lupen-jumbo-db-\(UUID().uuidString)")
@@ -316,8 +316,8 @@ struct CodexStreamingImportTests {
     }
 
     @Test("interrupted jumbo import restarts to identical aggregates")
-    func jumboCancellationRestart() throws {
-        try CorpusHeavyTestGate.withExclusiveAccess {
+    func jumboCancellationRestart() async throws {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
         let fixture = try Self.makeJumboCorpus()
         defer { fixture.cleanup() }
         let scratch = FileManager.default.temporaryDirectory

--- a/LupenTests/Store/ImporterMemoryBoundTests.swift
+++ b/LupenTests/Store/ImporterMemoryBoundTests.swift
@@ -62,9 +62,9 @@ struct ImporterMemoryBoundTests {
         // regression repeats on every attempt; ambient noise doesn't:
         // assert on the cleanest of three measured sweeps.
         var bestDelta = Double.greatestFiniteMagnitude
-        try CorpusHeavyTestGate.withExclusiveAccess {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
             for attempt in 0..<3 {
-                if attempt > 0 { Thread.sleep(forTimeInterval: 1.0) }
+                if attempt > 0 { try await Task.sleep(for: .seconds(1)) }
                 let delta = try measuredSweep(outputDir: outputDir, attempt: attempt)
                 bestDelta = min(bestDelta, delta)
                 if bestDelta < Double(RefactorBudgets.importerPeakRSSMB) { break }

--- a/LupenTests/Store/SQLiteEquivalenceTests.swift
+++ b/LupenTests/Store/SQLiteEquivalenceTests.swift
@@ -103,11 +103,11 @@ struct SQLiteEquivalenceTests {
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("lupen-sqlite-equiv-gen-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: outputDir) }
-        // Generate outside the heavy-test gate: the gate is synchronous, and
-        // the spawn must use the cooperative-safe helper (never the blocking
-        // `waitUntilExit()`). See `TestProcess`.
+        // Generate outside the heavy-test gate so the gate only wraps the
+        // comparison work, and because the spawn must use the cooperative-safe
+        // helper (never the blocking `waitUntilExit()`). See `TestProcess`.
         try await generateCorpus(into: outputDir)
-        try CorpusHeavyTestGate.withExclusiveAccess {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
             try generatedCorpusThreeWayAgreementBody(outputDir: outputDir)
         }
     }

--- a/LupenTests/Store/SQLiteSelectionLatencyTests.swift
+++ b/LupenTests/Store/SQLiteSelectionLatencyTests.swift
@@ -56,7 +56,7 @@ struct SQLiteSelectionLatencyTests {
         // import to seconds.
         try await generateCorpus(into: root.appendingPathComponent("corpus"), claudeMB: 48, codexMB: 48)
 
-        try CorpusHeavyTestGate.withExclusiveAccess {
+        try await CorpusHeavyTestGate.withExclusiveAccess {
         for provider in [ProviderKind.claudeCode, .codex] {
             let databaseURL = root.appendingPathComponent("\(provider.rawValue).sqlite3")
             let store: ProviderStore

--- a/LupenTests/Support/CorpusHeavyTestGate.swift
+++ b/LupenTests/Support/CorpusHeavyTestGate.swift
@@ -9,21 +9,63 @@ import Foundation
 
 /// Cross-suite serialization for corpus-scale test sections.
 ///
-/// Several suites import multi-hundred-MB generated corpora, and a few
-/// of them ASSERT on process-wide samples (phys footprint, RSS deltas,
-/// wall-clock latency). `.serialized` only orders tests within one
-/// suite — under whole-suite parallelism the allocators and the
-/// measurers still overlap in the same process and the measurements
-/// read each other's transients (the 3.8a jumbo lesson, again at
-/// full-suite scale). Wrapping the heavy sections in this gate keeps
-/// them mutually exclusive without slowing the thousands of KB-scale
-/// unit tests around them.
+/// Several suites import multi-hundred-MB generated corpora, and a few of them
+/// ASSERT on process-wide samples (phys footprint, RSS deltas, wall-clock
+/// latency). `.serialized` only orders tests within one suite — under
+/// whole-suite parallelism the allocators and the measurers still overlap in
+/// the same process and the measurements read each other's transients (the
+/// 3.8a jumbo lesson, again at full-suite scale). Wrapping the heavy sections
+/// in this gate keeps them mutually exclusive without slowing the thousands of
+/// KB-scale unit tests around them.
+///
+/// **Async, not a blocking `NSLock`.** A test waiting for the gate *suspends*
+/// and yields its cooperative-pool thread instead of pinning it. That is
+/// load-bearing under Swift Testing's parallel execution: a blocking
+/// `NSLock.lock()` keeps the waiter's pool thread occupied for the entire
+/// ~130 s a heavy section holds the gate, so several heavy suites queued on the
+/// gate pin several pool threads at once and starve the pool that *async* tests
+/// (subprocess waits in `TestProcess`, `Task.sleep`) need to resume — those
+/// then time out at their `.timeLimit`. With the async gate, only the one
+/// *running* section holds a pool thread (its synchronous sweep); every waiter
+/// is suspended, leaving the pool free. `body` runs in the caller's context,
+/// not on the gate's actor.
 enum CorpusHeavyTestGate {
-    private static let lock = NSLock()
+    private static let state = GateState()
 
-    static func withExclusiveAccess<T>(_ body: () throws -> T) rethrows -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return try body()
+    static func withExclusiveAccess<T>(_ body: () async throws -> T) async throws -> T {
+        await state.acquire()
+        do {
+            let result = try await body()
+            await state.release()
+            return result
+        } catch {
+            await state.release()
+            throw error
+        }
+    }
+
+    /// Binary semaphore implemented as an actor: `acquire` suspends (yielding
+    /// the pool thread) while the gate is held; `release` hands it to the next
+    /// waiter FIFO, or frees it.
+    private actor GateState {
+        private var busy = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func acquire() async {
+            if !busy {
+                busy = true
+                return
+            }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        func release() {
+            if waiters.isEmpty {
+                busy = false
+            } else {
+                // Keep `busy == true`: ownership passes straight to the waiter.
+                waiters.removeFirst().resume()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an app-wide appearance override so users can pin Lupen to **Light** or **Dark** regardless of the macOS system setting. `System` (the default) keeps the existing behaviour of following macOS.

Preferences gains an **Appearance** section with a segmented picker (System / Light / Dark).

## How it works

- `AppearanceMode` enum (Domain layer, no AppKit dependency) — `system` / `light` / `dark`, persisted verbatim in `app_settings.json`.
- `AppSettings.appearanceMode` follows the existing `SessionListLayoutMode` enum-setting pattern: `@Observable` field, debounced persist, `decodeIfPresent ?? .system` so pre-existing settings files load cleanly.
- `AppDelegate` mirrors `settings.appearanceMode` onto `NSApp.appearance` before any window/status item is built, and re-applies on change via `withObservationTracking` (same pattern as provider-mode observation). `NSApp.appearance` is app-wide, so every window picks it up.
- The menu-bar item's icon is a **non-template** image whose palette is baked at compose time, so unlike windows it doesn't redraw itself on an appearance flip — `AppDelegate` recomposes it explicitly (`StatusBarController.refreshForAppearanceChange()`) right after setting `NSApp.appearance`.

## Notes for the reviewer

- Default is `.system`, so existing users see no behaviour change.
- Old `app_settings.json` files (no `appearanceMode` key) migrate to `.system`.
- While wiring persistence I fixed a latent bug: `AppSettingsStorage.save()` rebuilds `AppSettingsData` field-by-field and was dropping the new field (would have persisted `.system` regardless) — caught by the round-trip tests added here. (That field-by-field rebuild is a standing maintenance hazard worth a follow-up, but out of scope here.)

## Testing

- `xcodebuild build-for-testing` — succeeded, no new warnings.
- `AppSettingsStorageTests` — added: default `.system`, every-mode JSON round-trip, and migration of a legacy file with no `appearanceMode` key. All pass.

The actual Light/Dark switching is window-server-dependent and can't be reproduced in unit tests; it should be verified by running the app and flipping the picker.