### PR TITLE
feat: multi-source session indexing (index Claude Code / Codex from multiple roots)

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -1119,7 +1119,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 storeProvider: { [weak self] source in self?.manageSourceStore(for: source) },
                 contextProvider: { [weak self] source in self?.manageContext(for: source) },
                 requestRescan: { [weak self] source in self?.sqliteFirstStartups[source.id]?.coordinator.requestRescan() },
-                rebuildIndex: { [weak self] source in self?.sqliteFirstStartups[source.id]?.rebuildIndex() }
+                rebuildIndex: { [weak self] source in self?.sqliteFirstStartups[source.id]?.rebuildIndex() },
+                hasLiveDriver: { [weak self] source in self?.sqliteFirstStartups[source.id] != nil }
             )
         }
         manageSessionsWindowController?.show()

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -189,7 +189,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var preferencesWindowController: PreferencesWindowController?
     private var manageSessionsWindowController: ManageSessionsWindowController?
     /// Store cache the manage window uses to read an inactive provider's index.
-    private var managedReadStores: [ProviderKind: ProviderStore] = [:]
+    private var managedReadStores: [String: ProviderStore] = [:]
     private var verifyUsageMenuItem: NSMenuItem?
     private lazy var logWindowController = LogWindowController(logger: LoggerService.shared)
     private let smokeTest = LaunchSmokeTestConfig.current()
@@ -1105,47 +1105,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func openManageSessions(_ sender: Any?) {
         if manageSessionsWindowController == nil {
+            let sources = settings.enabledResolvedSources
+            guard let active = settings.resolvedSources.source(id: settings.activeSourceId)
+                ?? sources.first else { return }
             manageSessionsWindowController = ManageSessionsWindowController(
-                provider: settings.activeProvider,
+                source: active,
+                sources: sources,
                 isIndexingProvider: { [weak self] in self?.store.isIndexing ?? false },
-                storeProvider: { [weak self] provider in self?.manageProviderStore(for: provider) },
-                contextProvider: { [weak self] provider in self?.manageContext(for: provider) },
-                requestRescan: { [weak self] provider in self?.sqliteFirstStartups[provider.rawValue]?.coordinator.requestRescan() },
-                rebuildIndex: { [weak self] provider in self?.sqliteFirstStartups[provider.rawValue]?.rebuildIndex() }
+                storeProvider: { [weak self] source in self?.manageSourceStore(for: source) },
+                contextProvider: { [weak self] source in self?.manageContext(for: source) },
+                requestRescan: { [weak self] source in self?.sqliteFirstStartups[source.id]?.coordinator.requestRescan() },
+                rebuildIndex: { [weak self] source in self?.sqliteFirstStartups[source.id]?.rebuildIndex() }
             )
         }
         manageSessionsWindowController?.show()
     }
 
-    /// Provides the indexing store for the active provider, or opens that
-    /// provider's index DB directly (for read/delete consistency) when
-    /// inactive. Lets the manage window show Claude Code tab sessions even
-    /// when started on codex.
-    private func manageProviderStore(for provider: ProviderKind) -> ProviderStore? {
-        if let startup = sqliteFirstStartups[provider.rawValue] {
+    /// Provides the indexing store for a source, or opens that source's index
+    /// DB directly (for read/delete consistency) when its driver isn't active.
+    /// Lets the manage window show any enabled source's sessions.
+    private func manageSourceStore(for source: SessionSource) -> ProviderStore? {
+        if let startup = sqliteFirstStartups[source.id] {
             // Prefer the active store, and release any read-only pool opened
             // while inactive (avoids file-handle/WAL leaks — a GRDB pool closes
             // when its ref is released).
-            managedReadStores[provider] = nil
+            managedReadStores[source.id] = nil
             return startup.coordinator.store
         }
-        if let cached = managedReadStores[provider] {
+        if let cached = managedReadStores[source.id] {
             return cached
         }
-        let url = LupenPaths.indexDatabaseURL(for: provider)
+        let url = LupenPaths.indexDatabaseURL(forSourceId: source.id)
         guard FileManager.default.fileExists(atPath: url.path),
               let database = try? ProviderDatabase.open(at: url) else { return nil }
         let store = ProviderStore(database: database)
-        managedReadStores[provider] = store
+        managedReadStores[source.id] = store
         return store
     }
 
-    private func manageContext(for provider: ProviderKind) -> ManageProviderContext? {
-        switch provider {
+    private func manageContext(for source: SessionSource) -> ManageProviderContext? {
+        switch source.kind {
         case .claudeCode:
-            return .claude(projectsDirectory: FileDiscovery().projectsDirectory)
+            return .claude(projectsDirectory: source.root)
         case .codex:
-            return .codex(codexHome: CodexSessionDiscovery(codexHome: codexHomeURLFromSettings()).codexHome)
+            return .codex(codexHome: source.root)
         }
     }
 

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -194,10 +194,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var logWindowController = LogWindowController(logger: LoggerService.shared)
     private let smokeTest = LaunchSmokeTestConfig.current()
     private let launchDiagnosticsConfig = LaunchDiagnosticsConfig.current()
-    /// SQLite-first drivers, one per provider (plan 3.5): both keep
-    /// indexing in the background; only the active provider's driver
-    /// projects into the store. Provider switch = projection swap.
-    private var sqliteFirstStartups: [ProviderKind: SQLiteFirstStartup] = [:]
+    /// SQLite-first drivers, keyed by session-source id (a built-in's id is
+    /// its `ProviderKind.rawValue`). Only the active source's driver projects
+    /// into the store; switching is a projection swap. Keying by source id
+    /// (not bare `ProviderKind`) lets sibling sources of the same kind each
+    /// own a driver.
+    private var sqliteFirstStartups: [String: SQLiteFirstStartup] = [:]
     private var sqliteFirstCodexHome: URL?
     private var smokeTestCompleted = false
 
@@ -419,7 +421,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// drivers keep importing with their store writes muted.
     private func sqliteFirstActivate(provider: ProviderKind, codexHome: URL?) {
         guard let store else { return }
-        for (kind, startup) in sqliteFirstStartups where kind != provider {
+        let sourceId = provider.rawValue
+        for (key, startup) in sqliteFirstStartups where key != sourceId {
             startup.deactivateProjection()
         }
         store.setActiveProviderForProjectionSwap(provider)
@@ -429,14 +432,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // import bounded on the real 100 GB corpus (the legacy
             // full-load entry points were deleted in 5.1).
             let resolvedHome = CodexSessionDiscovery(codexHome: codexHome).codexHome
-            if sqliteFirstStartups[.codex] != nil, sqliteFirstCodexHome != resolvedHome {
-                sqliteFirstStartups[.codex]?.stop()
-                sqliteFirstStartups[.codex] = nil
+            if sqliteFirstStartups[sourceId] != nil, sqliteFirstCodexHome != resolvedHome {
+                sqliteFirstStartups[sourceId]?.stop()
+                sqliteFirstStartups[sourceId] = nil
             }
             sqliteFirstCodexHome = resolvedHome
         }
 
-        if let existing = sqliteFirstStartups[provider] {
+        if let existing = sqliteFirstStartups[sourceId] {
             existing.activateProjection()
             return
         }
@@ -452,8 +455,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
         do {
-            let startup = try SQLiteFirstStartup(source: source, appStore: store)
-            sqliteFirstStartups[provider] = startup
+            let startup = try SQLiteFirstStartup(source: source, appStore: store, sourceId: sourceId)
+            sqliteFirstStartups[sourceId] = startup
             startup.start()   // a fresh driver starts with its projection active
             LaunchMemoryCheckpoint.record(
                 "app.sqliteFirst.startupBegan",
@@ -1055,8 +1058,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 isIndexingProvider: { [weak self] in self?.store.isIndexing ?? false },
                 storeProvider: { [weak self] provider in self?.manageProviderStore(for: provider) },
                 contextProvider: { [weak self] provider in self?.manageContext(for: provider) },
-                requestRescan: { [weak self] provider in self?.sqliteFirstStartups[provider]?.coordinator.requestRescan() },
-                rebuildIndex: { [weak self] provider in self?.sqliteFirstStartups[provider]?.rebuildIndex() }
+                requestRescan: { [weak self] provider in self?.sqliteFirstStartups[provider.rawValue]?.coordinator.requestRescan() },
+                rebuildIndex: { [weak self] provider in self?.sqliteFirstStartups[provider.rawValue]?.rebuildIndex() }
             )
         }
         manageSessionsWindowController?.show()
@@ -1067,7 +1070,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// inactive. Lets the manage window show Claude Code tab sessions even
     /// when started on codex.
     private func manageProviderStore(for provider: ProviderKind) -> ProviderStore? {
-        if let startup = sqliteFirstStartups[provider] {
+        if let startup = sqliteFirstStartups[provider.rawValue] {
             // Prefer the active store, and release any read-only pool opened
             // while inactive (avoids file-handle/WAL leaks — a GRDB pool closes
             // when its ref is released).

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -1104,10 +1104,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Manage Sessions & Storage window
 
     @objc func openManageSessions(_ sender: Any?) {
-        if manageSessionsWindowController == nil {
-            let sources = settings.enabledResolvedSources
-            guard let active = settings.resolvedSources.source(id: settings.activeSourceId)
-                ?? sources.first else { return }
+        let sources = settings.enabledResolvedSources
+        guard let active = settings.resolvedSources.source(id: settings.activeSourceId)
+            ?? sources.first else { return }
+        if let controller = manageSessionsWindowController {
+            // Reused singleton — re-push the current sources/active so a source
+            // added/removed/activated since the last open is reflected.
+            controller.update(sources: sources, active: active)
+        } else {
             manageSessionsWindowController = ManageSessionsWindowController(
                 source: active,
                 sources: sources,

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -371,15 +371,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         WallClockCoordinator.shared.start()
 
         let startupProvider = settings.activeProvider
-        let startupPlan = StartupDataLoadPlan(
-            provider: startupProvider,
-            codexHome: codexHomeURLFromSettings()
-        )
         armSmokeTestTimeoutIfNeeded(provider: startupProvider)
         // Plan 5.1: SQLite-first is the only startup path — the legacy
         // cache/orchestrator pipeline was deleted. GUI smoke runs
         // measure this same path and exit once indexing settles.
-        startSQLiteFirstStartup(plan: startupPlan)
+        //
+        // If the persisted active source is a user-added/auto-detected one,
+        // restore it via the custom path; otherwise take the built-in plan
+        // path (smoke runs only ever target built-ins).
+        if let active = settings.resolvedSources.source(id: settings.activeSourceId),
+           active.enabled, active.origin != .builtin {
+            sqliteFirstActivateCustom(source: active)
+        } else {
+            startSQLiteFirstStartup(plan: StartupDataLoadPlan(
+                provider: startupProvider,
+                codexHome: codexHomeURLFromSettings()
+            ))
+        }
         if smokeTest != nil {
             pollSmokeTestCompletion(provider: startupProvider)
         }
@@ -562,12 +570,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func startObservingProviderMode() {
         withObservationTracking {
-            _ = settings.activeProvider
+            _ = settings.activeSourceId
             _ = settings.codexRootPath
         } onChange: { [weak self] in
             DispatchQueue.main.async {
                 self?.updateProviderSpecificMenuTitles()
-                self?.syncStoreToActiveProvider()
+                self?.syncStoreToActiveSource()
                 self?.startObservingProviderMode()
             }
         }
@@ -607,13 +615,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         verifyUsageMenuItem?.title = settings.activeProvider.verificationMenuTitle
     }
 
-    private func syncStoreToActiveProvider() {
-        // Plan 3.5/5.1: switching providers swaps the active projection
-        // — there is no legacy switch path anymore.
-        sqliteFirstActivate(
-            provider: settings.activeProvider,
-            codexHome: codexHomeURLFromSettings()
-        )
+    private func syncStoreToActiveSource() {
+        // Switching the active source is a projection swap. Built-in sources
+        // keep the legacy per-provider path (which honours the codexRootPath /
+        // smoke codexHome overrides); a user-added/auto-detected source uses
+        // its own root via the custom path. A missing/disabled active id falls
+        // back to the built-in path for the resolved provider.
+        let activeId = settings.activeSourceId
+        if let active = settings.resolvedSources.source(id: activeId),
+           active.enabled, active.origin != .builtin {
+            sqliteFirstActivateCustom(source: active)
+        } else {
+            sqliteFirstActivate(
+                provider: settings.activeProvider,
+                codexHome: codexHomeURLFromSettings()
+            )
+        }
+    }
+
+    /// Activate a non-built-in source: project its index, creating and starting
+    /// the driver on first use. Mirrors `sqliteFirstActivate(provider:)` but
+    /// keyed by the source's stable id and rooted at `source.root`.
+    private func sqliteFirstActivateCustom(source: SessionSource) {
+        guard let store else { return }
+        let sourceId = source.id
+        for (key, startup) in sqliteFirstStartups where key != sourceId {
+            startup.deactivateProjection()
+        }
+        store.setActiveSourceForProjectionSwap(source)
+
+        if let existing = sqliteFirstStartups[sourceId] {
+            existing.activateProjection()
+            return
+        }
+        do {
+            let startup = try SQLiteFirstStartup(
+                source: ProviderIndexSource(source), appStore: store, sourceId: sourceId
+            )
+            sqliteFirstStartups[sourceId] = startup
+            startup.start()
+            LaunchMemoryCheckpoint.record(
+                "app.sqliteFirst.startupBegan",
+                config: launchDiagnosticsConfig,
+                metadata: ["provider": source.kind.rawValue, "source": sourceId]
+            )
+        } catch {
+            LoggerService.shared.error(
+                "SQLite-first startup failed (source \(sourceId)): \(error)",
+                context: "App"
+            )
+            store.isLoading = false
+        }
     }
 
     private func codexHomeURLFromSettings() -> URL? {

--- a/Lupen/CLI/CLIEngine.swift
+++ b/Lupen/CLI/CLIEngine.swift
@@ -32,16 +32,41 @@ struct CLIEngine {
         appSupportRoot: URL = LupenPaths.applicationSupportRoot(),
         progress: (String) -> Void = { CLIOutput.note($0) }
     ) throws -> CLIEngine {
-        let database = try ProviderDatabase.open(provider: provider, appSupportRoot: appSupportRoot)
+        // A built-in provider is just its built-in source; delegate so the
+        // index path / refresh source are identical to the per-source path.
+        try open(
+            source: SessionSourceRegistry.builtinSource(
+                for: provider,
+                claudeRoot: FileDiscovery().projectsDirectory,
+                codexRoot: CodexSessionDiscovery().codexHome
+            ),
+            refresh: refresh,
+            appSupportRoot: appSupportRoot,
+            progress: progress
+        )
+    }
+
+    /// Open the index for an explicit session source — the per-source DB under
+    /// `providers/<source.id>/`, refreshed from `source.root` via the source's
+    /// parser. The built-in convenience above routes through here.
+    static func open(
+        source: SessionSource,
+        refresh: Bool,
+        appSupportRoot: URL = LupenPaths.applicationSupportRoot(),
+        progress: (String) -> Void = { CLIOutput.note($0) }
+    ) throws -> CLIEngine {
+        let database = try ProviderDatabase.open(
+            at: LupenPaths.indexDatabaseURL(forSourceId: source.id, appSupportRoot: appSupportRoot)
+        )
         let store = ProviderStore(database: database)
 
         var outcome: CLIRefresher.Outcome?
         if refresh {
-            let lockURL = LupenPaths.refreshLockURL(for: provider, appSupportRoot: appSupportRoot)
+            let lockURL = LupenPaths.refreshLockURL(forSourceId: source.id, appSupportRoot: appSupportRoot)
             if let lock = CLIProcessLock.acquire(at: lockURL, timeout: 30) {
                 defer { lock.release() }
                 outcome = CLIRefresher.run(
-                    source: CLIRefresher.source(for: provider),
+                    source: ProviderIndexSource(source),
                     store: store,
                     progress: progress
                 )
@@ -51,7 +76,7 @@ struct CLIEngine {
         }
 
         return CLIEngine(
-            provider: provider,
+            provider: source.kind,
             store: store,
             bootstrapOutcome: database.outcome,
             didRefresh: refresh,

--- a/Lupen/CLI/CLISourceResolver.swift
+++ b/Lupen/CLI/CLISourceResolver.swift
@@ -1,0 +1,46 @@
+//
+//  CLISourceResolver.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Foundation
+
+/// Resolves a `--provider`/`--source` CLI argument to a `SessionSource` so the
+/// terminal and the app share one source definition (plan §5.4). Built-in
+/// aliases keep working (`claude` / `claude-code` / `claudeCode`, `codex`);
+/// any other argument matches an enabled source by its stable id or its
+/// case-insensitive name.
+///
+/// ⚠️ Scope note (plan §5.4): user-registered sources are app↔CLI identical,
+/// but env-derived built-in roots (CLAUDE_CONFIG_DIR / CODEX_HOME) depend on
+/// the launch context, so a terminal run may resolve a different directory
+/// than the GUI for the built-ins.
+enum CLISourceResolver {
+
+    /// Pure resolution against a provided source list.
+    static func resolve(_ argument: String, in sources: [SessionSource]) -> SessionSource? {
+        let arg = argument.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch arg.lowercased() {
+        case "claude", "claude-code", "claudecode":
+            return sources.first { $0.origin == .builtin && $0.kind == .claudeCode }
+        case "codex":
+            return sources.first { $0.origin == .builtin && $0.kind == .codex }
+        default:
+            break
+        }
+        if let byId = sources.source(id: arg) { return byId }
+        let lower = arg.lowercased()
+        return sources.first { $0.name.lowercased() == lower }
+    }
+
+    /// Live resolution: load the persisted app settings, compose the canonical
+    /// source list, and resolve. `settingsURL` is injectable for tests; the
+    /// default reads the same file the GUI writes.
+    static func resolveLive(_ argument: String, settingsURL: URL? = nil) -> SessionSource? {
+        let saved = AppSettingsStorage(fileURL: settingsURL).load().sessionSources
+        let resolved = SessionSourceRegistry.resolve(saved: saved)
+        return resolve(argument, in: resolved)
+    }
+}

--- a/Lupen/CLI/Commands/BreakdownCommands.swift
+++ b/Lupen/CLI/Commands/BreakdownCommands.swift
@@ -16,7 +16,7 @@ struct ModelsCommand: ParsableCommand {
     func run() throws {
         let range = try options.resolveRange()
         let sort = try BreakdownSort.parse(rowOptions.sort, default: .cost)
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let rows = try engine.store.modelUsageAggregates(from: range.from, to: range.to)
@@ -41,7 +41,7 @@ struct ProjectsCommand: ParsableCommand {
     func run() throws {
         let range = try options.resolveRange()
         let sort = try BreakdownSort.parse(rowOptions.sort, default: .cost)
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let rows = try engine.store.projectAggregates(from: range.from, to: range.to)

--- a/Lupen/CLI/Commands/BudgetStatuslineCommands.swift
+++ b/Lupen/CLI/Commands/BudgetStatuslineCommands.swift
@@ -24,7 +24,7 @@ struct BudgetCommand: ParsableCommand {
 
     func run() throws {
         let range = try options.resolveRange()
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let report = CLIBudgetReport(
@@ -96,7 +96,7 @@ struct StatuslineCommand: ParsableCommand {
         // first run, or rebuild it after an app-version schema bump, but it
         // never imports.) Stay silent — no freshness note — so a bare
         // `$(lupen statusline)` capture is a single clean token.
-        let engine = try CLIEngine.open(provider: options.provider, refresh: false)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: false)
         let cost = try engine.store.totalCostUSD(from: range.from, to: range.to)
 
         if options.json {

--- a/Lupen/CLI/Commands/SearchResumeCommands.swift
+++ b/Lupen/CLI/Commands/SearchResumeCommands.swift
@@ -20,7 +20,7 @@ struct SearchCommand: ParsableCommand {
     }
 
     func run() throws {
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         // Sanitize the query into an FTS5 prefix expression (as the GUI's
@@ -120,7 +120,7 @@ struct ResumeCommand: ParsableCommand {
 
     func run() throws {
         // Resume reads the existing index (no refresh needed to look up a known id).
-        let engine = try CLIEngine.open(provider: options.provider, refresh: false)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: false)
         guard let row = try engine.store.session(id: sessionId) else {
             throw ValidationError(
                 "No session '\(sessionId)' for \(options.provider.cliLabel). Use the full id from `lupen search` or `lupen top --json`."

--- a/Lupen/CLI/Commands/SkillsCommand.swift
+++ b/Lupen/CLI/Commands/SkillsCommand.swift
@@ -18,7 +18,7 @@ struct SkillsCommand: ParsableCommand {
         let range = try options.resolveRange()
         let sort = try SkillSort.parse(rowOptions.sort, default: .cost)
 
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let aggregates = try engine.store.skillAggregates(from: range.from, to: range.to)

--- a/Lupen/CLI/Commands/SummaryCommand.swift
+++ b/Lupen/CLI/Commands/SummaryCommand.swift
@@ -14,7 +14,7 @@ struct SummaryCommand: ParsableCommand {
 
     func run() throws {
         let range = try options.resolveRange()
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let totals = try engine.store.usageTotals(from: range.from, to: range.to)

--- a/Lupen/CLI/Commands/TimeReportCommands.swift
+++ b/Lupen/CLI/Commands/TimeReportCommands.swift
@@ -41,7 +41,7 @@ enum TimeReportRunner {
         let range = try options.resolveRange()
         let sort = try TimeSort.parse(rowOptions.sort, default: .date)
 
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let daily = try engine.store.usageBuckets(hourly: false, from: range.from, to: range.to)

--- a/Lupen/CLI/Commands/TopCommand.swift
+++ b/Lupen/CLI/Commands/TopCommand.swift
@@ -24,7 +24,7 @@ struct TopCommand: ParsableCommand {
     func run() throws {
         let range = try options.resolveRange()
 
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
 
         let periodCost = try engine.store.totalCostUSD(from: range.from, to: range.to)

--- a/Lupen/CLI/Commands/UtilityCommands.swift
+++ b/Lupen/CLI/Commands/UtilityCommands.swift
@@ -58,7 +58,7 @@ struct RefreshCommand: ParsableCommand {
     @OptionGroup var options: CLIGlobalOptions
 
     func run() throws {
-        let engine = try CLIEngine.open(provider: options.provider, refresh: true)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: true)
         CLIOutput.line(CLIRefreshMessage.text(for: engine.refreshOutcome))
     }
 }

--- a/Lupen/CLI/Commands/VerifyCommand.swift
+++ b/Lupen/CLI/Commands/VerifyCommand.swift
@@ -23,7 +23,7 @@ struct VerifyCommand: ParsableCommand {
     @OptionGroup var options: CLIGlobalOptions
 
     func run() throws {
-        let engine = try CLIEngine.open(provider: options.provider, refresh: options.refresh)
+        let engine = try CLIEngine.open(source: options.resolvedSource, refresh: options.refresh)
         if let note = engine.freshnessNote() { CLIOutput.note(note) }
         if options.periodLabel != "all time" {
             CLIOutput.note("verify audits all sessions; period filters are ignored.")

--- a/Lupen/CLI/LupenCLI.swift
+++ b/Lupen/CLI/LupenCLI.swift
@@ -94,7 +94,9 @@ struct CLIGlobalOptions: ParsableArguments {
 
     /// The resolved session source: a custom source when --source matches one,
     /// otherwise the built-in for --provider. The built-in path is cheap (no
-    /// settings load / detect cost) so the common case stays fast.
+    /// settings load / detect cost) so the common case stays fast. An unknown
+    /// --source is rejected in `validate()`, so this only reaches the fallback
+    /// for a blank/absent value.
     var resolvedSource: SessionSource {
         if let source, !source.trimmingCharacters(in: .whitespaces).isEmpty,
            let resolved = CLISourceResolver.resolveLive(source) {
@@ -146,6 +148,16 @@ struct CLIGlobalOptions: ParsableArguments {
     func validate() throws {
         if json && csv {
             throw ValidationError("Use only one of --json or --csv.")
+        }
+        // Reject an unknown --source up front instead of silently falling back
+        // to the default provider (which would print a *different* source's
+        // data). Built-in/absent values resolve trivially.
+        if let source, !source.trimmingCharacters(in: .whitespaces).isEmpty,
+           CLISourceResolver.resolveLive(source) == nil {
+            throw ValidationError(
+                "Unknown --source '\(source)'. Pass a session source name or id "
+                + "(see Settings ▸ Session Sources), or omit --source."
+            )
         }
     }
 

--- a/Lupen/CLI/LupenCLI.swift
+++ b/Lupen/CLI/LupenCLI.swift
@@ -86,8 +86,35 @@ extension ProviderKind: ExpressibleByArgument {
 /// flags read identically across the tool (the ccusage-style vocabulary:
 /// `--since/--until`, `--last`, `--month`, `--json`).
 struct CLIGlobalOptions: ParsableArguments {
-    @Option(name: .long, help: "Provider to report on.")
-    var provider: ProviderKind = .claudeCode
+    @Option(name: .customLong("provider"), help: "Built-in provider to report on (claudeCode | codex). Ignored when --source is given.")
+    var providerArg: ProviderKind = .claudeCode
+
+    @Option(name: .customLong("source"), help: "Session source to report on, by name or id (overrides --provider). Includes user-added and auto-detected sources.")
+    var source: String?
+
+    /// The resolved session source: a custom source when --source matches one,
+    /// otherwise the built-in for --provider. The built-in path is cheap (no
+    /// settings load / detect cost) so the common case stays fast.
+    var resolvedSource: SessionSource {
+        if let source, !source.trimmingCharacters(in: .whitespaces).isEmpty,
+           let resolved = CLISourceResolver.resolveLive(source) {
+            return resolved
+        }
+        return SessionSourceRegistry.builtinSource(
+            for: providerArg,
+            claudeRoot: FileDiscovery().projectsDirectory,
+            codexRoot: CodexSessionDiscovery().codexHome
+        )
+    }
+
+    /// Parser kind of the resolved source — what commands branch on. Skips the
+    /// live resolution on the common (no --source) path.
+    var provider: ProviderKind {
+        if let source, !source.trimmingCharacters(in: .whitespaces).isEmpty {
+            return resolvedSource.kind
+        }
+        return providerArg
+    }
 
     @Option(name: .long, help: "Start date (YYYY-MM-DD), inclusive. Pair with --until.")
     var since: String?

--- a/Lupen/Cache/AppSettingsStorage.swift
+++ b/Lupen/Cache/AppSettingsStorage.swift
@@ -54,6 +54,11 @@ struct AppSettingsData: Codable, Equatable, Sendable {
     /// fields needed to remember a Connect across launches without
     /// re-parsing settings.json from scratch on every read.
     var statuslinePrefs: StatuslinePrefsData
+    /// User-defined session sources: added folders plus enable/name overrides
+    /// for built-in and auto-detected sources. Empty = defaults only. Stored
+    /// in its OWN field (not `providerConfigurations`) to avoid the legacy
+    /// `ensureBuiltIn` root-clobber on persist.
+    var sessionSources: [SessionSource]
 
     /// Default on first launch / corrupt file fallback.
     ///
@@ -86,7 +91,8 @@ struct AppSettingsData: Codable, Equatable, Sendable {
             startAtLogin: false,
             showParseWarningBadge: defaultBadgesOn,
             showParseErrorBadge: defaultBadgesOn,
-            statuslinePrefs: .default
+            statuslinePrefs: .default,
+            sessionSources: []
         )
     }()
 
@@ -104,7 +110,8 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         startAtLogin: Bool,
         showParseWarningBadge: Bool,
         showParseErrorBadge: Bool,
-        statuslinePrefs: StatuslinePrefsData = .default
+        statuslinePrefs: StatuslinePrefsData = .default,
+        sessionSources: [SessionSource] = []
     ) {
         self.sessionListLayout = sessionListLayout
         self.appearanceMode = appearanceMode
@@ -129,6 +136,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         self.showParseWarningBadge = showParseWarningBadge
         self.showParseErrorBadge = showParseErrorBadge
         self.statuslinePrefs = statuslinePrefs
+        self.sessionSources = sessionSources
     }
 
     enum CodingKeys: String, CodingKey {
@@ -146,6 +154,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         case showParseWarningBadge
         case showParseErrorBadge
         case statuslinePrefs
+        case sessionSources
     }
 
     init(from decoder: Decoder) throws {
@@ -211,6 +220,10 @@ struct AppSettingsData: Codable, Equatable, Sendable {
             StatuslinePrefsData.self,
             forKey: .statuslinePrefs
         ) ?? AppSettingsData.default.statuslinePrefs
+        self.sessionSources = try c.decodeIfPresent(
+            [SessionSource].self,
+            forKey: .sessionSources
+        ) ?? AppSettingsData.default.sessionSources
     }
 
     private static func normalizePinnedSessionIds(_ ids: [String], defaultProvider: ProviderKind) -> [String] {
@@ -371,7 +384,8 @@ struct AppSettingsStorage: Sendable {
                 startAtLogin: data.startAtLogin,
                 showParseWarningBadge: data.showParseWarningBadge,
                 showParseErrorBadge: data.showParseErrorBadge,
-                statuslinePrefs: data.statuslinePrefs
+                statuslinePrefs: data.statuslinePrefs,
+                sessionSources: data.sessionSources
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Lupen/Cache/AppSettingsStorage.swift
+++ b/Lupen/Cache/AppSettingsStorage.swift
@@ -11,6 +11,12 @@ struct AppSettingsData: Codable, Equatable, Sendable {
     /// App-wide appearance override. `.system` follows macOS (default).
     var appearanceMode: AppearanceMode
     var activeProvider: ProviderKind
+    /// Stable id of the active session source — the authority for which source
+    /// is projected. Built-in source ids equal `ProviderKind.rawValue`, so
+    /// `activeProvider` is kept in sync as the active source's parser kind.
+    /// Migrated from `activeProvider` when absent in a file written by an
+    /// older build.
+    var activeSourceId: String
     var pinnedSessionIds: [String]
     var claudeCodeRootPath: String?
     var codexRootPath: String?
@@ -81,6 +87,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
             sessionListLayout: .flat,
             appearanceMode: .system,
             activeProvider: .claudeCode,
+            activeSourceId: ProviderKind.claudeCode.rawValue,
             pinnedSessionIds: [],
             claudeCodeRootPath: nil,
             codexRootPath: nil,
@@ -100,6 +107,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         sessionListLayout: SessionListLayoutMode,
         appearanceMode: AppearanceMode = .system,
         activeProvider: ProviderKind = .claudeCode,
+        activeSourceId: String? = nil,
         pinnedSessionIds: [String],
         claudeCodeRootPath: String? = nil,
         codexRootPath: String? = nil,
@@ -116,6 +124,9 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         self.sessionListLayout = sessionListLayout
         self.appearanceMode = appearanceMode
         self.activeProvider = activeProvider
+        // Built-in source id == ProviderKind.rawValue, so deriving from the
+        // active provider is the correct migration when no id was persisted.
+        self.activeSourceId = activeSourceId ?? activeProvider.rawValue
         self.pinnedSessionIds = Self.normalizePinnedSessionIds(
             pinnedSessionIds,
             defaultProvider: activeProvider
@@ -143,6 +154,7 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         case sessionListLayout
         case appearanceMode
         case activeProvider
+        case activeSourceId
         case pinnedSessionIds
         case claudeCodeRootPath
         case codexRootPath
@@ -170,6 +182,10 @@ struct AppSettingsData: Codable, Equatable, Sendable {
         let activeProviderRaw = try c.decodeIfPresent(String.self, forKey: .activeProvider)
         self.activeProvider = activeProviderRaw.flatMap(ProviderKind.init(rawValue:))
             ?? AppSettingsData.default.activeProvider
+        // Migration: older files have no `activeSourceId` — derive it from the
+        // active provider (built-in id == rawValue).
+        self.activeSourceId = try c.decodeIfPresent(String.self, forKey: .activeSourceId)
+            ?? self.activeProvider.rawValue
         self.pinnedSessionIds = Self.normalizePinnedSessionIds(try c.decodeIfPresent(
             [String].self,
             forKey: .pinnedSessionIds
@@ -374,6 +390,7 @@ struct AppSettingsStorage: Sendable {
                 sessionListLayout: data.sessionListLayout,
                 appearanceMode: data.appearanceMode,
                 activeProvider: data.activeProvider,
+                activeSourceId: data.activeSourceId,
                 pinnedSessionIds: data.pinnedSessionIds.sorted(),
                 claudeCodeRootPath: data.claudeCodeRootPath,
                 codexRootPath: data.codexRootPath,

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -230,8 +230,24 @@ final class AppSettings {
     var sessionSources: [SessionSource] {
         didSet {
             guard oldValue != sessionSources else { return }
+            recomputeResolvedSources()
             schedulePersist()
         }
+    }
+
+    /// The composed, canonical source list — built-in defaults + auto-detected
+    /// candidates + the user's `sessionSources` overrides — recomputed only
+    /// when `sessionSources` changes (the composition runs `detect()`, which
+    /// stats the filesystem, so it is cached here rather than recomputed per
+    /// read). The mode picker and the indexing lifecycle read from this SSOT.
+    private(set) var resolvedSources: [SessionSource]
+
+    /// Whitelist projection of `resolvedSources` — only enabled sources are
+    /// indexed and shown in the picker.
+    var enabledResolvedSources: [SessionSource] { resolvedSources.enabledSources }
+
+    private func recomputeResolvedSources() {
+        resolvedSources = SessionSourceRegistry.resolve(saved: sessionSources)
     }
 
     // MARK: - Dependencies
@@ -268,6 +284,8 @@ final class AppSettings {
         self.showParseErrorBadge = loaded.showParseErrorBadge
         self.statuslinePrefs = loaded.statuslinePrefs
         self.sessionSources = loaded.sessionSources
+        // didSet doesn't fire during init, so seed the composed list here.
+        self.resolvedSources = SessionSourceRegistry.resolve(saved: loaded.sessionSources)
     }
 
     // Note: no `deinit { pendingPersist?.cancel() }` — the scheduled

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -283,25 +283,34 @@ final class AppSettings {
 
     /// Remove a user-added source. Built-in and auto-detected sources are not
     /// removable (disable them instead). If it was active, falls back to the
-    /// Claude built-in.
+    /// first remaining enabled source.
     func removeSource(id: String) {
         guard resolvedSources.source(id: id)?.origin == .userAdded else { return }
         let next = sessionSources.filter { $0.id != id }
         guard next.count != sessionSources.count else { return }
-        if activeSourceId == id { activeSourceId = SessionSourceRegistry.claudeBuiltinID }
+        if activeSourceId == id { activeSourceId = fallbackActiveSourceId(excluding: id) }
         sessionSources = next
     }
 
     /// Enable/disable a source (whitelist toggle). Refuses to disable the last
-    /// enabled source; disabling the active source falls back to the Claude
-    /// built-in.
+    /// enabled source; disabling the active source falls back to another
+    /// still-enabled source (never to a disabled one).
     func setSourceEnabled(id: String, _ enabled: Bool) {
         guard let current = resolvedSources.source(id: id), current.enabled != enabled else { return }
         if !enabled, resolvedSources.enabledSources.count <= 1 { return }
-        if !enabled, activeSourceId == id { activeSourceId = SessionSourceRegistry.claudeBuiltinID }
+        if !enabled, activeSourceId == id { activeSourceId = fallbackActiveSourceId(excluding: id) }
         var updated = current
         updated.enabled = enabled
         upsertSourceOverride(updated)
+    }
+
+    /// The id to make active when the current active source is being removed or
+    /// disabled: the first still-enabled source other than `id`. The Claude
+    /// built-in is only a last-resort default (unreachable while the
+    /// min-one-enabled guard holds), so the active source is always enabled.
+    private func fallbackActiveSourceId(excluding id: String) -> String {
+        resolvedSources.enabledSources.first { $0.id != id }?.id
+            ?? SessionSourceRegistry.claudeBuiltinID
     }
 
     /// Rename a source. Rejects an empty name or one already used by a

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -250,6 +250,112 @@ final class AppSettings {
         resolvedSources = SessionSourceRegistry.resolve(saved: sessionSources)
     }
 
+    // MARK: - Session source management
+    //
+    // The Settings UI drives these; each mutates the `sessionSources` override
+    // list (or `activeSourceId`), which recomputes `resolvedSources` and
+    // persists. Built-in and auto-detected sources are enabled/renamed by
+    // writing an override carrying their id; only user-added sources are
+    // removable.
+
+    /// Register a user folder as a new enabled source. Returns nil if the
+    /// normalized root duplicates an existing source. Name defaults to a
+    /// suggestion and is made unique.
+    @discardableResult
+    func addSource(root: URL, kind: ProviderKind, name: String? = nil) -> SessionSource? {
+        let normalizedRoot = SessionSource.normalizedRoot(root)
+        guard SessionSourceInference.duplicateRootSource(normalizedRoot, in: resolvedSources) == nil
+        else { return nil }
+        let base = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suggested = (base?.isEmpty == false ? base! :
+            SessionSourceInference.suggestName(forRoot: normalizedRoot, kind: kind))
+        let uniqueName = SessionSourceInference.uniqueName(
+            suggested, existingNames: resolvedSources.map(\.name)
+        )
+        let source = SessionSource(
+            id: makeUserSourceId(forRoot: normalizedRoot, kind: kind),
+            name: uniqueName, kind: kind, root: normalizedRoot,
+            origin: .userAdded, enabled: true
+        )
+        sessionSources = sessionSources + [source]
+        return source
+    }
+
+    /// Remove a user-added source. Built-in and auto-detected sources are not
+    /// removable (disable them instead). If it was active, falls back to the
+    /// Claude built-in.
+    func removeSource(id: String) {
+        guard resolvedSources.source(id: id)?.origin == .userAdded else { return }
+        let next = sessionSources.filter { $0.id != id }
+        guard next.count != sessionSources.count else { return }
+        if activeSourceId == id { activeSourceId = SessionSourceRegistry.claudeBuiltinID }
+        sessionSources = next
+    }
+
+    /// Enable/disable a source (whitelist toggle). Refuses to disable the last
+    /// enabled source; disabling the active source falls back to the Claude
+    /// built-in.
+    func setSourceEnabled(id: String, _ enabled: Bool) {
+        guard let current = resolvedSources.source(id: id), current.enabled != enabled else { return }
+        if !enabled, resolvedSources.enabledSources.count <= 1 { return }
+        if !enabled, activeSourceId == id { activeSourceId = SessionSourceRegistry.claudeBuiltinID }
+        var updated = current
+        updated.enabled = enabled
+        upsertSourceOverride(updated)
+    }
+
+    /// Rename a source. Rejects an empty name or one already used by a
+    /// different source. Returns whether the rename was applied.
+    @discardableResult
+    func renameSource(id: String, to newName: String) -> Bool {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let current = resolvedSources.source(id: id), !trimmed.isEmpty else { return false }
+        let otherNames = resolvedSources.filter { $0.id != id }.map(\.name)
+        guard !otherNames.contains(trimmed) else { return false }
+        guard current.name != trimmed else { return true }
+        var updated = current
+        updated.name = trimmed
+        upsertSourceOverride(updated)
+        return true
+    }
+
+    /// Make `id` the active (projected) source. Only enabled sources can be
+    /// activated. Returns whether it was applied.
+    @discardableResult
+    func setActiveSource(id: String) -> Bool {
+        guard let source = resolvedSources.source(id: id), source.enabled else { return false }
+        activeSourceId = id
+        return true
+    }
+
+    private func upsertSourceOverride(_ source: SessionSource) {
+        var next = sessionSources
+        if let index = next.firstIndex(where: { $0.id == source.id }) {
+            next[index] = source
+        } else {
+            next.append(source)
+        }
+        sessionSources = next
+    }
+
+    private func makeUserSourceId(forRoot root: URL, kind: ProviderKind) -> String {
+        let tail = root.standardizedFileURL.pathComponents
+            .filter { $0 != "/" }
+            .suffix(2)
+            .joined(separator: "-")
+        var slug = tail
+            .replacingOccurrences(of: ProviderScopedID.separator, with: "-")
+            .replacingOccurrences(of: " ", with: "-")
+            .replacingOccurrences(of: "/", with: "-")
+        if slug.isEmpty { slug = kind.rawValue }
+        let base = "user-\(slug)"
+        let existingIds = Set(resolvedSources.map(\.id))
+        guard existingIds.contains(base) else { return base }
+        var suffix = 2
+        while existingIds.contains("\(base)-\(suffix)") { suffix += 1 }
+        return "\(base)-\(suffix)"
+    }
+
     // MARK: - Dependencies
 
     private let storage: AppSettingsStorage

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -206,6 +206,17 @@ final class AppSettings {
         }
     }
 
+    /// User's session-source overrides (added folders + enable/name changes).
+    /// Built-in and auto-detected sources are layered on at resolve time; this
+    /// stores only what the user customised. Observed so the picker/indexing
+    /// react when a source is added/activated.
+    var sessionSources: [SessionSource] {
+        didSet {
+            guard oldValue != sessionSources else { return }
+            schedulePersist()
+        }
+    }
+
     // MARK: - Dependencies
 
     private let storage: AppSettingsStorage
@@ -239,6 +250,7 @@ final class AppSettings {
         self.showParseWarningBadge = loaded.showParseWarningBadge
         self.showParseErrorBadge = loaded.showParseErrorBadge
         self.statuslinePrefs = loaded.statuslinePrefs
+        self.sessionSources = loaded.sessionSources
     }
 
     // Note: no `deinit { pendingPersist?.cancel() }` — the scheduled
@@ -361,7 +373,8 @@ final class AppSettings {
             startAtLogin: startAtLogin,
             showParseWarningBadge: showParseWarningBadge,
             showParseErrorBadge: showParseErrorBadge,
-            statuslinePrefs: statuslinePrefs
+            statuslinePrefs: statuslinePrefs,
+            sessionSources: sessionSources
         )
     }
 

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -83,13 +83,30 @@ final class AppSettings {
         }
     }
 
-    /// Global provider mode. Every user-visible surface should render data
-    /// for this provider only.
-    var activeProvider: ProviderKind {
+    /// Stable id of the active session source — the persisted authority for
+    /// which source is shown. Built-in source ids equal `ProviderKind.rawValue`
+    /// so `activeProvider` below round-trips through it losslessly.
+    var activeSourceId: String {
         didSet {
-            guard oldValue != activeProvider else { return }
+            guard oldValue != activeSourceId else { return }
             schedulePersist()
         }
+    }
+
+    /// Global provider mode. Every user-visible surface should render data
+    /// for this provider only. Projection of `activeSourceId`: the getter
+    /// resolves the active source's parser kind, the setter maps a kind to its
+    /// built-in source id. Keeps the many call sites that read/write
+    /// `activeProvider` working unchanged; observation still fires because the
+    /// accessors touch the observed `activeSourceId` (and `sessionSources`
+    /// only for non-built-in ids).
+    var activeProvider: ProviderKind {
+        get {
+            ProviderKind(rawValue: activeSourceId)
+                ?? sessionSources.source(id: activeSourceId)?.kind
+                ?? .claudeCode
+        }
+        set { activeSourceId = newValue.rawValue }
     }
 
     /// IDs of sessions the user has pinned to the top of the Flat layout.
@@ -233,7 +250,7 @@ final class AppSettings {
         let loaded = storage.load()
         self.sessionListLayout = loaded.sessionListLayout
         self.appearanceMode = loaded.appearanceMode
-        self.activeProvider = loaded.activeProvider
+        self.activeSourceId = loaded.activeSourceId
         self.pinnedSessionIds = Set(loaded.pinnedSessionIds)
         self.claudeCodeRootPath = loaded.claudeCodeRootPath
         self.codexRootPath = loaded.codexRootPath
@@ -363,6 +380,7 @@ final class AppSettings {
             sessionListLayout: sessionListLayout,
             appearanceMode: appearanceMode,
             activeProvider: activeProvider,
+            activeSourceId: activeSourceId,
             pinnedSessionIds: Array(pinnedSessionIds).sorted(),
             claudeCodeRootPath: claudeCodeRootPath,
             codexRootPath: codexRootPath,

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -319,7 +319,11 @@ final class AppSettings {
     func renameSource(id: String, to newName: String) -> Bool {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let current = resolvedSources.source(id: id), !trimmed.isEmpty else { return false }
-        let otherNames = resolvedSources.filter { $0.id != id }.map(\.name)
+        // Check both the visible sources AND saved overrides: a saved source can
+        // be shadowed out of `resolvedSources` by a root collision yet still
+        // persist in `sessionSources`, so comparing only the visible set could
+        // let two persisted sources share a name.
+        let otherNames = (resolvedSources + sessionSources).filter { $0.id != id }.map(\.name)
         guard !otherNames.contains(trimmed) else { return false }
         guard current.name != trimmed else { return true }
         var updated = current
@@ -358,7 +362,10 @@ final class AppSettings {
             .replacingOccurrences(of: "/", with: "-")
         if slug.isEmpty { slug = kind.rawValue }
         let base = "user-\(slug)"
-        let existingIds = Set(resolvedSources.map(\.id))
+        // Include saved ids too: a source shadowed out of `resolvedSources` by a
+        // root collision still lives in `sessionSources`, and a new id must not
+        // collide with it (else two persisted sources would share an id).
+        let existingIds = Set(resolvedSources.map(\.id)).union(sessionSources.map(\.id))
         guard existingIds.contains(base) else { return base }
         var suffix = 2
         while existingIds.contains("\(base)-\(suffix)") { suffix += 1 }

--- a/Lupen/Domain/AppStateStore.swift
+++ b/Lupen/Domain/AppStateStore.swift
@@ -70,7 +70,20 @@ final class AppStateStore: @unchecked Sendable {
 
     // MARK: - Private State
 
-    private(set) var activeProvider: ProviderKind = .claudeCode
+    /// The currently-projected session source — the authority for which
+    /// source's data is in `sessions` and is being verified/rendered. A
+    /// `SessionSource` (not a bare `ProviderKind`) so the store carries the
+    /// source's stable id and root, which the per-source DB / pipeline layers
+    /// consume. Today only built-in sources are ever active; the projection
+    /// swap maps a `ProviderKind` to its built-in source.
+    private(set) var activeSource: SessionSource
+
+    /// Parser kind of the active source. Read-only back-compat accessor over
+    /// `activeSource` — the many call sites that branch on Claude vs Codex
+    /// keep reading `activeProvider` unchanged; the authority moved to
+    /// `activeSource`. Observation still fires here because the getter reads
+    /// the observed `activeSource`.
+    var activeProvider: ProviderKind { activeSource.kind }
 
     private let claudeProvider: ClaudeProvider
 
@@ -94,6 +107,25 @@ final class AppStateStore: @unchecked Sendable {
         self.projectsDirectoryOverride = projectsDirectory
         self.claudeProvider = claudeProvider
         self.launchDiagnosticsConfig = launchDiagnosticsConfig
+        // Default active source = the Claude Code built-in. Roots are derived
+        // from the init params (not `self`'s computed accessors, which aren't
+        // usable until init completes); `effectiveProjectsDirectory` honours
+        // the test override the same way.
+        self.activeSource = SessionSourceRegistry.builtinSource(
+            for: .claudeCode,
+            claudeRoot: projectsDirectory ?? claudeProvider.defaultSourceRoot,
+            codexRoot: CodexProvider().defaultSourceRoot
+        )
+    }
+
+    /// The built-in source for `provider`, with roots faithful to what this
+    /// store scans (Claude honours the projects-directory test override).
+    private func builtinSource(for provider: ProviderKind) -> SessionSource {
+        SessionSourceRegistry.builtinSource(
+            for: provider,
+            claudeRoot: effectiveProjectsDirectory,
+            codexRoot: CodexProvider().defaultSourceRoot
+        )
     }
 
     private func scopedClaudeSessionId(_ sessionId: String) -> String {
@@ -122,7 +154,7 @@ final class AppStateStore: @unchecked Sendable {
     /// The legacy `switchProvider` graph capture/restore was deleted in
     /// Phase 5.1.
     func setActiveProviderForProjectionSwap(_ provider: ProviderKind) {
-        activeProvider = provider
+        activeSource = builtinSource(for: provider)
     }
 
     /// Public entry point for the active provider usage audit engine.
@@ -625,7 +657,7 @@ final class AppStateStore: @unchecked Sendable {
         isLoading: Bool,
         loadingProgress: String = ""
     ) {
-        activeProvider = provider
+        activeSource = builtinSource(for: provider)
         self.isLoading = isLoading
         self.loadingProgress = loadingProgress
         launchProgress = isLoading ? .transition(to: .scanningFiles) : .transition(to: .done)

--- a/Lupen/Domain/AppStateStore.swift
+++ b/Lupen/Domain/AppStateStore.swift
@@ -155,7 +155,15 @@ final class AppStateStore: @unchecked Sendable {
     /// The legacy `switchProvider` graph capture/restore was deleted in
     /// Phase 5.1.
     func setActiveProviderForProjectionSwap(_ provider: ProviderKind) {
-        activeSource = builtinSource(for: provider)
+        setActiveSourceForProjectionSwap(builtinSource(for: provider))
+    }
+
+    /// Projection swap to an arbitrary session source (built-in or not). The
+    /// driver layer flips which source's index is projected; this records the
+    /// active source so `activeProvider`, the per-source DB id, and the picker
+    /// selection all agree.
+    func setActiveSourceForProjectionSwap(_ source: SessionSource) {
+        activeSource = source
     }
 
     /// Public entry point for the active provider usage audit engine.

--- a/Lupen/Domain/AppStateStore.swift
+++ b/Lupen/Domain/AppStateStore.swift
@@ -114,17 +114,18 @@ final class AppStateStore: @unchecked Sendable {
         self.activeSource = SessionSourceRegistry.builtinSource(
             for: .claudeCode,
             claudeRoot: projectsDirectory ?? claudeProvider.defaultSourceRoot,
-            codexRoot: CodexProvider().defaultSourceRoot
+            codexRoot: CodexSessionDiscovery().codexHome
         )
     }
 
     /// The built-in source for `provider`, with roots faithful to what this
-    /// store scans (Claude honours the projects-directory test override).
+    /// store scans (Claude honours the projects-directory test override;
+    /// Codex's root is the codexHome, parent of sessions/).
     private func builtinSource(for provider: ProviderKind) -> SessionSource {
         SessionSourceRegistry.builtinSource(
             for: provider,
             claudeRoot: effectiveProjectsDirectory,
-            codexRoot: CodexProvider().defaultSourceRoot
+            codexRoot: CodexSessionDiscovery().codexHome
         )
     }
 

--- a/Lupen/Domain/Codex/CodexSessionDiscovery.swift
+++ b/Lupen/Domain/Codex/CodexSessionDiscovery.swift
@@ -12,7 +12,12 @@ struct CodexSessionDiscovery: Sendable {
             return codexHomeOverride
         }
         if let env = ProcessInfo.processInfo.environment["CODEX_HOME"], !env.isEmpty {
-            return URL(fileURLWithPath: env)
+            // Expand `~` and standardize so this matches the root that
+            // KnownSourceLocations derives for the same CODEX_HOME — otherwise
+            // a tilde'd value would make the built-in and the auto-detected
+            // Codex source point at differently-spelled paths and dodge the
+            // registry's root-dedup. A no-op for an already-absolute value.
+            return URL(fileURLWithPath: (env as NSString).expandingTildeInPath).standardizedFileURL
         }
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".codex")

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -182,6 +182,19 @@ final class ManageStore {
         load()
     }
 
+    /// Re-push the switcher's source list + active selection. The window is a
+    /// reused singleton, so sources added/removed/enabled in Settings (or a
+    /// new active source picked in the sidebar) between opens are applied here.
+    func updateSources(_ newSources: [SessionSource], active: SessionSource) {
+        guard newSources != sources || active.id != source.id else { return }
+        sources = newSources
+        source = active
+        selectedIDs = []
+        rows = []
+        diskItems = []
+        load()
+    }
+
     // MARK: - Load
 
     func load() {

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -43,6 +43,10 @@ final class ManageStore {
     private let contextProvider: @MainActor (SessionSource) -> ManageProviderContext?
     private let requestRescan: @MainActor (SessionSource) -> Void
     private let rebuildIndex: @MainActor (SessionSource) -> Void
+    /// Whether a live indexing driver exists for a source. Rebuild/rescan are
+    /// no-ops without one (only activated sources have a driver), so the UI
+    /// uses this to avoid offering an action that would silently do nothing.
+    private let hasLiveDriver: @MainActor (SessionSource) -> Bool
     /// Callback for AppKit views to receive updates (explicit, instead of @Observable auto-tracking).
     @ObservationIgnored var onChange: (@MainActor () -> Void)?
     private let scanService = ManageScanService()
@@ -58,7 +62,8 @@ final class ManageStore {
         storeProvider: @escaping @MainActor (SessionSource) -> ProviderStore?,
         contextProvider: @escaping @MainActor (SessionSource) -> ManageProviderContext?,
         requestRescan: @escaping @MainActor (SessionSource) -> Void,
-        rebuildIndex: @escaping @MainActor (SessionSource) -> Void
+        rebuildIndex: @escaping @MainActor (SessionSource) -> Void,
+        hasLiveDriver: @escaping @MainActor (SessionSource) -> Bool = { _ in true }
     ) {
         self.source = source
         self.sources = sources
@@ -67,7 +72,13 @@ final class ManageStore {
         self.contextProvider = contextProvider
         self.requestRescan = requestRescan
         self.rebuildIndex = rebuildIndex
+        self.hasLiveDriver = hasLiveDriver
     }
+
+    /// Whether the displayed source can be rebuilt/rescanned right now — i.e.
+    /// it has a live indexing driver. False for an enabled-but-never-activated
+    /// source shown via the read-only switcher.
+    var canManageIndex: Bool { hasLiveDriver(source) }
 
     // MARK: - Derived
 

--- a/Lupen/Domain/Manage/ManageStore.swift
+++ b/Lupen/Domain/Manage/ManageStore.swift
@@ -27,17 +27,22 @@ final class ManageStore {
     var scope: ManageScope = .sessions
     var selectedIDs: Set<String> = []
     private(set) var isScanning = false
-    private(set) var provider: ProviderKind
-    /// Whether the current provider is indexing (sessions are protected and blocked while indexing).
+    /// The session source currently shown. Keyed by its stable id for the
+    /// per-source index DB; `provider` (its kind) drives row tagging / copy.
+    private(set) var source: SessionSource
+    /// All sources offered in the window's switcher (the enabled set).
+    private(set) var sources: [SessionSource]
+    var provider: ProviderKind { source.kind }
+    /// Whether the current source is indexing (sessions are protected and blocked while indexing).
     var isIndexingNow: Bool { isIndexingProvider() }
     /// All-disk tab (read-only) entries — largest occupants first.
     private(set) var diskItems: [DiskSizer.Entry] = []
 
     private let isIndexingProvider: @MainActor () -> Bool
-    private let storeProvider: @MainActor (ProviderKind) -> ProviderStore?
-    private let contextProvider: @MainActor (ProviderKind) -> ManageProviderContext?
-    private let requestRescan: @MainActor (ProviderKind) -> Void
-    private let rebuildIndex: @MainActor (ProviderKind) -> Void
+    private let storeProvider: @MainActor (SessionSource) -> ProviderStore?
+    private let contextProvider: @MainActor (SessionSource) -> ManageProviderContext?
+    private let requestRescan: @MainActor (SessionSource) -> Void
+    private let rebuildIndex: @MainActor (SessionSource) -> Void
     /// Callback for AppKit views to receive updates (explicit, instead of @Observable auto-tracking).
     @ObservationIgnored var onChange: (@MainActor () -> Void)?
     private let scanService = ManageScanService()
@@ -47,14 +52,16 @@ final class ManageStore {
     private var scanFlag: ScanCancellationFlag?
 
     init(
-        provider: ProviderKind,
+        source: SessionSource,
+        sources: [SessionSource],
         isIndexingProvider: @escaping @MainActor () -> Bool,
-        storeProvider: @escaping @MainActor (ProviderKind) -> ProviderStore?,
-        contextProvider: @escaping @MainActor (ProviderKind) -> ManageProviderContext?,
-        requestRescan: @escaping @MainActor (ProviderKind) -> Void,
-        rebuildIndex: @escaping @MainActor (ProviderKind) -> Void
+        storeProvider: @escaping @MainActor (SessionSource) -> ProviderStore?,
+        contextProvider: @escaping @MainActor (SessionSource) -> ManageProviderContext?,
+        requestRescan: @escaping @MainActor (SessionSource) -> Void,
+        rebuildIndex: @escaping @MainActor (SessionSource) -> Void
     ) {
-        self.provider = provider
+        self.source = source
+        self.sources = sources
         self.isIndexingProvider = isIndexingProvider
         self.storeProvider = storeProvider
         self.contextProvider = contextProvider
@@ -108,17 +115,17 @@ final class ManageStore {
 
     /// Per-provider storage directory used by Reveal in the manage window.
     var providerSupportRoot: URL {
-        LupenPaths.providerRoot(for: provider)
+        LupenPaths.providerRoot(forSourceId: source.id)
     }
 
     func loadCacheInfo() {
         let root = LupenPaths.applicationSupportRoot()
-        let indexURL = LupenPaths.indexDatabaseURL(for: provider, appSupportRoot: root)
+        let indexURL = LupenPaths.indexDatabaseURL(forSourceId: source.id, appSupportRoot: root)
         let indexBytes = DiskSizer.fileAllocatedSize(indexURL)
         let walBytes = DiskSizer.fileAllocatedSize(URL(fileURLWithPath: indexURL.path + "-wal"))
         let shmBytes = DiskSizer.fileAllocatedSize(URL(fileURLWithPath: indexURL.path + "-shm"))
         let snapshotBytes = snapshotURLs(root: root).reduce(Int64(0)) { $0 + DiskSizer.fileAllocatedSize($1) }
-        let coverage = try? storeProvider(provider)?.coverage()
+        let coverage = try? storeProvider(source)?.coverage()
         let lastIndexed = (try? FileManager.default.attributesOfItem(atPath: indexURL.path))?[.modificationDate] as? Date
         cacheInfo = CacheInfo(
             indexBytes: indexBytes, walBytes: walBytes, shmBytes: shmBytes,
@@ -128,7 +135,7 @@ final class ManageStore {
 
     /// Rebuild the index (original logs untouched) — reuses the existing rebuild path.
     func rebuildCacheIndex() {
-        rebuildIndex(provider)
+        rebuildIndex(source)
         loadCacheInfo()
     }
 
@@ -142,9 +149,9 @@ final class ManageStore {
     }
 
     private func snapshotURLs(root: URL) -> [URL] {
-        [LupenPaths.sessionCacheURL(for: provider, appSupportRoot: root),
-         LupenPaths.parseSnapshotURL(for: provider, appSupportRoot: root),
-         LupenPaths.offsetsURL(for: provider, appSupportRoot: root)]
+        [LupenPaths.sessionCacheURL(forSourceId: source.id, appSupportRoot: root),
+         LupenPaths.parseSnapshotURL(forSourceId: source.id, appSupportRoot: root),
+         LupenPaths.offsetsURL(forSourceId: source.id, appSupportRoot: root)]
     }
 
     // MARK: - Selection
@@ -164,12 +171,12 @@ final class ManageStore {
         onChange?()
     }
 
-    func switchProvider(_ newProvider: ProviderKind) {
-        guard newProvider != provider else { return }
-        provider = newProvider
+    func switchSource(_ newSource: SessionSource) {
+        guard newSource.id != source.id else { return }
+        source = newSource
         selectedIDs = []
-        // Clear the previous provider's rows immediately to avoid a flicker
-        // of wrong-provider data before the async load's first render.
+        // Clear the previous source's rows immediately to avoid a flicker
+        // of wrong-source data before the async load's first render.
         rows = []
         diskItems = []
         load()
@@ -178,7 +185,7 @@ final class ManageStore {
     // MARK: - Load
 
     func load() {
-        guard let store = storeProvider(provider), let context = contextProvider(provider) else {
+        guard let store = storeProvider(source), let context = contextProvider(source) else {
             rows = []
             diskItems = []
             cacheInfo = nil
@@ -245,7 +252,7 @@ final class ManageStore {
     func trash(rows: [ManageRowModel]) async -> ManageTrashService.Outcome {
         let outcome = await trashService.trash(rows.flatMap(\.trashTargets))
         let trashed = Set(outcome.trashedPaths)
-        if let store = storeProvider(provider) {
+        if let store = storeProvider(source) {
             var indexPaths: [String] = []
             // Only prune the whole session's index for rows whose parent file
             // (jsonl) actually went to the Trash. If only the companion
@@ -271,7 +278,7 @@ final class ManageStore {
     /// Undo — restore from the Trash, trigger index re-registration (rescan), then re-render.
     func undoTrash(_ entries: [ManageTrashService.RestoreEntry]) async {
         await trashService.restore(entries)
-        requestRescan(provider)
+        requestRescan(source)
         load()
     }
 

--- a/Lupen/Domain/Providers/KnownSourceLocations.swift
+++ b/Lupen/Domain/Providers/KnownSourceLocations.swift
@@ -25,7 +25,7 @@ enum KnownSourceLocations {
         fileManager: FileManager = .default
     ) -> [SessionSource] {
         candidateTable(environment: environment, home: home).compactMap { candidate in
-            guard isReadableDirectory(candidate.root, fileManager: fileManager) else { return nil }
+            guard isReadableDirectory(candidate.probe, fileManager: fileManager) else { return nil }
             return SessionSource(
                 id: candidate.id,
                 name: candidate.name,
@@ -41,7 +41,16 @@ enum KnownSourceLocations {
         let id: String
         let name: String
         let kind: ProviderKind
+        /// The base directory the pipeline indexes. For Claude this is the
+        /// `projects` directory it scans directly; for Codex it is the
+        /// `codexHome` (parent of `sessions/`), because the importer also
+        /// reads `session_index.jsonl` from that parent.
         let root: URL
+        /// The directory whose existence gates inclusion. Defaults to `root`;
+        /// Codex probes `root/sessions` so a bare `$CODEX_HOME` without any
+        /// recorded sessions isn't surfaced.
+        var existenceProbe: URL? = nil
+        var probe: URL { existenceProbe ?? root }
     }
 
     private static func candidateTable(environment: [String: String], home: URL) -> [Candidate] {
@@ -64,11 +73,13 @@ enum KnownSourceLocations {
             ))
         }
         if let dir = trimmedEnv(environment["CODEX_HOME"]) {
+            let codexHome = expand(dir)
             rows.append(Candidate(
                 id: "codex-home",
                 name: "CODEX_HOME",
                 kind: .codex,
-                root: expand(dir).appendingPathComponent("sessions")
+                root: codexHome,
+                existenceProbe: codexHome.appendingPathComponent("sessions")
             ))
         }
         return rows

--- a/Lupen/Domain/Providers/KnownSourceLocations.swift
+++ b/Lupen/Domain/Providers/KnownSourceLocations.swift
@@ -1,0 +1,90 @@
+//
+//  KnownSourceLocations.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Foundation
+
+/// Auto-detection of well-known session-log locations beyond the two built-in
+/// defaults (`~/.claude/projects`, `~/.codex/sessions`).
+///
+/// Detected sources are returned **disabled** — the user explicitly activates
+/// them in Settings (whitelist model), so nothing is indexed without consent.
+/// Pure and fully injectable (`environment`/`home`/`fileManager`) for tests.
+/// Extend coverage by adding a row to `candidateTable`.
+enum KnownSourceLocations {
+
+    /// Existing, readable candidate directories, each as a disabled
+    /// `.autoDetected` source. Built-in default roots are intentionally NOT
+    /// returned here (they are injected separately as `.builtin`).
+    static func detect(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> [SessionSource] {
+        candidateTable(environment: environment, home: home).compactMap { candidate in
+            guard isReadableDirectory(candidate.root, fileManager: fileManager) else { return nil }
+            return SessionSource(
+                id: candidate.id,
+                name: candidate.name,
+                kind: candidate.kind,
+                root: candidate.root,
+                origin: .autoDetected,
+                enabled: false
+            )
+        }
+    }
+
+    private struct Candidate {
+        let id: String
+        let name: String
+        let kind: ProviderKind
+        let root: URL
+    }
+
+    private static func candidateTable(environment: [String: String], home: URL) -> [Candidate] {
+        var rows: [Candidate] = [
+            Candidate(
+                id: "xcode-claude",
+                name: "Xcode Claude",
+                kind: .claudeCode,
+                root: home.appendingPathComponent(
+                    "Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/projects"
+                )
+            )
+        ]
+        if let dir = trimmedEnv(environment["CLAUDE_CONFIG_DIR"]) {
+            rows.append(Candidate(
+                id: "claude-config-dir",
+                name: "CLAUDE_CONFIG_DIR",
+                kind: .claudeCode,
+                root: expand(dir).appendingPathComponent("projects")
+            ))
+        }
+        if let dir = trimmedEnv(environment["CODEX_HOME"]) {
+            rows.append(Candidate(
+                id: "codex-home",
+                name: "CODEX_HOME",
+                kind: .codex,
+                root: expand(dir).appendingPathComponent("sessions")
+            ))
+        }
+        return rows
+    }
+
+    private static func trimmedEnv(_ value: String?) -> String? {
+        guard let v = value?.trimmingCharacters(in: .whitespacesAndNewlines), !v.isEmpty else { return nil }
+        return v
+    }
+
+    private static func expand(_ path: String) -> URL {
+        URL(fileURLWithPath: (path as NSString).expandingTildeInPath).standardizedFileURL
+    }
+
+    private static func isReadableDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+    }
+}

--- a/Lupen/Domain/Providers/LupenPaths.swift
+++ b/Lupen/Domain/Providers/LupenPaths.swift
@@ -22,37 +22,99 @@ enum LupenPaths {
             .appendingPathComponent("Lupen")
     }
 
+    // MARK: - Source-id-keyed paths (multi-source)
+
+    /// Per-source on-disk root, keyed by the source's stable id. Built-in
+    /// source ids equal `ProviderKind.rawValue`, so a built-in source resolves
+    /// to the same `providers/<rawValue>` folder the app has always used — the
+    /// multi-source model adds sibling folders without disturbing existing ones.
     static func providerRoot(
-        for provider: ProviderKind,
+        forSourceId sourceId: String,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
         appSupportRoot
             .appendingPathComponent("providers")
-            .appendingPathComponent(provider.rawValue)
+            .appendingPathComponent(sourceId)
+    }
+
+    static func sessionCacheURL(
+        forSourceId sourceId: String,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: sourceId, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("session_cache.json")
+    }
+
+    static func parseSnapshotURL(
+        forSourceId sourceId: String,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: sourceId, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("parse_snapshot.json")
+    }
+
+    static func offsetsURL(
+        forSourceId sourceId: String,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: sourceId, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("offsets.json")
+    }
+
+    /// Per-source SQLite index database (SQLite-first refactor,
+    /// docs/Research/2026-06-10-sqlite-first-refactor). One file per source
+    /// keeps lifecycles independent and makes the rebuild-on-version-bump
+    /// policy a per-source wipe.
+    static func indexDatabaseURL(
+        forSourceId sourceId: String,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: sourceId, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("index.sqlite3")
+    }
+
+    /// Advisory lock file the CLI holds while refreshing this source's index,
+    /// so two `lupen` runs don't index in parallel.
+    static func refreshLockURL(
+        forSourceId sourceId: String,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: sourceId, appSupportRoot: appSupportRoot)
+            .appendingPathComponent("refresh.lock")
+    }
+
+    // MARK: - ProviderKind convenience (built-in sources)
+    //
+    // Each delegates to the source-id variant using the kind's rawValue (==
+    // the built-in source id), so existing call sites are unchanged and the
+    // resulting paths are byte-identical to the pre-multi-source layout.
+
+    static func providerRoot(
+        for provider: ProviderKind,
+        appSupportRoot: URL = applicationSupportRoot()
+    ) -> URL {
+        providerRoot(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 
     static func sessionCacheURL(
         for provider: ProviderKind,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
-        providerRoot(for: provider, appSupportRoot: appSupportRoot)
-            .appendingPathComponent("session_cache.json")
+        sessionCacheURL(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 
     static func parseSnapshotURL(
         for provider: ProviderKind,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
-        providerRoot(for: provider, appSupportRoot: appSupportRoot)
-            .appendingPathComponent("parse_snapshot.json")
+        parseSnapshotURL(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 
     static func offsetsURL(
         for provider: ProviderKind,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
-        providerRoot(for: provider, appSupportRoot: appSupportRoot)
-            .appendingPathComponent("offsets.json")
+        offsetsURL(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 
     static func codexUsageSnapshotURL(
@@ -62,25 +124,17 @@ enum LupenPaths {
             .appendingPathComponent("usage_snapshot.json")
     }
 
-    /// Per-provider SQLite index database (SQLite-first refactor,
-    /// docs/Research/2026-06-10-sqlite-first-refactor). One file per
-    /// provider keeps lifecycles independent and makes the
-    /// rebuild-on-version-bump policy a per-provider wipe.
     static func indexDatabaseURL(
         for provider: ProviderKind,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
-        providerRoot(for: provider, appSupportRoot: appSupportRoot)
-            .appendingPathComponent("index.sqlite3")
+        indexDatabaseURL(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 
-    /// Advisory lock file the CLI holds while refreshing this provider's
-    /// index, so two `lupen` runs don't index in parallel.
     static func refreshLockURL(
         for provider: ProviderKind,
         appSupportRoot: URL = applicationSupportRoot()
     ) -> URL {
-        providerRoot(for: provider, appSupportRoot: appSupportRoot)
-            .appendingPathComponent("refresh.lock")
+        refreshLockURL(forSourceId: provider.rawValue, appSupportRoot: appSupportRoot)
     }
 }

--- a/Lupen/Domain/Providers/SessionSource.swift
+++ b/Lupen/Domain/Providers/SessionSource.swift
@@ -1,0 +1,102 @@
+//
+//  SessionSource.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Foundation
+
+/// One indexing instance: a single root directory parsed with a given
+/// `ProviderKind`. Multiple sources may share a kind — e.g. the default
+/// `~/.claude/projects` and an Xcode Coding Assistant path are two Claude
+/// sources, each indexed in isolation (its own `providers/<id>/index.sqlite3`).
+///
+/// `id` is the stable slug — the on-disk index-folder name and the CLI query
+/// key — and must never change once created. `name` is the user-facing label
+/// (mode picker, CLI `--provider`); it is editable but must stay unique.
+///
+/// Persisted in `app_settings.json` under `sessionSources`. Built-in sources
+/// and auto-detected candidates are injected at runtime, so this list only
+/// needs to carry the user's overrides (added sources + enable/name changes);
+/// an empty list means "defaults only".
+struct SessionSource: Identifiable, Codable, Equatable, Sendable {
+
+    /// Where the source came from — drives default-enabled and removability.
+    enum Origin: String, Codable, Sendable {
+        case builtin        // Claude Code / Codex defaults — always present
+        case autoDetected   // from KnownSourceLocations — disabled until activated
+        case userAdded      // a folder the user registered
+    }
+
+    /// Stable identity / index-folder slug. Unique across sources and (like
+    /// `ProviderID`) must not contain the `ProviderScopedID` separator.
+    let id: String
+    /// User-facing, editable label. Unique across sources.
+    var name: String
+    /// Parser/format. Two kinds only (claude/codex); each source picks one.
+    let kind: ProviderKind
+    /// Single root directory (standardized at init). Identity is the
+    /// standardized path, not the resolved inode — two symlinked paths to the
+    /// same directory are treated as distinct sources.
+    let root: URL
+    let origin: Origin
+    /// Whitelist flag — only enabled sources are indexed and shown.
+    var enabled: Bool
+
+    /// `id` validity: non-empty and free of the `ProviderScopedID` separator
+    /// (`:`), since `id` becomes the on-disk index-folder slug and CLI key.
+    /// Mirrors `ProviderID`'s constraint.
+    static func isValidID(_ id: String) -> Bool {
+        !id.isEmpty && !id.contains(ProviderScopedID.separator)
+    }
+
+    /// Normalize a root to a directory-hint-free, standardized file URL so that
+    /// `encode(path)` → `decode(fileURLWithPath:)` round-trips identically. A
+    /// trailing slash on a directory URL would otherwise be lost on the path
+    /// round-trip, making the re-decoded source compare unequal to the original.
+    static func normalizedRoot(_ url: URL) -> URL {
+        URL(fileURLWithPath: url.standardizedFileURL.path)
+    }
+
+    init(id: String, name: String, kind: ProviderKind, root: URL, origin: Origin, enabled: Bool) {
+        precondition(Self.isValidID(id), "SessionSource.id must be non-empty and must not contain ':'")
+        self.id = id
+        self.name = name
+        self.kind = kind
+        self.root = Self.normalizedRoot(root)
+        self.origin = origin
+        self.enabled = enabled
+    }
+
+    // `root` is encoded as a plain filesystem path (not URL's default
+    // `file://…` form) so `app_settings.json` stays human-readable and diffable.
+    enum CodingKeys: String, CodingKey { case id, name, kind, root, origin, enabled }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedId = try c.decode(String.self, forKey: .id)
+        guard Self.isValidID(decodedId) else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Invalid SessionSource id: \(decodedId)"
+            ))
+        }
+        self.id = decodedId
+        self.name = try c.decode(String.self, forKey: .name)
+        self.kind = try c.decode(ProviderKind.self, forKey: .kind)
+        self.root = Self.normalizedRoot(URL(fileURLWithPath: try c.decode(String.self, forKey: .root)))
+        self.origin = try c.decode(Origin.self, forKey: .origin)
+        self.enabled = try c.decode(Bool.self, forKey: .enabled)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(kind, forKey: .kind)
+        try c.encode(root.path, forKey: .root)
+        try c.encode(origin, forKey: .origin)
+        try c.encode(enabled, forKey: .enabled)
+    }
+}

--- a/Lupen/Domain/Providers/SessionSourceInference.swift
+++ b/Lupen/Domain/Providers/SessionSourceInference.swift
@@ -1,0 +1,110 @@
+//
+//  SessionSourceInference.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Foundation
+
+/// Pure helpers behind the "add a folder" flow in Settings ▸ Session Sources
+/// (plan §4.4): infer the parser kind and the source root from a folder the
+/// user picked, suggest a display name, and validate name/path uniqueness.
+/// Kept free of AppKit so the inference rules are unit-testable.
+enum SessionSourceInference {
+
+    struct Inference: Equatable {
+        let kind: ProviderKind
+        /// The normalized base directory the pipeline will index — for Codex
+        /// the codexHome (parent of `sessions/`), for Claude the `projects`
+        /// directory it scans directly.
+        let root: URL
+    }
+
+    /// Infer `(kind, root)` from a picked folder using directory structure.
+    /// Returns nil when the layout is ambiguous so the caller can ask the user
+    /// to choose the kind explicitly.
+    ///
+    /// Codex's root is the codexHome, so picking either the codexHome (which
+    /// contains `sessions/`) or the `sessions/` directory itself resolves to
+    /// the codexHome. Claude's root is the `projects` directory, so picking a
+    /// config directory that contains `projects/` resolves into it.
+    static func infer(
+        fromPickedFolder picked: URL,
+        fileManager: FileManager = .default
+    ) -> Inference? {
+        let dir = picked.standardizedFileURL
+        let name = dir.lastPathComponent.lowercased()
+
+        func hasSubdirectory(_ component: String) -> Bool {
+            isReadableDirectory(dir.appendingPathComponent(component), fileManager: fileManager)
+        }
+
+        // Codex: a codexHome holds `sessions/` (and session_index.jsonl).
+        if hasSubdirectory("sessions") {
+            return Inference(kind: .codex, root: normalized(dir))
+        }
+        if name == "sessions" {
+            return Inference(kind: .codex, root: normalized(dir.deletingLastPathComponent()))
+        }
+        // Claude: the pipeline scans the `projects` directory directly.
+        if name == "projects" {
+            return Inference(kind: .claudeCode, root: normalized(dir))
+        }
+        if hasSubdirectory("projects") {
+            return Inference(kind: .claudeCode, root: normalized(dir.appendingPathComponent("projects")))
+        }
+        return nil
+    }
+
+    /// Suggest an editable display name from the source root. Prefers the most
+    /// distinctive ancestor directory (skipping generic tokens like `projects`,
+    /// `.claude`, the user's home) combined with the kind's short label, e.g.
+    /// `…/Xcode/CodingAssistant/ClaudeAgentConfig/projects` → "ClaudeAgentConfig
+    /// Claude". Falls back to the kind's display name.
+    static func suggestName(forRoot root: URL, kind: ProviderKind) -> String {
+        let label = ProviderRegistry.descriptor(for: kind).shortDisplayName
+        let generic: Set<String> = [
+            "/", "projects", "sessions", ".claude", ".codex", "users", "library",
+        ]
+        let distinctive = root.standardizedFileURL.pathComponents
+            .reversed()
+            .first { component in
+                let lower = component.lowercased()
+                return !generic.contains(lower)
+                    && !component.hasPrefix(".")
+                    && component.count > 1
+            }
+        guard let distinctive else { return label }
+        return "\(distinctive) \(label)"
+    }
+
+    /// Make `base` unique against `existingNames` by appending " 2", " 3", ….
+    /// Case-sensitive (names are user-facing labels). Returns `base` unchanged
+    /// when it's already unique.
+    static func uniqueName(_ base: String, existingNames: [String]) -> String {
+        let taken = Set(existingNames)
+        guard taken.contains(base) else { return base }
+        var suffix = 2
+        while taken.contains("\(base) \(suffix)") { suffix += 1 }
+        return "\(base) \(suffix)"
+    }
+
+    /// The existing source whose normalized root equals `root`, if any —
+    /// used to warn "already registered" before adding a duplicate path.
+    static func duplicateRootSource(_ root: URL, in sources: [SessionSource]) -> SessionSource? {
+        let normalizedPath = SessionSource.normalizedRoot(root).path
+        return sources.first { $0.root.path == normalizedPath }
+    }
+
+    // MARK: - Helpers
+
+    private static func normalized(_ url: URL) -> URL {
+        SessionSource.normalizedRoot(url)
+    }
+
+    private static func isReadableDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+    }
+}

--- a/Lupen/Domain/Providers/SessionSourceRegistry.swift
+++ b/Lupen/Domain/Providers/SessionSourceRegistry.swift
@@ -126,7 +126,9 @@ enum SessionSourceRegistry {
     static func resolve(
         saved: [SessionSource],
         claudeRoot: URL = ClaudeProvider().defaultSourceRoot,
-        codexRoot: URL = CodexProvider().defaultSourceRoot,
+        // Codex's root is the codexHome (parent of sessions/), since the
+        // importer reads session_index.jsonl from there too.
+        codexRoot: URL = CodexSessionDiscovery().codexHome,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         home: URL = FileManager.default.homeDirectoryForCurrentUser,
         fileManager: FileManager = .default

--- a/Lupen/Domain/Providers/SessionSourceRegistry.swift
+++ b/Lupen/Domain/Providers/SessionSourceRegistry.swift
@@ -1,0 +1,145 @@
+//
+//  SessionSourceRegistry.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Foundation
+
+/// Single source of truth for the *canonical, ordered* list of session
+/// sources the app knows about. It overlays three layers:
+///
+///   1. **builtins** — Claude Code / Codex defaults, always present, enabled.
+///   2. **auto-detected** — `KnownSourceLocations.detect()` candidates,
+///      disabled until the user activates them (whitelist model).
+///   3. **saved overrides** — `AppSettings.sessionSources`: the user's
+///      enable/name changes to the above, plus any folders they added.
+///
+/// The picker, indexing driver set, and active-source resolution all read
+/// from this one composition so they never disagree about which sources
+/// exist or are active.
+///
+/// Pure and fully injectable — `compose` takes the three layers directly so
+/// the merge policy is unit-testable without touching disk or environment.
+enum SessionSourceRegistry {
+
+    /// Built-in source ids equal `ProviderKind.rawValue` so each maps to its
+    /// pre-existing index folder (`providers/<id>/index.sqlite3`) — upgrading
+    /// to the multi-source model re-uses the current index with no rebuild.
+    static var claudeBuiltinID: String { ProviderKind.claudeCode.rawValue }
+    static var codexBuiltinID: String { ProviderKind.codex.rawValue }
+
+    /// The two always-present built-in sources, enabled by default. Roots are
+    /// injected (the real defaults are env-aware via the providers), so the
+    /// builtin source's root stays faithful to what the pipeline scans.
+    static func builtins(claudeRoot: URL, codexRoot: URL) -> [SessionSource] {
+        [
+            SessionSource(
+                id: claudeBuiltinID,
+                name: ProviderRegistry.descriptor(for: .claudeCode).displayName,
+                kind: .claudeCode,
+                root: claudeRoot,
+                origin: .builtin,
+                enabled: true
+            ),
+            SessionSource(
+                id: codexBuiltinID,
+                name: ProviderRegistry.descriptor(for: .codex).displayName,
+                kind: .codex,
+                root: codexRoot,
+                origin: .builtin,
+                enabled: true
+            ),
+        ]
+    }
+
+    /// Compose the canonical list: code-provided candidates first (builtins,
+    /// then auto-detected, order preserved), each overlaid with the user's
+    /// saved `name`/`enabled` if present; then any saved sources that aren't
+    /// code candidates (the user-added folders) appended in saved order.
+    ///
+    /// Merge contract for candidates: **code owns identity** (`kind`/`root`/
+    /// `origin`) since a builtin/detected path can move between releases,
+    /// while the **user owns `name` and `enabled`** (their desired state, as
+    /// last persisted).
+    ///
+    /// Two uniqueness invariants hold on the output, both resolved by
+    /// emission order (builtin > detected > user-added):
+    ///   - **unique id** — a repeated id collapses to its first occurrence.
+    ///   - **unique root** — two sources must never point at the same
+    ///     normalized directory, or that directory would be indexed twice.
+    ///     This matters because the builtins' roots are env-aware
+    ///     (`$CLAUDE_CONFIG_DIR`/`$CODEX_HOME`), so a detected candidate
+    ///     (or a user-added folder) can resolve to a builtin's root under a
+    ///     different id; the builtin wins and the duplicate is dropped.
+    static func compose(
+        builtins: [SessionSource],
+        detected: [SessionSource],
+        saved: [SessionSource]
+    ) -> [SessionSource] {
+        let savedByID = Dictionary(saved.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var result: [SessionSource] = []
+        var emittedIDs = Set<String>()
+        var emittedRoots = Set<String>()
+
+        // Append a source unless its id or root was already emitted. Earlier
+        // layers win, so builtins are never dropped in favour of a detected
+        // or user-added collision.
+        func emit(_ source: SessionSource) {
+            guard !emittedIDs.contains(source.id),
+                  !emittedRoots.contains(source.root.path) else { return }
+            emittedIDs.insert(source.id)
+            emittedRoots.insert(source.root.path)
+            result.append(source)
+        }
+
+        for candidate in builtins + detected {
+            if let override = savedByID[candidate.id] {
+                var merged = candidate
+                merged.name = override.name
+                merged.enabled = override.enabled
+                emit(merged)
+            } else {
+                emit(candidate)
+            }
+        }
+
+        // Saved entries with no matching candidate are the user's added
+        // folders (or a once-detected source whose path is no longer present).
+        for source in saved where !emittedIDs.contains(source.id) {
+            emit(source)
+        }
+
+        return result
+    }
+
+    /// App-facing convenience: wire the real builtins, auto-detection, and the
+    /// user's saved overrides into one composed list. Roots/environment are
+    /// injectable for tests; defaults use the live providers and process env.
+    static func resolve(
+        saved: [SessionSource],
+        claudeRoot: URL = ClaudeProvider().defaultSourceRoot,
+        codexRoot: URL = CodexProvider().defaultSourceRoot,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> [SessionSource] {
+        compose(
+            builtins: builtins(claudeRoot: claudeRoot, codexRoot: codexRoot),
+            detected: KnownSourceLocations.detect(
+                environment: environment, home: home, fileManager: fileManager
+            ),
+            saved: saved
+        )
+    }
+}
+
+extension Array where Element == SessionSource {
+    /// Whitelist projection — only enabled sources are indexed and shown in
+    /// the mode picker.
+    var enabledSources: [SessionSource] { filter(\.enabled) }
+
+    /// First source whose stable id matches, or nil.
+    func source(id: String) -> SessionSource? { first { $0.id == id } }
+}

--- a/Lupen/Domain/Providers/SessionSourceRegistry.swift
+++ b/Lupen/Domain/Providers/SessionSourceRegistry.swift
@@ -30,27 +30,33 @@ enum SessionSourceRegistry {
     static var claudeBuiltinID: String { ProviderKind.claudeCode.rawValue }
     static var codexBuiltinID: String { ProviderKind.codex.rawValue }
 
-    /// The two always-present built-in sources, enabled by default. Roots are
-    /// injected (the real defaults are env-aware via the providers), so the
-    /// builtin source's root stays faithful to what the pipeline scans.
-    static func builtins(claudeRoot: URL, codexRoot: URL) -> [SessionSource] {
-        [
-            SessionSource(
+    /// The single built-in source for a parser kind. Used both as the default
+    /// active source and as the projection-swap target while only built-in
+    /// sources are activatable. Enabled by default; id equals the kind's
+    /// rawValue (see above). Root is injected so it stays faithful to the
+    /// env-aware default the pipeline actually scans.
+    static func builtinSource(for kind: ProviderKind, claudeRoot: URL, codexRoot: URL) -> SessionSource {
+        switch kind {
+        case .claudeCode:
+            return SessionSource(
                 id: claudeBuiltinID,
                 name: ProviderRegistry.descriptor(for: .claudeCode).displayName,
-                kind: .claudeCode,
-                root: claudeRoot,
-                origin: .builtin,
-                enabled: true
-            ),
-            SessionSource(
+                kind: .claudeCode, root: claudeRoot, origin: .builtin, enabled: true
+            )
+        case .codex:
+            return SessionSource(
                 id: codexBuiltinID,
                 name: ProviderRegistry.descriptor(for: .codex).displayName,
-                kind: .codex,
-                root: codexRoot,
-                origin: .builtin,
-                enabled: true
-            ),
+                kind: .codex, root: codexRoot, origin: .builtin, enabled: true
+            )
+        }
+    }
+
+    /// The two always-present built-in sources, enabled by default.
+    static func builtins(claudeRoot: URL, codexRoot: URL) -> [SessionSource] {
+        [
+            builtinSource(for: .claudeCode, claudeRoot: claudeRoot, codexRoot: codexRoot),
+            builtinSource(for: .codex, claudeRoot: claudeRoot, codexRoot: codexRoot),
         ]
     }
 

--- a/Lupen/Store/ProviderIndexCoordinator.swift
+++ b/Lupen/Store/ProviderIndexCoordinator.swift
@@ -18,6 +18,18 @@ enum ProviderIndexSource: Sendable, Equatable {
         case .codex: return .codex
         }
     }
+
+    /// Build the index source a session source feeds the pipeline: the
+    /// scanner reads `source.root` keyed by `source.kind` — Claude scans the
+    /// projects directory directly, Codex uses the codexHome (parent of
+    /// `sessions/`, also holding `session_index.jsonl`). `SessionSource.root`
+    /// already carries the right base directory per kind, so no derivation.
+    init(_ source: SessionSource) {
+        switch source.kind {
+        case .claudeCode: self = .claude(projectsDirectory: source.root)
+        case .codex: self = .codex(codexHome: source.root)
+        }
+    }
 }
 
 /// Events a coordinator delivers to the main actor (plan §5: progress /

--- a/Lupen/Store/SQLiteFirstStartup.swift
+++ b/Lupen/Store/SQLiteFirstStartup.swift
@@ -103,14 +103,22 @@ final class SQLiteFirstStartup: @unchecked Sendable {
     init(
         source: ProviderIndexSource,
         appStore: AppStateStore,
+        sourceId: String? = nil,
         databaseURL: URL? = nil,
+        appSupportRoot: URL = LupenPaths.applicationSupportRoot(),
         refreshThrottle: TimeInterval = 0.5,
         rescanDebounce: TimeInterval = 0.5,
         isFileWatchingEnabled: Bool = true
     ) throws {
-        let resolvedURL = databaseURL ?? LupenPaths
-            .providerRoot(for: source.provider)
-            .appendingPathComponent("index.sqlite3")
+        // The index DB folder is keyed by the session source's stable id so
+        // sibling sources index in isolation. Defaulting to the provider's
+        // rawValue (== the built-in source id) keeps a built-in launch on its
+        // existing `providers/<rawValue>/index.sqlite3` file — byte-identical
+        // to the pre-multi-source layout, no rebuild.
+        let resolvedSourceId = sourceId ?? source.provider.rawValue
+        let resolvedURL = databaseURL ?? LupenPaths.indexDatabaseURL(
+            forSourceId: resolvedSourceId, appSupportRoot: appSupportRoot
+        )
         try FileManager.default.createDirectory(
             at: resolvedURL.deletingLastPathComponent(),
             withIntermediateDirectories: true

--- a/Lupen/UI/Dashboard/SessionListViewController.swift
+++ b/Lupen/UI/Dashboard/SessionListViewController.swift
@@ -420,15 +420,9 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
         providerModeControl.imagePosition = .imageLeading
         providerModeControl.setAccessibilityLabel("Provider mode")
         providerModeControl.toolTip = "Select provider mode"
-        providerModeControl.removeAllItems()
-        for provider in ProviderRegistry.all {
-            let item = NSMenuItem(title: provider.displayName, action: nil, keyEquivalent: "")
-            item.representedObject = provider.kind.rawValue
-            item.toolTip = provider.displayName
-            item.image = Self.providerModeImage(for: provider)
-            providerModeControl.menu?.addItem(item)
-        }
+        rebuildProviderModeMenu()
         updateProviderModeControlSelection()
+        startObservingSourceList()
 
         providerModeControl.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(providerModeControl)
@@ -555,32 +549,58 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
             : .secondaryLabelColor
     }
 
-    private func updateProviderModeControlSelection() {
-        guard let index = ProviderRegistry.all.firstIndex(where: { $0.kind == settings.activeProvider }) else {
-            return
+    /// Build the mode popup from the enabled session sources (plan §4.5 —
+    /// the picker SSOT is the active source list, not `ProviderRegistry.all`).
+    /// Each item carries the source id; the kind drives the leading icon.
+    private func rebuildProviderModeMenu() {
+        providerModeControl.removeAllItems()
+        for source in settings.enabledResolvedSources {
+            let descriptor = ProviderRegistry.descriptor(for: source.kind)
+            let item = NSMenuItem(title: source.name, action: nil, keyEquivalent: "")
+            item.representedObject = source.id
+            item.toolTip = "\(source.name) — \(source.root.path)"
+            item.image = Self.providerModeImage(for: descriptor)
+            providerModeControl.menu?.addItem(item)
         }
+    }
+
+    /// Re-arm a one-shot observation of the source list so the popup rebuilds
+    /// when a source is added / activated / renamed (same pattern as the
+    /// sidebar's `startObserving`).
+    private func startObservingSourceList() {
+        withObservationTracking {
+            _ = settings.resolvedSources
+        } onChange: { [weak self] in
+            DispatchQueue.main.async {
+                self?.rebuildProviderModeMenu()
+                self?.updateProviderModeControlSelection()
+                self?.startObservingSourceList()
+            }
+        }
+    }
+
+    private func updateProviderModeControlSelection() {
+        let sources = settings.enabledResolvedSources
+        guard !sources.isEmpty else { return }
+        let index = sources.firstIndex { $0.id == settings.activeSourceId } ?? 0
         providerModeControl.selectItem(at: index)
-        applyProviderModeVisuals(for: ProviderRegistry.all[index])
+        let source = sources[index]
+        applyProviderModeVisuals(name: source.name, kind: source.kind)
     }
 
     @objc private func providerModeChanged(_ sender: NSPopUpButton) {
-        if let rawValue = sender.selectedItem?.representedObject as? String,
-           let provider = ProviderKind(rawValue: rawValue) {
-            settings.activeProvider = provider
-            return
-        }
-        let index = sender.indexOfSelectedItem
-        guard ProviderRegistry.all.indices.contains(index) else { return }
-        settings.activeProvider = ProviderRegistry.all[index].kind
+        guard let id = sender.selectedItem?.representedObject as? String else { return }
+        settings.setActiveSource(id: id)
     }
 
-    private func applyProviderModeVisuals(for provider: ProviderDescriptor) {
-        let accent = Self.providerModeAccentColor(for: provider.kind)
+    private func applyProviderModeVisuals(name: String, kind: ProviderKind) {
+        let descriptor = ProviderRegistry.descriptor(for: kind)
+        let accent = Self.providerModeAccentColor(for: kind)
         providerModeControl.accentColor = accent
-        providerModeControl.image = Self.providerModeImage(for: provider)
+        providerModeControl.image = Self.providerModeImage(for: descriptor)
         providerModeControl.contentTintColor = accent
         providerModeControl.attributedTitle = NSAttributedString(
-            string: provider.displayName,
+            string: name,
             attributes: [
                 .font: NSFont.systemFont(ofSize: 14, weight: .semibold),
                 .foregroundColor: NSColor.labelColor,
@@ -780,6 +800,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
             // store change never fires for them.
             _ = settings.sessionListLayout
             _ = settings.activeProvider
+            _ = settings.activeSourceId
             _ = settings.pinnedSessionIds
         } onChange: { [weak self] in
             DispatchQueue.main.async {
@@ -787,6 +808,7 @@ final class SessionListViewController: NSViewController, NSOutlineViewDataSource
                     "observation fired (from arm #\(armIndex))",
                     context: "Sidebar"
                 )
+                self?.updateProviderModeControlSelection()
                 self?.reloadData()
                 self?.startObserving()
             }

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -21,7 +21,8 @@ final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate
         storeProvider: @escaping @MainActor (SessionSource) -> ProviderStore?,
         contextProvider: @escaping @MainActor (SessionSource) -> ManageProviderContext?,
         requestRescan: @escaping @MainActor (SessionSource) -> Void,
-        rebuildIndex: @escaping @MainActor (SessionSource) -> Void
+        rebuildIndex: @escaping @MainActor (SessionSource) -> Void,
+        hasLiveDriver: @escaping @MainActor (SessionSource) -> Bool
     ) {
         let store = ManageStore(
             source: source,
@@ -30,7 +31,8 @@ final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate
             storeProvider: storeProvider,
             contextProvider: contextProvider,
             requestRescan: requestRescan,
-            rebuildIndex: rebuildIndex
+            rebuildIndex: rebuildIndex,
+            hasLiveDriver: hasLiveDriver
         )
         self.store = store
         let window = NSWindow(

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -12,6 +12,8 @@ import AppKit
 @MainActor
 final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate {
 
+    private let store: ManageStore
+
     init(
         source: SessionSource,
         sources: [SessionSource],
@@ -30,6 +32,7 @@ final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate
             requestRescan: requestRescan,
             rebuildIndex: rebuildIndex
         )
+        self.store = store
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1040, height: 680),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -48,6 +51,13 @@ final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate
     }
 
     @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    /// Re-push the latest enabled sources + active selection before showing —
+    /// the controller is a reused singleton, so changes since the last open
+    /// must be applied or the switcher would show a stale list.
+    func update(sources: [SessionSource], active: SessionSource) {
+        store.updateSources(sources, active: active)
+    }
 
     func show() {
         window?.bringToFront()

--- a/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
+++ b/Lupen/UI/ManageSessions/ManageSessionsWindowController.swift
@@ -13,15 +13,17 @@ import AppKit
 final class ManageSessionsWindowController: NSWindowController, NSWindowDelegate {
 
     init(
-        provider: ProviderKind,
+        source: SessionSource,
+        sources: [SessionSource],
         isIndexingProvider: @escaping @MainActor () -> Bool,
-        storeProvider: @escaping @MainActor (ProviderKind) -> ProviderStore?,
-        contextProvider: @escaping @MainActor (ProviderKind) -> ManageProviderContext?,
-        requestRescan: @escaping @MainActor (ProviderKind) -> Void,
-        rebuildIndex: @escaping @MainActor (ProviderKind) -> Void
+        storeProvider: @escaping @MainActor (SessionSource) -> ProviderStore?,
+        contextProvider: @escaping @MainActor (SessionSource) -> ManageProviderContext?,
+        requestRescan: @escaping @MainActor (SessionSource) -> Void,
+        rebuildIndex: @escaping @MainActor (SessionSource) -> Void
     ) {
         let store = ManageStore(
-            provider: provider,
+            source: source,
+            sources: sources,
             isIndexingProvider: isIndexingProvider,
             storeProvider: storeProvider,
             contextProvider: contextProvider,

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -38,7 +38,7 @@ final class ManageViewController: NSViewController {
     private let sessionResumer = SessionResumer()
 
     private let providerSeg = NSSegmentedControl(
-        labels: ["Claude Code", "Codex"], trackingMode: .selectOne, target: nil, action: nil)
+        labels: [], trackingMode: .selectOne, target: nil, action: nil)
     private let scopeSeg = NSSegmentedControl(
         labels: ["Sessions", "Lupen Cache", "All Disk"], trackingMode: .selectOne, target: nil, action: nil)
     private let searchField = NSSearchField()
@@ -109,9 +109,9 @@ final class ManageViewController: NSViewController {
     // MARK: - Build
 
     private func buildUI() {
-        providerSeg.selectedSegment = store.provider == .claudeCode ? 0 : 1
         providerSeg.target = self
         providerSeg.action = #selector(providerChanged)
+        rebuildProviderSegments()
 
         scopeSeg.selectedSegment = 0
         scopeSeg.target = self
@@ -310,8 +310,22 @@ final class ManageViewController: NSViewController {
 
     // MARK: - Toolbar actions
 
+    /// Populate the source switcher from the enabled sources (one segment
+    /// each, labelled by name), selecting the current source.
+    private func rebuildProviderSegments() {
+        providerSeg.segmentCount = store.sources.count
+        for (index, src) in store.sources.enumerated() {
+            providerSeg.setLabel(src.name, forSegment: index)
+        }
+        if let index = store.sources.firstIndex(where: { $0.id == store.source.id }) {
+            providerSeg.selectedSegment = index
+        }
+    }
+
     @objc private func providerChanged() {
-        store.switchProvider(providerSeg.selectedSegment == 0 ? .claudeCode : .codex)
+        let index = providerSeg.selectedSegment
+        guard store.sources.indices.contains(index) else { return }
+        store.switchSource(store.sources[index])
     }
     @objc private func scopeChanged() {
         let scopes: [ManageScope] = [.sessions, .cache, .allDisk]

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -545,6 +545,9 @@ final class ManageViewController: NSViewController {
 
     private func refresh() {
         guard isReady else { return }
+        // Keep the source switcher in sync with the store (handles the window
+        // being re-opened with an updated source list / active selection).
+        rebuildProviderSegments()
         switch store.scope {
         case .sessions:
             cachedRows = store.displayRows

--- a/Lupen/UI/ManageSessions/ManageViewController.swift
+++ b/Lupen/UI/ManageSessions/ManageViewController.swift
@@ -517,6 +517,17 @@ final class ManageViewController: NSViewController {
     // MARK: - Cache tab
 
     private func confirmRebuild() {
+        // An enabled-but-never-activated source has no live driver, so a
+        // rebuild would silently do nothing. Tell the user how to enable it
+        // instead of pretending the rebuild ran.
+        guard store.canManageIndex else {
+            let info = NSAlert()
+            info.messageText = "Activate this source to rebuild"
+            info.informativeText = "Switch to this source in the sidebar (the mode picker) first — only the active source's index can be rebuilt."
+            info.addButton(withTitle: "OK")
+            info.runModal()
+            return
+        }
         let alert = NSAlert()
         alert.messageText = "Rebuild the index?"
         alert.informativeText = "Clears the derived index and re-scans your session logs. Original logs are not modified."

--- a/Lupen/UI/Preferences/PreferencesForm.swift
+++ b/Lupen/UI/Preferences/PreferencesForm.swift
@@ -36,6 +36,16 @@ struct PreferencesForm: View {
     /// section. Production AppDelegate always supplies one.
     var statuslineService: StatuslineConnectionService? = nil
 
+    /// The active-source selection for the Mode picker. Reads `activeSourceId`
+    /// and routes writes through `setActiveSource` (which only honours enabled
+    /// sources — the picker lists exactly those).
+    private var activeSourceBinding: Binding<String> {
+        Binding(
+            get: { settings.activeSourceId },
+            set: { settings.setActiveSource(id: $0) }
+        )
+    }
+
     var body: some View {
         Form {
             Section {
@@ -73,20 +83,22 @@ struct PreferencesForm: View {
             }
 
             Section {
-                Picker("Mode", selection: $settings.activeProvider) {
-                    ForEach(ProviderRegistry.all) { provider in
-                        Text(provider.displayName).tag(provider.kind)
+                Picker("Mode", selection: activeSourceBinding) {
+                    ForEach(settings.enabledResolvedSources) { source in
+                        Text(source.name).tag(source.id)
                     }
                 }
                 .pickerStyle(.menu)
             } header: {
                 Text("Mode")
             } footer: {
-                Text("Lupen shows sessions, totals, reports, and verification for the selected mode.")
+                Text("Lupen shows sessions, totals, reports, and verification for the selected source.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            SessionSourcesSettingsSection(settings: settings)
 
             UpdatesSettingsSection()
 

--- a/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
+++ b/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
@@ -113,12 +113,49 @@ struct SessionSourcesSettingsSection: View {
         panel.prompt = "Add"
         panel.message = "Choose a Claude Code projects folder or a Codex home."
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        // Infer kind/root from structure; fall back to Claude for an ambiguous
-        // folder (the user can remove it and re-add if the guess is wrong).
+
+        let kind: ProviderKind
+        let root: URL
         if let inferred = SessionSourceInference.infer(fromPickedFolder: url) {
-            _ = settings.addSource(root: inferred.root, kind: inferred.kind)
+            kind = inferred.kind
+            root = inferred.root
+        } else if let chosen = askKind(for: url) {
+            // Ambiguous layout — the user picks the kind rather than guessing.
+            kind = chosen
+            root = url
         } else {
-            _ = settings.addSource(root: url, kind: .claudeCode)
+            return
         }
+        if settings.addSource(root: root, kind: kind) == nil {
+            notifyDuplicate(root: root)
+        }
+    }
+
+    /// Ask which parser an ambiguous folder holds. Returns nil on Cancel.
+    private func askKind(for url: URL) -> ProviderKind? {
+        let alert = NSAlert()
+        alert.messageText = "Which kind of sessions does this folder hold?"
+        alert.informativeText = url.path
+        alert.addButton(withTitle: "Claude Code")
+        alert.addButton(withTitle: "Codex")
+        alert.addButton(withTitle: "Cancel")
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return .claudeCode
+        case .alertSecondButtonReturn: return .codex
+        default: return nil
+        }
+    }
+
+    /// Tell the user the picked folder is already registered (addSource
+    /// returned nil on a duplicate normalized root).
+    private func notifyDuplicate(root: URL) {
+        let alert = NSAlert()
+        alert.messageText = "This folder is already a session source."
+        if let existing = SessionSourceInference.duplicateRootSource(
+            SessionSource.normalizedRoot(root), in: settings.resolvedSources
+        ) {
+            alert.informativeText = "“\(existing.name)” already points at \(root.path)."
+        }
+        alert.runModal()
     }
 }

--- a/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
+++ b/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
@@ -1,0 +1,124 @@
+//
+//  SessionSourcesSettingsSection.swift
+//  Lupen
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import SwiftUI
+import AppKit
+
+/// Settings ▸ Session Sources (plan §4): lists the composed sources
+/// (built-in + auto-detected + user-added) with an enable toggle each, a
+/// kind/origin badge, the path, and an "Add Folder…" action that infers the
+/// kind/root from the picked directory. Only enabled sources are indexed and
+/// appear in the mode picker.
+///
+/// All mutations go through the tested `AppSettings` management API
+/// (`setSourceEnabled` / `addSource` / `removeSource`); this view is the
+/// declarative surface over them.
+struct SessionSourcesSettingsSection: View {
+
+    @Bindable var settings: AppSettings
+
+    var body: some View {
+        Section {
+            ForEach(settings.resolvedSources) { source in
+                row(source)
+            }
+            Button {
+                addFolder()
+            } label: {
+                Label("Add Folder…", systemImage: "plus")
+            }
+        } header: {
+            Text("Session Sources")
+        } footer: {
+            Text("Only enabled sources are indexed and shown in the mode picker. Built-in Claude Code and Codex are always available; add a folder to track sessions stored elsewhere (e.g. an Xcode Coding Assistant or a custom CLAUDE_CONFIG_DIR / CODEX_HOME).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ source: SessionSource) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Toggle("", isOn: enabledBinding(for: source))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(source.name).fontWeight(.medium)
+                    kindBadge(source.kind)
+                    Text(originLabel(source.origin))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                Text(source.root.path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .truncationMode(.middle)
+                    .lineLimit(1)
+                    .help(source.root.path)
+            }
+
+            Spacer(minLength: 8)
+
+            if source.origin == .userAdded {
+                Button {
+                    settings.removeSource(id: source.id)
+                } label: {
+                    Image(systemName: "minus.circle")
+                }
+                .buttonStyle(.borderless)
+                .help("Remove this source")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func kindBadge(_ kind: ProviderKind) -> some View {
+        let color: Color = kind == .claudeCode ? .indigo : .teal
+        return Text(ProviderRegistry.descriptor(for: kind).shortDisplayName)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private func originLabel(_ origin: SessionSource.Origin) -> String {
+        switch origin {
+        case .builtin: return "Built-in"
+        case .autoDetected: return "Detected"
+        case .userAdded: return "Added"
+        }
+    }
+
+    private func enabledBinding(for source: SessionSource) -> Binding<Bool> {
+        Binding(
+            get: { settings.resolvedSources.source(id: source.id)?.enabled ?? false },
+            set: { settings.setSourceEnabled(id: source.id, $0) }
+        )
+    }
+
+    private func addFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Add"
+        panel.message = "Choose a Claude Code projects folder or a Codex home."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        // Infer kind/root from structure; fall back to Claude for an ambiguous
+        // folder (the user can remove it and re-add if the guess is wrong).
+        if let inferred = SessionSourceInference.infer(fromPickedFolder: url) {
+            _ = settings.addSource(root: inferred.root, kind: inferred.kind)
+        } else {
+            _ = settings.addSource(root: url, kind: .claudeCode)
+        }
+    }
+}

--- a/LupenTests/CLI/CLIGlobalOptionsTests.swift
+++ b/LupenTests/CLI/CLIGlobalOptionsTests.swift
@@ -1,0 +1,49 @@
+//
+//  CLIGlobalOptionsTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/27.
+//
+
+import Testing
+import Foundation
+import ArgumentParser
+@testable import Lupen
+
+/// Covers the `--source` / `--provider` resolution on the shared CLI options:
+/// a built-in alias resolves to its kind, an unknown `--source` is rejected
+/// up front (not silently fallen back), and the no-source path stays on the
+/// chosen provider. `--source` aliases resolve against the live registry, so
+/// the built-in aliases used here are deterministic regardless of the user's
+/// saved sources.
+@Suite("CLIGlobalOptions --source / --provider resolution")
+struct CLIGlobalOptionsTests {
+
+    @Test("no --source uses the --provider built-in")
+    func noSourceUsesProvider() throws {
+        let opts = try CLIGlobalOptions.parse(["--provider", "codex"])
+        #expect(opts.provider == .codex)
+        #expect(opts.resolvedSource.id == "codex")
+    }
+
+    @Test("--source resolves a built-in alias and its kind")
+    func sourceResolvesBuiltin() throws {
+        let opts = try CLIGlobalOptions.parse(["--source", "codex"])
+        #expect(opts.provider == .codex)
+        #expect(opts.resolvedSource.kind == .codex)
+    }
+
+    @Test("an unknown --source is rejected, not silently fallen back")
+    func unknownSourceRejected() {
+        #expect(throws: (any Error).self) {
+            _ = try CLIGlobalOptions.parse(["--source", "definitely-not-a-source-xyz-123"])
+        }
+    }
+
+    @Test("blank --source is ignored and falls through to the provider")
+    func blankSourceIgnored() throws {
+        let opts = try CLIGlobalOptions.parse(["--source", "   ", "--provider", "claudeCode"])
+        #expect(opts.provider == .claudeCode)
+        #expect(opts.resolvedSource.id == "claudeCode")
+    }
+}

--- a/LupenTests/CLI/CLISourceResolverTests.swift
+++ b/LupenTests/CLI/CLISourceResolverTests.swift
@@ -1,0 +1,85 @@
+//
+//  CLISourceResolverTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("CLISourceResolver")
+struct CLISourceResolverTests {
+
+    private func sources() -> [SessionSource] {
+        var list = SessionSourceRegistry.builtins(
+            claudeRoot: URL(fileURLWithPath: "/h/.claude/projects"),
+            codexRoot: URL(fileURLWithPath: "/h/.codex")
+        )
+        list.append(SessionSource(
+            id: "xcode-claude", name: "Xcode Claude", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/x/projects"), origin: .autoDetected, enabled: true
+        ))
+        list.append(SessionSource(
+            id: "user-work", name: "Work Codex", kind: .codex,
+            root: URL(fileURLWithPath: "/w/.codex"), origin: .userAdded, enabled: true
+        ))
+        return list
+    }
+
+    @Test("built-in aliases resolve to the built-in sources")
+    func builtinAliases() {
+        let s = sources()
+        #expect(CLISourceResolver.resolve("claude", in: s)?.id == "claudeCode")
+        #expect(CLISourceResolver.resolve("claude-code", in: s)?.id == "claudeCode")
+        #expect(CLISourceResolver.resolve("claudeCode", in: s)?.id == "claudeCode")
+        #expect(CLISourceResolver.resolve("codex", in: s)?.id == "codex")
+    }
+
+    @Test("an exact id resolves")
+    func byId() {
+        #expect(CLISourceResolver.resolve("xcode-claude", in: sources())?.id == "xcode-claude")
+    }
+
+    @Test("a case-insensitive name resolves, with whitespace trimmed")
+    func byName() {
+        #expect(CLISourceResolver.resolve("work codex", in: sources())?.id == "user-work")
+        #expect(CLISourceResolver.resolve("  Work Codex  ", in: sources())?.id == "user-work")
+    }
+
+    @Test("an unknown argument resolves to nil")
+    func unknown() {
+        #expect(CLISourceResolver.resolve("nope", in: sources()) == nil)
+    }
+
+    @Test("resolveLive reads a persisted settings file and resolves a user source by name")
+    func resolveLiveFromSettingsFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-cli-resolve-\(UUID().uuidString)")
+            .appendingPathComponent("app_settings.json")
+        try FileManager.default.createDirectory(
+            at: tmp.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmp.deletingLastPathComponent()) }
+
+        let custom = SessionSource(
+            id: "user-myproj", name: "My Project", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/my/proj/projects"), origin: .userAdded, enabled: true
+        )
+        AppSettingsStorage(fileURL: tmp).save(
+            AppSettingsData(
+                sessionListLayout: .flat, pinnedSessionIds: [],
+                showTodayCostInMenuBar: true, openDashboardOnLaunch: false,
+                startAtLogin: false, showParseWarningBadge: false, showParseErrorBadge: false,
+                sessionSources: [custom]
+            )
+        )
+
+        let resolved = CLISourceResolver.resolveLive("My Project", settingsURL: tmp)
+        #expect(resolved?.id == "user-myproj")
+        #expect(resolved?.kind == .claudeCode)
+        // Built-in alias still resolves through the live composition.
+        #expect(CLISourceResolver.resolveLive("codex", settingsURL: tmp)?.id == "codex")
+    }
+}

--- a/LupenTests/Cache/AppSettingsStorageTests.swift
+++ b/LupenTests/Cache/AppSettingsStorageTests.swift
@@ -381,4 +381,81 @@ struct AppSettingsStorageTests {
             try JSONDecoder().decode(SessionSource.self, from: Data(json.utf8))
         }
     }
+
+    // MARK: - activeSourceId migration / round-trip
+
+    @Test("legacy file without activeSourceId derives it from activeProvider")
+    func legacyFileMigratesActiveSourceIdFromProvider() throws {
+        let (storage, url) = makeStorage()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let json = """
+        {
+          "sessionListLayout": "flat",
+          "activeProvider": "codex",
+          "pinnedSessionIds": []
+        }
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+
+        let loaded = storage.load()
+        #expect(loaded.activeProvider == .codex)
+        #expect(loaded.activeSourceId == "codex")
+    }
+
+    @Test("legacy file with neither key defaults to the Claude source id")
+    func legacyFileDefaultsActiveSourceIdToClaude() throws {
+        let (storage, url) = makeStorage()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try "{ \"sessionListLayout\": \"flat\", \"pinnedSessionIds\": [] }"
+            .write(to: url, atomically: true, encoding: .utf8)
+
+        let loaded = storage.load()
+        #expect(loaded.activeProvider == .claudeCode)
+        #expect(loaded.activeSourceId == "claudeCode")
+    }
+
+    @Test("an explicit activeSourceId is preserved and not overwritten by provider")
+    func explicitActiveSourceIdWins() throws {
+        let (storage, url) = makeStorage()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let json = """
+        {
+          "sessionListLayout": "flat",
+          "activeProvider": "claudeCode",
+          "activeSourceId": "xcode-claude",
+          "pinnedSessionIds": []
+        }
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+
+        let loaded = storage.load()
+        #expect(loaded.activeSourceId == "xcode-claude")
+        #expect(loaded.activeProvider == .claudeCode)
+    }
+
+    @Test("save + load round-trips a custom activeSourceId independent of provider")
+    func activeSourceIdRoundTrips() {
+        let (storage, _) = makeStorage()
+        let data = AppSettingsData(
+            sessionListLayout: .flat,
+            activeProvider: .claudeCode,
+            activeSourceId: "xcode-claude",
+            pinnedSessionIds: [],
+            showTodayCostInMenuBar: true,
+            openDashboardOnLaunch: false,
+            startAtLogin: false,
+            showParseWarningBadge: false,
+            showParseErrorBadge: false
+        )
+        storage.save(data)
+        let loaded = storage.load()
+        #expect(loaded.activeSourceId == "xcode-claude")
+        #expect(loaded.activeProvider == .claudeCode)
+    }
 }

--- a/LupenTests/Cache/AppSettingsStorageTests.swift
+++ b/LupenTests/Cache/AppSettingsStorageTests.swift
@@ -300,4 +300,85 @@ struct AppSettingsStorageTests {
             #expect(storage.load().appearanceMode == mode)
         }
     }
+
+    @Test("legacy file without a sessionSources key migrates to empty")
+    func legacyFileWithoutSessionSources() throws {
+        let (storage, url) = makeStorage()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let json = """
+        {
+          "sessionListLayout": "flat",
+          "pinnedSessionIds": []
+        }
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        #expect(storage.load().sessionSources.isEmpty)
+    }
+
+    @Test("sessionSources round-trip (built-in, auto-detected, user-added)")
+    func sessionSourcesRoundTrip() {
+        let (storage, _) = makeStorage()
+        let sources = [
+            SessionSource(id: "claudeCode", name: "Claude Code", kind: .claudeCode,
+                          root: URL(fileURLWithPath: "/Users/x/.claude/projects"),
+                          origin: .builtin, enabled: true),
+            SessionSource(id: "xcode-claude", name: "Xcode Claude", kind: .claudeCode,
+                          root: URL(fileURLWithPath: "/Users/x/Library/Developer/Xcode/CodingAssistant/p/projects"),
+                          origin: .autoDetected, enabled: false),
+            SessionSource(id: "work-codex", name: "Work Codex", kind: .codex,
+                          root: URL(fileURLWithPath: "/work/.codex/sessions"),
+                          origin: .userAdded, enabled: true),
+        ]
+        storage.save(AppSettingsData(
+            sessionListLayout: .flat,
+            pinnedSessionIds: [],
+            showTodayCostInMenuBar: true,
+            openDashboardOnLaunch: false,
+            startAtLogin: false,
+            showParseWarningBadge: false,
+            showParseErrorBadge: false,
+            sessionSources: sources
+        ))
+        #expect(storage.load().sessionSources == sources)
+    }
+
+    @Test("SessionSource encodes root as a plain path (not file://) and round-trips")
+    func sessionSourceRootEncoding() throws {
+        let source = SessionSource(id: "x", name: "X", kind: .claudeCode,
+                                   root: URL(fileURLWithPath: "/a/b/projects"),
+                                   origin: .userAdded, enabled: true)
+        let data = try JSONEncoder().encode(source)
+        let json = String(decoding: data, as: UTF8.self)
+        // Encoded as a filesystem path, not URL's `file://…` form. (JSONEncoder
+        // escapes the slashes as `\/`, so assert on the decoded path, not the
+        // raw substring.)
+        #expect(!json.contains("file:"))
+        #expect(json.contains("projects"))
+        let decoded = try JSONDecoder().decode(SessionSource.self, from: data)
+        #expect(decoded == source)
+        #expect(decoded.root.path == "/a/b/projects")
+    }
+
+    @Test("SessionSource standardizes root (trailing slash dropped) and round-trips")
+    func sessionSourceStandardizesRoot() throws {
+        let source = SessionSource(id: "x", name: "X", kind: .claudeCode,
+                                   root: URL(fileURLWithPath: "/a/b/c/"),
+                                   origin: .userAdded, enabled: true)
+        #expect(source.root.path == "/a/b/c")
+        let decoded = try JSONDecoder().decode(
+            SessionSource.self, from: JSONEncoder().encode(source))
+        #expect(decoded.root.path == "/a/b/c")
+        #expect(decoded == source)
+    }
+
+    @Test("SessionSource decode rejects an id containing the ':' separator")
+    func sessionSourceRejectsColonId() {
+        let json = #"{"id":"bad:id","name":"X","kind":"claudeCode","root":"/a/b","origin":"userAdded","enabled":true}"#
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(SessionSource.self, from: Data(json.utf8))
+        }
+    }
 }

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -458,6 +458,30 @@ struct AppSettingsTests {
         #expect(settings.enabledResolvedSources.contains { $0.id == "claudeCode" })
     }
 
+    @Test("disabling the active source falls back to an enabled source, not a disabled built-in")
+    func disableActiveFallsBackToEnabled() {
+        let (settings, _) = makeSettings()
+        let work = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode)!
+        settings.setSourceEnabled(id: "claudeCode", false)   // claude off; codex + work still on
+        #expect(settings.setActiveSource(id: work.id))
+        settings.setSourceEnabled(id: work.id, false)        // disable the active source
+        let active = settings.resolvedSources.source(id: settings.activeSourceId)
+        #expect(active?.enabled == true)                     // never lands on a disabled source
+        #expect(settings.activeSourceId != "claudeCode")     // claude is disabled here
+    }
+
+    @Test("removing the active source falls back to an enabled source, not a disabled built-in")
+    func removeActiveFallsBackToEnabled() {
+        let (settings, _) = makeSettings()
+        let work = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode)!
+        settings.setSourceEnabled(id: "claudeCode", false)
+        #expect(settings.setActiveSource(id: work.id))
+        settings.removeSource(id: work.id)
+        let active = settings.resolvedSources.source(id: settings.activeSourceId)
+        #expect(active?.enabled == true)
+        #expect(settings.activeSourceId != "claudeCode")
+    }
+
     @Test("renameSource rejects an empty or duplicate name")
     func renameSourceRejects() {
         let (settings, _) = makeSettings()

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -385,4 +385,107 @@ struct AppSettingsTests {
         #expect(settings.activeSourceId == "ghost-source")
         #expect(settings.activeProvider == .claudeCode)
     }
+
+    // MARK: - source management API
+
+    @Test("addSource registers an enabled user-added source")
+    func addSourceRegisters() {
+        let (settings, _) = makeSettings()
+        let added = settings.addSource(
+            root: URL(fileURLWithPath: "/unique/a/projects"), kind: .claudeCode, name: "Work"
+        )
+        let source = try! #require(added)
+        #expect(source.origin == .userAdded)
+        #expect(source.enabled)
+        #expect(source.name == "Work")
+        #expect(settings.enabledResolvedSources.contains { $0.id == source.id })
+    }
+
+    @Test("addSource rejects a duplicate normalized root")
+    func addSourceRejectsDuplicateRoot() {
+        let (settings, _) = makeSettings()
+        _ = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode)
+        let dup = settings.addSource(root: URL(fileURLWithPath: "/unique/a/"), kind: .claudeCode)
+        #expect(dup == nil)
+    }
+
+    @Test("addSource uniquifies a colliding name")
+    func addSourceUniquifiesName() {
+        let (settings, _) = makeSettings()
+        _ = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode, name: "Work")
+        let second = settings.addSource(root: URL(fileURLWithPath: "/unique/b"), kind: .claudeCode, name: "Work")
+        #expect(second?.name == "Work 2")
+    }
+
+    @Test("removeSource only removes user-added sources")
+    func removeSourceOnlyUserAdded() {
+        let (settings, _) = makeSettings()
+        let added = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode)!
+        settings.removeSource(id: added.id)
+        #expect(settings.resolvedSources.source(id: added.id) == nil)
+        // A built-in id is not removable.
+        settings.removeSource(id: "claudeCode")
+        #expect(settings.resolvedSources.source(id: "claudeCode") != nil)
+    }
+
+    @Test("removing the active source falls back to the Claude built-in")
+    func removeActiveSourceFallsBack() {
+        let (settings, _) = makeSettings()
+        let added = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .codex)!
+        #expect(settings.setActiveSource(id: added.id))
+        settings.removeSource(id: added.id)
+        #expect(settings.activeSourceId == "claudeCode")
+        #expect(settings.activeProvider == .claudeCode)
+    }
+
+    @Test("setSourceEnabled toggles the whitelist projection")
+    func setSourceEnabledToggles() {
+        let (settings, _) = makeSettings()
+        let added = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode)!
+        settings.setSourceEnabled(id: added.id, false)
+        #expect(!settings.enabledResolvedSources.contains { $0.id == added.id })
+        settings.setSourceEnabled(id: added.id, true)
+        #expect(settings.enabledResolvedSources.contains { $0.id == added.id })
+    }
+
+    @Test("the last enabled source cannot be disabled")
+    func cannotDisableLastEnabledSource() {
+        let (settings, _) = makeSettings()
+        // Fresh: only the two built-ins are enabled.
+        settings.setSourceEnabled(id: "codex", false)
+        #expect(!settings.enabledResolvedSources.contains { $0.id == "codex" })
+        settings.setSourceEnabled(id: "claudeCode", false)   // would be the last → refused
+        #expect(settings.enabledResolvedSources.contains { $0.id == "claudeCode" })
+    }
+
+    @Test("renameSource rejects an empty or duplicate name")
+    func renameSourceRejects() {
+        let (settings, _) = makeSettings()
+        let a = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode, name: "Alpha")!
+        let b = settings.addSource(root: URL(fileURLWithPath: "/unique/b"), kind: .claudeCode, name: "Beta")!
+        #expect(settings.renameSource(id: b.id, to: "Alpha") == false)
+        #expect(settings.renameSource(id: b.id, to: "   ") == false)
+        #expect(settings.resolvedSources.source(id: b.id)?.name == "Beta")
+        #expect(a.id != b.id)
+    }
+
+    @Test("renameSource applies a valid new name")
+    func renameSourceApplies() {
+        let (settings, _) = makeSettings()
+        let a = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .claudeCode, name: "Alpha")!
+        #expect(settings.renameSource(id: a.id, to: "Renamed"))
+        #expect(settings.resolvedSources.source(id: a.id)?.name == "Renamed")
+    }
+
+    @Test("setActiveSource requires the source to be enabled")
+    func setActiveSourceRequiresEnabled() {
+        let (settings, _) = makeSettings()
+        let added = settings.addSource(root: URL(fileURLWithPath: "/unique/a"), kind: .codex)!
+        #expect(settings.setActiveSource(id: added.id))
+        #expect(settings.activeSourceId == added.id)
+        #expect(settings.activeProvider == .codex)
+
+        settings.setSourceEnabled(id: added.id, false)  // also flips active back to Claude
+        #expect(settings.setActiveSource(id: added.id) == false)
+    }
 }

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -482,6 +482,23 @@ struct AppSettingsTests {
         #expect(settings.activeSourceId != "claudeCode")
     }
 
+    @Test("renameSource rejects a name held by a root-shadowed saved source")
+    func renameRejectsShadowedName() {
+        let dup = URL(fileURLWithPath: "/unique/dup/projects")
+        let a = SessionSource(id: "user-a", name: "Foo", kind: .claudeCode, root: dup, origin: .userAdded, enabled: true)
+        let b = SessionSource(id: "user-b", name: "Bar", kind: .claudeCode, root: dup, origin: .userAdded, enabled: true)
+        let (settings, _) = makeSettings(initial: AppSettingsData(
+            sessionListLayout: .flat, activeProvider: .claudeCode, pinnedSessionIds: [],
+            showTodayCostInMenuBar: true, openDashboardOnLaunch: false, startAtLogin: false,
+            showParseWarningBadge: false, showParseErrorBadge: false, sessionSources: [a, b]
+        ))
+        // b is dropped from resolvedSources by the root collision, yet persists.
+        #expect(settings.resolvedSources.source(id: "user-b") == nil)
+        #expect(settings.sessionSources.contains { $0.id == "user-b" })
+        // Renaming the visible source to the shadowed one's name must be rejected.
+        #expect(settings.renameSource(id: "user-a", to: "Bar") == false)
+    }
+
     @Test("renameSource rejects an empty or duplicate name")
     func renameSourceRejects() {
         let (settings, _) = makeSettings()

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -331,6 +331,44 @@ struct AppSettingsTests {
         #expect(settings.activeProvider == .claudeCode)
     }
 
+    // MARK: - resolvedSources (composition SSOT bridge)
+
+    @Test("resolvedSources always contains the two enabled built-ins")
+    func resolvedSourcesContainsBuiltins() {
+        let (settings, _) = makeSettings()
+        #expect(settings.resolvedSources.source(id: "claudeCode")?.enabled == true)
+        #expect(settings.resolvedSources.source(id: "codex")?.enabled == true)
+        let enabledIds = Set(settings.enabledResolvedSources.map(\.id))
+        #expect(enabledIds.contains("claudeCode"))
+        #expect(enabledIds.contains("codex"))
+    }
+
+    @Test("adding an enabled user source recomputes and surfaces it in enabledResolvedSources")
+    func userAddedSourceSurfacesAfterChange() {
+        let (settings, _) = makeSettings()
+        let custom = SessionSource(
+            id: "work", name: "Work", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/unique/work/projects"),
+            origin: .userAdded, enabled: true
+        )
+        settings.sessionSources = [custom]
+        #expect(settings.resolvedSources.source(id: "work")?.name == "Work")
+        #expect(settings.enabledResolvedSources.contains { $0.id == "work" })
+    }
+
+    @Test("a disabled user source is in resolvedSources but not enabledResolvedSources")
+    func disabledUserSourceFilteredFromEnabled() {
+        let (settings, _) = makeSettings()
+        let custom = SessionSource(
+            id: "work", name: "Work", kind: .codex,
+            root: URL(fileURLWithPath: "/unique/work/sessions"),
+            origin: .userAdded, enabled: false
+        )
+        settings.sessionSources = [custom]
+        #expect(settings.resolvedSources.contains { $0.id == "work" })
+        #expect(!settings.enabledResolvedSources.contains { $0.id == "work" })
+    }
+
     @Test("activeProvider getter falls back to Claude for an unresolvable id")
     func activeProviderGetterFallsBack() {
         let (settings, _) = makeSettings(initial: AppSettingsData(

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -277,4 +277,74 @@ struct AppSettingsTests {
             #expect(!mode.localizedTitle.isEmpty)
         }
     }
+
+    // MARK: - activeProvider ↔ activeSourceId projection
+
+    @Test("setting activeProvider maps to the built-in source id")
+    func activeProviderSetterMapsToBuiltinSourceId() {
+        let (settings, _) = makeSettings()
+        settings.activeProvider = .codex
+        #expect(settings.activeSourceId == "codex")
+        #expect(settings.activeProvider == .codex)
+
+        settings.activeProvider = .claudeCode
+        #expect(settings.activeSourceId == "claudeCode")
+        #expect(settings.activeProvider == .claudeCode)
+    }
+
+    @Test("activeProvider getter resolves a built-in source id to its kind")
+    func activeProviderGetterResolvesBuiltin() {
+        let (settings, _) = makeSettings(initial: AppSettingsData(
+            sessionListLayout: .flat,
+            activeProvider: .codex,
+            pinnedSessionIds: [],
+            showTodayCostInMenuBar: true,
+            openDashboardOnLaunch: false,
+            startAtLogin: false,
+            showParseWarningBadge: false,
+            showParseErrorBadge: false
+        ))
+        #expect(settings.activeSourceId == "codex")
+        #expect(settings.activeProvider == .codex)
+    }
+
+    @Test("activeProvider getter resolves a custom source id via sessionSources")
+    func activeProviderGetterResolvesCustomSource() {
+        let custom = SessionSource(
+            id: "xcode-claude", name: "Xcode Claude", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/x/projects"), origin: .autoDetected, enabled: true
+        )
+        let (settings, _) = makeSettings(initial: AppSettingsData(
+            sessionListLayout: .flat,
+            activeProvider: .claudeCode,
+            activeSourceId: "xcode-claude",
+            pinnedSessionIds: [],
+            showTodayCostInMenuBar: true,
+            openDashboardOnLaunch: false,
+            startAtLogin: false,
+            showParseWarningBadge: false,
+            showParseErrorBadge: false,
+            sessionSources: [custom]
+        ))
+        #expect(settings.activeSourceId == "xcode-claude")
+        // Resolved through sessionSources, not the rawValue map.
+        #expect(settings.activeProvider == .claudeCode)
+    }
+
+    @Test("activeProvider getter falls back to Claude for an unresolvable id")
+    func activeProviderGetterFallsBack() {
+        let (settings, _) = makeSettings(initial: AppSettingsData(
+            sessionListLayout: .flat,
+            activeProvider: .claudeCode,
+            activeSourceId: "ghost-source",
+            pinnedSessionIds: [],
+            showTodayCostInMenuBar: true,
+            openDashboardOnLaunch: false,
+            startAtLogin: false,
+            showParseWarningBadge: false,
+            showParseErrorBadge: false
+        ))
+        #expect(settings.activeSourceId == "ghost-source")
+        #expect(settings.activeProvider == .claudeCode)
+    }
 }

--- a/LupenTests/Domain/AppStateStoreActiveSourceTests.swift
+++ b/LupenTests/Domain/AppStateStoreActiveSourceTests.swift
@@ -1,0 +1,83 @@
+//
+//  AppStateStoreActiveSourceTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+import Observation
+@testable import Lupen
+
+/// Covers the `activeSource` authority introduced for the multi-source
+/// refactor: the store now stores a `SessionSource` and exposes
+/// `activeProvider` as a read-only projection of `activeSource.kind`, so the
+/// many `store.activeProvider` call sites keep working unchanged while the
+/// store carries full source identity.
+@Suite("AppStateStore.activeSource authority")
+@MainActor
+struct AppStateStoreActiveSourceTests {
+
+    @Test("default active source is the Claude Code built-in")
+    func defaultIsClaudeBuiltin() {
+        let store = AppStateStore()
+        #expect(store.activeProvider == .claudeCode)
+        #expect(store.activeSource.id == "claudeCode")
+        #expect(store.activeSource.kind == .claudeCode)
+        #expect(store.activeSource.origin == .builtin)
+        #expect(store.activeSource.enabled)
+    }
+
+    @Test("projection swap to Codex updates both activeSource and activeProvider")
+    func swapToCodex() {
+        let store = AppStateStore()
+        store.setActiveProviderForProjectionSwap(.codex)
+        #expect(store.activeProvider == .codex)
+        #expect(store.activeSource.id == "codex")
+        #expect(store.activeSource.kind == .codex)
+        #expect(store.activeSource.origin == .builtin)
+    }
+
+    @Test("projection swap round-trips back to Claude")
+    func swapRoundTrip() {
+        let store = AppStateStore()
+        store.setActiveProviderForProjectionSwap(.codex)
+        store.setActiveProviderForProjectionSwap(.claudeCode)
+        #expect(store.activeProvider == .claudeCode)
+        #expect(store.activeSource.id == "claudeCode")
+    }
+
+    @Test("Claude built-in root honours the projects-directory override")
+    func claudeRootHonoursOverride() {
+        let override = URL(fileURLWithPath: "/tmp/lupen-test-projects")
+        let store = AppStateStore(projectsDirectory: override)
+        #expect(store.activeSource.kind == .claudeCode)
+        #expect(store.activeSource.root.path == override.path)
+    }
+
+    @Test("injectProviderLoadingForTesting drives activeSource via the same path")
+    func injectLoadingUpdatesActiveSource() {
+        let store = AppStateStore()
+        store.injectProviderLoadingForTesting(provider: .codex, isLoading: false)
+        #expect(store.activeProvider == .codex)
+        #expect(store.activeSource.id == "codex")
+    }
+
+    /// The core invariant of this refactor: because `activeProvider` is now a
+    /// computed read of the observed `activeSource`, observers that track
+    /// `activeProvider` must still wake when the source swaps. Locks the
+    /// observation path the 113 call sites' UI relies on.
+    @Test("observing activeProvider still fires onChange when the source swaps")
+    func observationFiresThroughComputedProvider() async {
+        let store = AppStateStore()
+        await confirmation("activeProvider observer fires once") { fired in
+            withObservationTracking {
+                _ = store.activeProvider
+            } onChange: {
+                fired()
+            }
+            store.setActiveProviderForProjectionSwap(.codex)
+        }
+    }
+}

--- a/LupenTests/Domain/AppStateStoreActiveSourceTests.swift
+++ b/LupenTests/Domain/AppStateStoreActiveSourceTests.swift
@@ -56,6 +56,19 @@ struct AppStateStoreActiveSourceTests {
         #expect(store.activeSource.root.path == override.path)
     }
 
+    @Test("setActiveSourceForProjectionSwap activates an arbitrary (non-built-in) source")
+    func swapToArbitrarySource() {
+        let store = AppStateStore()
+        let custom = SessionSource(
+            id: "xcode-claude", name: "Xcode Claude", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/x/projects"), origin: .autoDetected, enabled: true
+        )
+        store.setActiveSourceForProjectionSwap(custom)
+        #expect(store.activeSource.id == "xcode-claude")
+        #expect(store.activeSource.origin == .autoDetected)
+        #expect(store.activeProvider == .claudeCode)
+    }
+
     @Test("injectProviderLoadingForTesting drives activeSource via the same path")
     func injectLoadingUpdatesActiveSource() {
         let store = AppStateStore()

--- a/LupenTests/Domain/Manage/ManageStoreTests.swift
+++ b/LupenTests/Domain/Manage/ManageStoreTests.swift
@@ -1,0 +1,68 @@
+//
+//  ManageStoreTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/27.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ManageStore source switching")
+@MainActor
+struct ManageStoreTests {
+
+    private func source(_ id: String, kind: ProviderKind = .claudeCode) -> SessionSource {
+        SessionSource(
+            id: id, name: id.capitalized, kind: kind,
+            root: URL(fileURLWithPath: "/tmp/\(id)"), origin: .userAdded, enabled: true
+        )
+    }
+
+    private func makeStore(
+        active: SessionSource,
+        sources: [SessionSource],
+        hasLiveDriver: @escaping @MainActor (SessionSource) -> Bool
+    ) -> ManageStore {
+        ManageStore(
+            source: active,
+            sources: sources,
+            isIndexingProvider: { false },
+            storeProvider: { _ in nil },
+            contextProvider: { _ in nil },
+            requestRescan: { _ in },
+            rebuildIndex: { _ in },
+            hasLiveDriver: hasLiveDriver
+        )
+    }
+
+    @Test("canManageIndex is true only when the active source has a live driver")
+    func canManageIndexReflectsDriver() {
+        let a = source("a")
+        #expect(makeStore(active: a, sources: [a], hasLiveDriver: { _ in true }).canManageIndex)
+        #expect(!makeStore(active: a, sources: [a], hasLiveDriver: { _ in false }).canManageIndex)
+    }
+
+    @Test("canManageIndex tracks the active source after a switch")
+    func canManageIndexTracksSwitch() {
+        let a = source("a")
+        let b = source("b", kind: .codex)
+        // Only "a" has a driver.
+        let store = makeStore(active: a, sources: [a, b], hasLiveDriver: { $0.id == "a" })
+        #expect(store.canManageIndex)
+        store.switchSource(b)
+        #expect(store.source.id == "b")
+        #expect(!store.canManageIndex)   // "b" was never activated → no driver
+    }
+
+    @Test("updateSources replaces the list and active selection")
+    func updateSourcesReplaces() {
+        let a = source("a")
+        let b = source("b", kind: .codex)
+        let store = makeStore(active: a, sources: [a], hasLiveDriver: { _ in true })
+        store.updateSources([a, b], active: b)
+        #expect(store.sources.map(\.id) == ["a", "b"])
+        #expect(store.source.id == "b")
+    }
+}

--- a/LupenTests/Domain/Providers/KnownSourceLocationsTests.swift
+++ b/LupenTests/Domain/Providers/KnownSourceLocationsTests.swift
@@ -64,7 +64,9 @@ struct KnownSourceLocationsTests {
         #expect(claude.root.standardizedFileURL == cfg.appendingPathComponent("projects").standardizedFileURL)
         let cx = try! #require(detected.first { $0.id == "codex-home" })
         #expect(cx.kind == .codex)
-        #expect(cx.root.standardizedFileURL == codex.appendingPathComponent("sessions").standardizedFileURL)
+        // Codex root is the codexHome (parent of sessions/), detected when
+        // sessions/ exists.
+        #expect(cx.root.standardizedFileURL == codex.standardizedFileURL)
         #expect(detected.allSatisfy { !$0.enabled && $0.origin == .autoDetected })
     }
 

--- a/LupenTests/Domain/Providers/KnownSourceLocationsTests.swift
+++ b/LupenTests/Domain/Providers/KnownSourceLocationsTests.swift
@@ -1,0 +1,106 @@
+//
+//  KnownSourceLocationsTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("KnownSourceLocations auto-detection")
+struct KnownSourceLocationsTests {
+
+    private func makeHome() -> (URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-home-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func mkdir(_ url: URL) {
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    private let xcodeRel = "Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/projects"
+
+    @Test("nothing detected when no candidate dirs exist and no env set")
+    func emptyWhenNothingPresent() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        #expect(KnownSourceLocations.detect(environment: [:], home: home).isEmpty)
+    }
+
+    @Test("Xcode Claude path detected only when present; disabled + autoDetected")
+    func xcodeDetection() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        #expect(KnownSourceLocations.detect(environment: [:], home: home).isEmpty)
+
+        let xcode = home.appendingPathComponent(xcodeRel)
+        mkdir(xcode)
+        let detected = KnownSourceLocations.detect(environment: [:], home: home)
+        #expect(detected.count == 1)
+        let s = try! #require(detected.first)
+        #expect(s.id == "xcode-claude")
+        #expect(s.kind == .claudeCode)
+        #expect(s.origin == .autoDetected)
+        #expect(s.enabled == false)
+        #expect(s.root.standardizedFileURL == xcode.standardizedFileURL)
+    }
+
+    @Test("CLAUDE_CONFIG_DIR and CODEX_HOME detected when env set and dir exists")
+    func envDetection() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        let cfg = home.appendingPathComponent("work-claude")
+        let codex = home.appendingPathComponent("work-codex")
+        mkdir(cfg.appendingPathComponent("projects"))
+        mkdir(codex.appendingPathComponent("sessions"))
+
+        let env = ["CLAUDE_CONFIG_DIR": cfg.path, "CODEX_HOME": codex.path]
+        let detected = KnownSourceLocations.detect(environment: env, home: home)
+
+        let claude = try! #require(detected.first { $0.id == "claude-config-dir" })
+        #expect(claude.kind == .claudeCode)
+        #expect(claude.root.standardizedFileURL == cfg.appendingPathComponent("projects").standardizedFileURL)
+        let cx = try! #require(detected.first { $0.id == "codex-home" })
+        #expect(cx.kind == .codex)
+        #expect(cx.root.standardizedFileURL == codex.appendingPathComponent("sessions").standardizedFileURL)
+        #expect(detected.allSatisfy { !$0.enabled && $0.origin == .autoDetected })
+    }
+
+    @Test("env var set but the directory is missing → not detected")
+    func envMissingDir() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        let env = ["CLAUDE_CONFIG_DIR": home.appendingPathComponent("nope").path]
+        #expect(KnownSourceLocations.detect(environment: env, home: home).isEmpty)
+    }
+
+    @Test("empty / whitespace env values are ignored")
+    func emptyEnvIgnored() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        let env = ["CLAUDE_CONFIG_DIR": "   ", "CODEX_HOME": ""]
+        #expect(KnownSourceLocations.detect(environment: env, home: home).isEmpty)
+    }
+
+    @Test("a regular file at the candidate path is not treated as a directory")
+    func fileNotDirectory() throws {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        let xcodeParent = home.appendingPathComponent(xcodeRel).deletingLastPathComponent()
+        mkdir(xcodeParent)
+        // Create `projects` as a FILE, not a directory.
+        try Data().write(to: xcodeParent.appendingPathComponent("projects"))
+        #expect(KnownSourceLocations.detect(environment: [:], home: home).isEmpty)
+    }
+
+    @Test("detected candidate ids are unique")
+    func uniqueIds() {
+        let (home, cleanup) = makeHome(); defer { cleanup() }
+        mkdir(home.appendingPathComponent(xcodeRel))
+        let cfg = home.appendingPathComponent("c"); mkdir(cfg.appendingPathComponent("projects"))
+        let cx = home.appendingPathComponent("x"); mkdir(cx.appendingPathComponent("sessions"))
+        let detected = KnownSourceLocations.detect(
+            environment: ["CLAUDE_CONFIG_DIR": cfg.path, "CODEX_HOME": cx.path], home: home
+        )
+        #expect(Set(detected.map(\.id)).count == detected.count)
+    }
+}

--- a/LupenTests/Domain/Providers/LupenPathsTests.swift
+++ b/LupenTests/Domain/Providers/LupenPathsTests.swift
@@ -16,4 +16,40 @@ struct LupenPathsTests {
         #expect(LupenPaths.offsetsURL(for: .codex, appSupportRoot: root).lastPathComponent == "offsets.json")
         #expect(LupenPaths.codexUsageSnapshotURL(appSupportRoot: root).lastPathComponent == "usage_snapshot.json")
     }
+
+    @Test("source-id paths nest under providers/<sourceId>")
+    func sourceIdPaths() {
+        let root = URL(fileURLWithPath: "/tmp/LupenTestRoot")
+        #expect(LupenPaths.providerRoot(forSourceId: "xcode-claude", appSupportRoot: root).path
+            == "/tmp/LupenTestRoot/providers/xcode-claude")
+        #expect(LupenPaths.indexDatabaseURL(forSourceId: "xcode-claude", appSupportRoot: root).path
+            == "/tmp/LupenTestRoot/providers/xcode-claude/index.sqlite3")
+        #expect(LupenPaths.sessionCacheURL(forSourceId: "xcode-claude", appSupportRoot: root).lastPathComponent
+            == "session_cache.json")
+        #expect(LupenPaths.parseSnapshotURL(forSourceId: "xcode-claude", appSupportRoot: root).lastPathComponent
+            == "parse_snapshot.json")
+        #expect(LupenPaths.offsetsURL(forSourceId: "xcode-claude", appSupportRoot: root).lastPathComponent
+            == "offsets.json")
+        #expect(LupenPaths.refreshLockURL(forSourceId: "xcode-claude", appSupportRoot: root).lastPathComponent
+            == "refresh.lock")
+    }
+
+    @Test("built-in ProviderKind paths equal the source-id paths for their rawValue")
+    func builtinKindEqualsSourceIdPath() {
+        let root = URL(fileURLWithPath: "/tmp/LupenTestRoot")
+        for kind in ProviderKind.allCases {
+            #expect(LupenPaths.providerRoot(for: kind, appSupportRoot: root)
+                == LupenPaths.providerRoot(forSourceId: kind.rawValue, appSupportRoot: root))
+            #expect(LupenPaths.indexDatabaseURL(for: kind, appSupportRoot: root)
+                == LupenPaths.indexDatabaseURL(forSourceId: kind.rawValue, appSupportRoot: root))
+            #expect(LupenPaths.sessionCacheURL(for: kind, appSupportRoot: root)
+                == LupenPaths.sessionCacheURL(forSourceId: kind.rawValue, appSupportRoot: root))
+            #expect(LupenPaths.parseSnapshotURL(for: kind, appSupportRoot: root)
+                == LupenPaths.parseSnapshotURL(forSourceId: kind.rawValue, appSupportRoot: root))
+            #expect(LupenPaths.offsetsURL(for: kind, appSupportRoot: root)
+                == LupenPaths.offsetsURL(forSourceId: kind.rawValue, appSupportRoot: root))
+            #expect(LupenPaths.refreshLockURL(for: kind, appSupportRoot: root)
+                == LupenPaths.refreshLockURL(forSourceId: kind.rawValue, appSupportRoot: root))
+        }
+    }
 }

--- a/LupenTests/Domain/Providers/SessionSourceInferenceTests.swift
+++ b/LupenTests/Domain/Providers/SessionSourceInferenceTests.swift
@@ -1,0 +1,132 @@
+//
+//  SessionSourceInferenceTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("SessionSourceInference — add-folder logic")
+struct SessionSourceInferenceTests {
+
+    private func makeTemp() -> (URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-infer-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func mkdir(_ url: URL) {
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    // MARK: - infer
+
+    @Test("a folder containing sessions/ is a Codex codexHome")
+    func inferCodexHome() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let home = tmp.appendingPathComponent("mycodex")
+        mkdir(home.appendingPathComponent("sessions"))
+        let inf = SessionSourceInference.infer(fromPickedFolder: home)
+        #expect(inf?.kind == .codex)
+        #expect(inf?.root.standardizedFileURL == home.standardizedFileURL)
+    }
+
+    @Test("picking the sessions/ directory resolves to its codexHome parent")
+    func inferCodexSessionsResolvesToParent() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let home = tmp.appendingPathComponent("mycodex")
+        let sessions = home.appendingPathComponent("sessions")
+        mkdir(sessions)
+        let inf = SessionSourceInference.infer(fromPickedFolder: sessions)
+        #expect(inf?.kind == .codex)
+        #expect(inf?.root.standardizedFileURL == home.standardizedFileURL)
+    }
+
+    @Test("a folder named projects is a Claude source rooted at itself")
+    func inferClaudeProjects() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let projects = tmp.appendingPathComponent("projects")
+        mkdir(projects)
+        let inf = SessionSourceInference.infer(fromPickedFolder: projects)
+        #expect(inf?.kind == .claudeCode)
+        #expect(inf?.root.standardizedFileURL == projects.standardizedFileURL)
+    }
+
+    @Test("a config dir containing projects/ resolves into the projects directory")
+    func inferClaudeConfigDirResolvesIntoProjects() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let config = tmp.appendingPathComponent("myclaude")
+        let projects = config.appendingPathComponent("projects")
+        mkdir(projects)
+        let inf = SessionSourceInference.infer(fromPickedFolder: config)
+        #expect(inf?.kind == .claudeCode)
+        #expect(inf?.root.standardizedFileURL == projects.standardizedFileURL)
+    }
+
+    @Test("an ambiguous folder returns nil (caller asks the user to choose)")
+    func inferAmbiguousIsNil() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let blank = tmp.appendingPathComponent("whatever")
+        mkdir(blank)
+        #expect(SessionSourceInference.infer(fromPickedFolder: blank) == nil)
+    }
+
+    @Test("Codex takes precedence: sessions/ wins even if projects/ also exists")
+    func inferCodexPrecedence() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let dir = tmp.appendingPathComponent("both")
+        mkdir(dir.appendingPathComponent("sessions"))
+        mkdir(dir.appendingPathComponent("projects"))
+        #expect(SessionSourceInference.infer(fromPickedFolder: dir)?.kind == .codex)
+    }
+
+    // MARK: - suggestName
+
+    @Test("name suggestion uses the most distinctive ancestor + kind label")
+    func suggestNameDistinctiveAncestor() {
+        let root = URL(fileURLWithPath: "/a/Xcode/CodingAssistant/projects")
+        #expect(SessionSourceInference.suggestName(forRoot: root, kind: .claudeCode)
+            == "CodingAssistant Claude")
+        let codexRoot = URL(fileURLWithPath: "/work/.codex")
+        #expect(SessionSourceInference.suggestName(forRoot: codexRoot, kind: .codex)
+            == "work Codex")
+    }
+
+    @Test("name suggestion falls back to the kind label when nothing is distinctive")
+    func suggestNameFallback() {
+        #expect(SessionSourceInference.suggestName(
+            forRoot: URL(fileURLWithPath: "/projects"), kind: .claudeCode) == "Claude")
+    }
+
+    // MARK: - uniqueName
+
+    @Test("uniqueName leaves a non-colliding name untouched")
+    func uniqueNameNoCollision() {
+        #expect(SessionSourceInference.uniqueName("Work", existingNames: ["Other"]) == "Work")
+    }
+
+    @Test("uniqueName suffixes the first free integer")
+    func uniqueNameSuffixes() {
+        #expect(SessionSourceInference.uniqueName("Work", existingNames: ["Work"]) == "Work 2")
+        #expect(SessionSourceInference.uniqueName("Work", existingNames: ["Work", "Work 2"]) == "Work 3")
+    }
+
+    // MARK: - duplicateRootSource
+
+    @Test("duplicateRootSource matches an existing source by normalized path")
+    func duplicateRootMatches() {
+        let existing = SessionSource(
+            id: "e", name: "E", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/a/b/projects"), origin: .userAdded, enabled: true
+        )
+        // Trailing slash on the candidate normalizes to the same path.
+        let candidate = URL(fileURLWithPath: "/a/b/projects/")
+        #expect(SessionSourceInference.duplicateRootSource(candidate, in: [existing])?.id == "e")
+        #expect(SessionSourceInference.duplicateRootSource(
+            URL(fileURLWithPath: "/a/b/other"), in: [existing]) == nil)
+    }
+}

--- a/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
+++ b/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
@@ -1,0 +1,295 @@
+//
+//  SessionSourceRegistryTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("SessionSourceRegistry composition")
+struct SessionSourceRegistryTests {
+
+    private let claudeRoot = URL(fileURLWithPath: "/Users/x/.claude/projects")
+    private let codexRoot = URL(fileURLWithPath: "/Users/x/.codex/sessions")
+
+    private func builtins() -> [SessionSource] {
+        SessionSourceRegistry.builtins(claudeRoot: claudeRoot, codexRoot: codexRoot)
+    }
+
+    private func detected(id: String, kind: ProviderKind, path: String) -> SessionSource {
+        SessionSource(
+            id: id, name: id, kind: kind,
+            root: URL(fileURLWithPath: path), origin: .autoDetected, enabled: false
+        )
+    }
+
+    // MARK: - builtins
+
+    @Test("builtin ids equal ProviderKind.rawValue so the index folder is reused")
+    func builtinIdentity() {
+        let b = builtins()
+        #expect(b.count == 2)
+        let claude = try! #require(b.source(id: "claudeCode"))
+        #expect(claude.kind == .claudeCode)
+        #expect(claude.origin == .builtin)
+        #expect(claude.enabled)
+        #expect(claude.name == "Claude Code")
+        #expect(claude.root.path == claudeRoot.path)
+        let codex = try! #require(b.source(id: "codex"))
+        #expect(codex.kind == .codex)
+        #expect(codex.origin == .builtin)
+        #expect(codex.enabled)
+        #expect(codex.id == ProviderKind.codex.rawValue)
+    }
+
+    // MARK: - compose: layering
+
+    @Test("no detected, no saved → just the two enabled builtins, in order")
+    func builtinsOnly() {
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [])
+        #expect(out.map(\.id) == ["claudeCode", "codex"])
+        #expect(out.allSatisfy { $0.enabled })
+    }
+
+    @Test("detected candidates follow builtins and stay disabled")
+    func detectedAfterBuiltinsDisabled() {
+        let xcode = detected(id: "xcode-claude", kind: .claudeCode, path: "/x/projects")
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [xcode], saved: [])
+        #expect(out.map(\.id) == ["claudeCode", "codex", "xcode-claude"])
+        #expect(out.source(id: "xcode-claude")?.enabled == false)
+        #expect(out.enabledSources.map(\.id) == ["claudeCode", "codex"])
+    }
+
+    // MARK: - compose: saved overrides
+
+    @Test("saved override flips a detected source to enabled and renames it")
+    func savedEnablesAndRenamesDetected() {
+        let xcode = detected(id: "xcode-claude", kind: .claudeCode, path: "/x/projects")
+        let override = SessionSource(
+            id: "xcode-claude", name: "My Xcode", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/x/projects"), origin: .autoDetected, enabled: true
+        )
+        let out = SessionSourceRegistry.compose(
+            builtins: builtins(), detected: [xcode], saved: [override]
+        )
+        let s = try! #require(out.source(id: "xcode-claude"))
+        #expect(s.enabled)
+        #expect(s.name == "My Xcode")
+        #expect(out.enabledSources.map(\.id) == ["claudeCode", "codex", "xcode-claude"])
+    }
+
+    @Test("saved override can disable a builtin")
+    func savedDisablesBuiltin() {
+        let override = SessionSource(
+            id: "codex", name: "Codex", kind: .codex,
+            root: codexRoot, origin: .builtin, enabled: false
+        )
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [override])
+        #expect(out.source(id: "codex")?.enabled == false)
+        #expect(out.enabledSources.map(\.id) == ["claudeCode"])
+    }
+
+    @Test("merge contract: code owns kind/root/origin, user owns name/enabled")
+    func mergeContractKeepsCodeIdentity() {
+        // A malformed/stale saved override that disagrees on identity fields.
+        let override = SessionSource(
+            id: "claudeCode", name: "Renamed", kind: .codex,
+            root: URL(fileURLWithPath: "/wrong/path"), origin: .userAdded, enabled: false
+        )
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [override])
+        let claude = try! #require(out.source(id: "claudeCode"))
+        // user-owned fields applied…
+        #expect(claude.name == "Renamed")
+        #expect(claude.enabled == false)
+        // …code-owned identity preserved.
+        #expect(claude.kind == .claudeCode)
+        #expect(claude.origin == .builtin)
+        #expect(claude.root.path == claudeRoot.path)
+    }
+
+    // MARK: - compose: user-added + edge cases
+
+    @Test("saved source with no matching candidate is appended as user-added")
+    func userAddedAppended() {
+        let added = SessionSource(
+            id: "my-work", name: "Work Claude", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/work/projects"), origin: .userAdded, enabled: true
+        )
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [added])
+        #expect(out.map(\.id) == ["claudeCode", "codex", "my-work"])
+        #expect(out.last?.origin == .userAdded)
+        #expect(out.last?.enabled == true)
+    }
+
+    @Test("user-added sources keep their saved order after the candidates")
+    func userAddedOrderPreserved() {
+        let a = SessionSource(id: "a", name: "A", kind: .claudeCode,
+                              root: URL(fileURLWithPath: "/a"), origin: .userAdded, enabled: true)
+        let b = SessionSource(id: "b", name: "B", kind: .codex,
+                              root: URL(fileURLWithPath: "/b"), origin: .userAdded, enabled: false)
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [a, b])
+        #expect(out.map(\.id) == ["claudeCode", "codex", "a", "b"])
+    }
+
+    @Test("a once-detected, now-absent saved source is retained as stale")
+    func staleDetectedRetained() {
+        // saved says enabled but detect() no longer returns it (path gone).
+        let stale = SessionSource(
+            id: "xcode-claude", name: "Xcode Claude", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/gone/projects"), origin: .autoDetected, enabled: true
+        )
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [stale])
+        let s = try! #require(out.source(id: "xcode-claude"))
+        #expect(s.enabled)
+        #expect(s.origin == .autoDetected)
+    }
+
+    @Test("output ids are always unique even with cross-layer id collisions")
+    func uniqueIdsAcrossLayers() {
+        // detected accidentally shares a builtin id; saved shares it too.
+        let dupDetected = detected(id: "codex", kind: .codex, path: "/dup")
+        let dupSaved = SessionSource(id: "codex", name: "x", kind: .codex,
+                                     root: codexRoot, origin: .builtin, enabled: true)
+        let out = SessionSourceRegistry.compose(
+            builtins: builtins(), detected: [dupDetected], saved: [dupSaved]
+        )
+        #expect(Set(out.map(\.id)).count == out.count)
+        // builtin wins the slot.
+        #expect(out.source(id: "codex")?.origin == .builtin)
+    }
+
+    // MARK: - compose: root uniqueness
+
+    @Test("detected candidate sharing a builtin's root is dropped (builtin wins)")
+    func detectedRootCollisionDropped() {
+        // Mirrors $CLAUDE_CONFIG_DIR: builtin claude root == detected root,
+        // different ids.
+        let dupRoot = detected(id: "claude-config-dir", kind: .claudeCode, path: claudeRoot.path)
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [dupRoot], saved: [])
+        #expect(out.map(\.id) == ["claudeCode", "codex"])
+        #expect(out.source(id: "claude-config-dir") == nil)
+    }
+
+    @Test("a user-added folder pointing at a builtin root is dropped")
+    func userAddedRootCollisionDropped() {
+        let dup = SessionSource(
+            id: "my-dup", name: "Dup", kind: .claudeCode,
+            root: claudeRoot, origin: .userAdded, enabled: true
+        )
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [], saved: [dup])
+        #expect(out.map(\.id) == ["claudeCode", "codex"])
+        #expect(out.source(id: "my-dup") == nil)
+    }
+
+    @Test("two distinct roots both survive (no false-positive dedup)")
+    func distinctRootsBothKept() {
+        let a = detected(id: "a", kind: .claudeCode, path: "/distinct/a/projects")
+        let b = detected(id: "b", kind: .claudeCode, path: "/distinct/b/projects")
+        let out = SessionSourceRegistry.compose(builtins: builtins(), detected: [a, b], saved: [])
+        #expect(out.map(\.id) == ["claudeCode", "codex", "a", "b"])
+    }
+
+    // MARK: - compose: degenerate inputs
+
+    @Test("empty inputs compose to an empty list")
+    func emptyComposeIsEmpty() {
+        #expect(SessionSourceRegistry.compose(builtins: [], detected: [], saved: []).isEmpty)
+    }
+
+    @Test("duplicate ids within saved resolve deterministically (first wins)")
+    func savedInternalDuplicateFirstWins() {
+        let first = SessionSource(id: "codex", name: "First", kind: .codex,
+                                  root: codexRoot, origin: .builtin, enabled: true)
+        let second = SessionSource(id: "codex", name: "Second", kind: .codex,
+                                   root: codexRoot, origin: .builtin, enabled: false)
+        let out = SessionSourceRegistry.compose(
+            builtins: builtins(), detected: [], saved: [first, second]
+        )
+        // override applied to the builtin `codex` uses the first saved entry.
+        #expect(out.source(id: "codex")?.name == "First")
+        #expect(out.source(id: "codex")?.enabled == true)
+    }
+
+    // MARK: - resolve (live wiring with injected env/home)
+
+    @Test("resolve wires detect(): env-detected source appears disabled")
+    func resolveWiresDetection() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-reg-\(UUID().uuidString)")
+        let codex = home.appendingPathComponent("cx")
+        try FileManager.default.createDirectory(
+            at: codex.appendingPathComponent("sessions"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let out = SessionSourceRegistry.resolve(
+            saved: [],
+            claudeRoot: claudeRoot, codexRoot: codexRoot,
+            environment: ["CODEX_HOME": codex.path], home: home
+        )
+        #expect(out.source(id: "codex-home")?.enabled == false)
+        #expect(out.enabledSources.map(\.id) == ["claudeCode", "codex"])
+    }
+
+    @Test("resolve applies a saved override on top of detection")
+    func resolveAppliesSavedOverride() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-reg-\(UUID().uuidString)")
+        let codex = home.appendingPathComponent("cx")
+        try FileManager.default.createDirectory(
+            at: codex.appendingPathComponent("sessions"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let override = SessionSource(
+            id: "codex-home", name: "Work Codex", kind: .codex,
+            root: codex.appendingPathComponent("sessions"), origin: .autoDetected, enabled: true
+        )
+        let out = SessionSourceRegistry.resolve(
+            saved: [override],
+            claudeRoot: claudeRoot, codexRoot: codexRoot,
+            environment: ["CODEX_HOME": codex.path], home: home
+        )
+        let s = try! #require(out.source(id: "codex-home"))
+        #expect(s.enabled)
+        #expect(s.name == "Work Codex")
+    }
+
+    @Test("resolve dedups an env-derived detection against the env-aware builtin root")
+    func resolveDedupsEnvRootAgainstBuiltin() throws {
+        // The real-world bug: when CODEX_HOME is set, the builtin codex root
+        // (env-aware) and the `codex-home` detection resolve to the same dir.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-reg-\(UUID().uuidString)")
+        let codex = home.appendingPathComponent("cx")
+        let sessions = codex.appendingPathComponent("sessions")
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let out = SessionSourceRegistry.resolve(
+            saved: [],
+            claudeRoot: claudeRoot,
+            codexRoot: sessions,   // the env-aware builtin root
+            environment: ["CODEX_HOME": codex.path], home: home
+        )
+        #expect(out.map(\.id) == ["claudeCode", "codex"])
+        #expect(out.source(id: "codex-home") == nil)
+    }
+
+    // MARK: - extension helpers
+
+    @Test("enabledSources filters and source(id:) looks up")
+    func extensionHelpers() {
+        let out = SessionSourceRegistry.compose(
+            builtins: builtins(),
+            detected: [detected(id: "d", kind: .claudeCode, path: "/d")],
+            saved: []
+        )
+        #expect(out.enabledSources.count == 2)
+        #expect(out.source(id: "d") != nil)
+        #expect(out.source(id: "nope") == nil)
+    }
+}

--- a/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
+++ b/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
@@ -45,6 +45,25 @@ struct SessionSourceRegistryTests {
         #expect(codex.id == ProviderKind.codex.rawValue)
     }
 
+    @Test("builtinSource(for:) yields the enabled, rawValue-id source per kind")
+    func builtinSourceForKind() {
+        let claude = SessionSourceRegistry.builtinSource(
+            for: .claudeCode, claudeRoot: claudeRoot, codexRoot: codexRoot
+        )
+        #expect(claude.id == "claudeCode")
+        #expect(claude.kind == .claudeCode)
+        #expect(claude.origin == .builtin)
+        #expect(claude.enabled)
+        #expect(claude.root.path == claudeRoot.path)
+
+        let codex = SessionSourceRegistry.builtinSource(
+            for: .codex, claudeRoot: claudeRoot, codexRoot: codexRoot
+        )
+        #expect(codex.id == "codex")
+        #expect(codex.kind == .codex)
+        #expect(codex.root.path == codexRoot.path)
+    }
+
     // MARK: - compose: layering
 
     @Test("no detected, no saved → just the two enabled builtins, in order")

--- a/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
+++ b/LupenTests/Domain/Providers/SessionSourceRegistryTests.swift
@@ -288,10 +288,11 @@ struct SessionSourceRegistryTests {
         try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }
 
+        _ = sessions   // created above so detection's sessions/ probe passes
         let out = SessionSourceRegistry.resolve(
             saved: [],
             claudeRoot: claudeRoot,
-            codexRoot: sessions,   // the env-aware builtin root
+            codexRoot: codex,   // the env-aware builtin root = codexHome
             environment: ["CODEX_HOME": codex.path], home: home
         )
         #expect(out.map(\.id) == ["claudeCode", "codex"])

--- a/LupenTests/Store/ProviderIndexSourceFromSessionSourceTests.swift
+++ b/LupenTests/Store/ProviderIndexSourceFromSessionSourceTests.swift
@@ -1,0 +1,36 @@
+//
+//  ProviderIndexSourceFromSessionSourceTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/26.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ProviderIndexSource(_ source: SessionSource)")
+struct ProviderIndexSourceFromSessionSourceTests {
+
+    @Test("a Claude source maps to .claude(projectsDirectory: root)")
+    func claudeMapping() {
+        let source = SessionSource(
+            id: "c", name: "C", kind: .claudeCode,
+            root: URL(fileURLWithPath: "/x/projects"), origin: .userAdded, enabled: true
+        )
+        let pis = ProviderIndexSource(source)
+        #expect(pis == .claude(projectsDirectory: URL(fileURLWithPath: "/x/projects")))
+        #expect(pis.provider == .claudeCode)
+    }
+
+    @Test("a Codex source maps to .codex(codexHome: root) — root is the codexHome")
+    func codexMapping() {
+        let source = SessionSource(
+            id: "x", name: "X", kind: .codex,
+            root: URL(fileURLWithPath: "/home/.codex"), origin: .userAdded, enabled: true
+        )
+        let pis = ProviderIndexSource(source)
+        #expect(pis == .codex(codexHome: URL(fileURLWithPath: "/home/.codex")))
+        #expect(pis.provider == .codex)
+    }
+}

--- a/LupenTests/Store/SQLiteFirstStartupTests.swift
+++ b/LupenTests/Store/SQLiteFirstStartupTests.swift
@@ -693,6 +693,52 @@ struct SQLiteFirstStartupTests {
         #expect(FileManager.default.fileExists(atPath: expected.path))
     }
 
+    @Test("two sources index into isolated per-source DBs + stores under one appSupportRoot")
+    func twoSourcesIndexInIsolation() async throws {
+        let (corpus, cleanupCorpus) = try RefactorFixtureCorpus.materialize()
+        defer { cleanupCorpus() }
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-multi-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let storeA = AppStateStore(projectsDirectory: corpus.projectsDir)
+        let sourceA = try SQLiteFirstStartup(
+            source: .claude(projectsDirectory: corpus.projectsDir),
+            appStore: storeA, sourceId: "src-a", appSupportRoot: appSupport,
+            refreshThrottle: 0.05, isFileWatchingEnabled: false
+        )
+        let storeB = AppStateStore()
+        let sourceB = try SQLiteFirstStartup(
+            source: .codex(codexHome: corpus.codexHome),
+            appStore: storeB, sourceId: "src-b", appSupportRoot: appSupport,
+            refreshThrottle: 0.05, isFileWatchingEnabled: false
+        )
+        sourceA.start(); sourceB.start()
+        defer { sourceA.stop(); sourceB.stop() }
+
+        var settled = false
+        for _ in 0..<300 {
+            if !storeA.sessions.isEmpty, !storeA.isLoading,
+               !storeB.sessions.isEmpty, !storeB.isLoading {
+                settled = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(settled, "did not settle: A=\(storeA.sessions.count) B=\(storeB.sessions.count)")
+
+        // Each source owns an isolated DB file under its own id.
+        let dbA = appSupport.appendingPathComponent("providers/src-a/index.sqlite3")
+        let dbB = appSupport.appendingPathComponent("providers/src-b/index.sqlite3")
+        #expect(FileManager.default.fileExists(atPath: dbA.path))
+        #expect(FileManager.default.fileExists(atPath: dbB.path))
+        // Content is isolated: A holds only Claude sessions, B only Codex —
+        // no cross-contamination despite sharing the appSupportRoot.
+        #expect(storeA.sessions.allSatisfy { $0.provider == .claudeCode })
+        #expect(storeB.sessions.allSatisfy { $0.provider == .codex })
+    }
+
     @Test("absent sourceId falls back to the provider rawValue folder (built-in)")
     func indexDBDefaultsToProviderFolder() throws {
         let appSupport = FileManager.default.temporaryDirectory

--- a/LupenTests/Store/SQLiteFirstStartupTests.swift
+++ b/LupenTests/Store/SQLiteFirstStartupTests.swift
@@ -665,6 +665,57 @@ struct SQLiteFirstStartupTests {
         #expect(dup.isVisibleInSessionList)
         #expect(dup.cachedTitle == "Duplicate rollout group")
     }
+
+    // MARK: - per-source index DB path (T4)
+
+    @Test("index DB is keyed by the session source id under appSupportRoot")
+    func indexDBKeyedBySourceId() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-srcid-\(UUID().uuidString)")
+        let projects = appSupport.appendingPathComponent("projects")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let store = AppStateStore(projectsDirectory: projects)
+        let startup = try SQLiteFirstStartup(
+            source: .claude(projectsDirectory: projects),
+            appStore: store,
+            sourceId: "xcode-claude",
+            appSupportRoot: appSupport,
+            isFileWatchingEnabled: false
+        )
+        defer { startup.stop() }
+
+        let expected = appSupport
+            .appendingPathComponent("providers")
+            .appendingPathComponent("xcode-claude")
+            .appendingPathComponent("index.sqlite3")
+        #expect(FileManager.default.fileExists(atPath: expected.path))
+    }
+
+    @Test("absent sourceId falls back to the provider rawValue folder (built-in)")
+    func indexDBDefaultsToProviderFolder() throws {
+        let appSupport = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-srcid-\(UUID().uuidString)")
+        let home = appSupport.appendingPathComponent("codex")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let store = AppStateStore()
+        let startup = try SQLiteFirstStartup(
+            source: .codex(codexHome: home),
+            appStore: store,
+            appSupportRoot: appSupport,
+            isFileWatchingEnabled: false
+        )
+        defer { startup.stop() }
+
+        let expected = appSupport
+            .appendingPathComponent("providers")
+            .appendingPathComponent("codex")
+            .appendingPathComponent("index.sqlite3")
+        #expect(FileManager.default.fileExists(atPath: expected.path))
+    }
 }
 
 private extension ISO8601DateFormatter {

--- a/research.md
+++ b/research.md
@@ -1,0 +1,109 @@
+# Research: 다중 세션 소스 경로 인식/추가 개선
+
+> 작성: jaden · 2026-06-26 · 브랜치 feat/appearance-mode
+> 목적: Xcode Coding Assistant처럼 별도 경로에 저장되는 세션을 Lupen이 모니터링하지 못하는 문제의 해결 방향 조사
+
+## 1. 문제 정의
+
+Claude Code는 실행 환경(프런트엔드)에 따라 세션 JSONL을 서로 다른 루트에 쓴다.
+
+| 실행 환경 | 세션 저장 경로(실측) |
+|---|---|
+| 터미널 `claude` CLI | `~/.claude/projects/<슬러그>/*.jsonl` |
+| Xcode Coding Assistant | `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/projects/<슬러그>/*.jsonl` |
+
+두 경로 모두 같은 프로젝트 슬러그(`-Users-user--work--lupen-main`)를 쓰지만, Lupen은 **`~/.claude/projects` 한 곳만** 스캔하므로 Xcode 세션의 비용·대화가 전혀 잡히지 않는다. 사용자가 다른 프런트엔드를 쓰면 모니터링 사각지대가 생긴다.
+
+## 2. 현재 경로 결정 구조 (코드 근거)
+
+### 2.1 Claude Code 루트
+- `FileDiscovery.baseDirectory` — `Lupen/Data/FileDiscovery.swift:20-26`
+  - `CLAUDE_CONFIG_DIR` 환경변수 → 없으면 `~/.claude`. **단일 경로만** 반환.
+- `ClaudeProvider.defaultSourceRoot` = `fileDiscovery.projectsDirectory` (`~/.claude/projects`) — `ClaudeProvider.swift:25-27`
+- `AppStateStore.effectiveProjectsDirectory` — `Lupen/Domain/AppStateStore.swift:78-80`
+  - `projectsDirectoryOverride ?? claudeProvider.defaultSourceRoot`. **단일 루트.**
+- `CLIRefresher.source(for:)` — `Lupen/CLI/CLIRefresher.swift:29-34`
+  - Claude는 `FileDiscovery().projectsDirectory` **하나**만 인덱싱.
+
+### 2.2 Codex 루트
+- `CodexSessionDiscovery.codexHome` — `Lupen/Domain/Codex/CodexSessionDiscovery.swift:10-23`
+  - 생성자 인자 → `CODEX_HOME` 환경변수 → `~/.codex`. **단일 경로.**
+
+### 2.3 파일 감시
+- `SQLiteFirstStartup.startWatching()` — `Lupen/Store/SQLiteFirstStartup.swift:278-293`
+  - source(claude/codex)에서 **단일 디렉토리** 하나를 골라 watcher에 전달.
+- `FileWatcher.startWatching(directory:)` — `Lupen/Data/FileWatcher.swift:43-89`
+  - `let paths = [directory.path]` — FSEventStream **하나**, 경로 배열 원소 1개.
+  - `self.stream` 단일 보관. **멀티 루트 감시 미지원.**
+  - 단, `FSEventStreamCreate`의 `paths` 인자는 원래 **다중 경로 배열을 받는 API** → 한 스트림으로 여러 루트 감시가 기술적으로 가능(중요).
+
+### 2.4 이미 존재하는 멀티 루트 스켈레톤 (핵심)
+- `ProviderConfiguration.sourceRoots: [URL]` (복수 배열) — `Lupen/Domain/Providers/ProviderConfiguration.swift:11-23`
+- `AppSettingsData.providerConfigurations: ProviderConfigurationStore` 로 **이미 영속화됨** — `AppSettingsStorage.swift:17`
+- **그러나** grep 결과 `sourceRoots`를 실제 discover/scan/watch에서 읽는 코드는 **0곳**. `fingerprint` 직렬화에만 쓰임.
+- **결론: 멀티 루트용 데이터 모델/영속화는 이미 깔려 있고, 파이프라인 연결만 안 된 상태.** 개선 비용이 생각보다 작다.
+
+## 3. 제약 / 함정
+
+### 3.1 GUI 앱은 셸 환경변수를 못 본다 (중요)
+- 현재 자동 인식의 유일한 수단은 `CLAUDE_CONFIG_DIR` / `CODEX_HOME` 환경변수다.
+- 메뉴바 앱은 launchd가 띄우므로 사용자가 `~/.zshrc` 등에 설정한 환경변수가 `ProcessInfo.environment`에 **들어오지 않을 수 있다**. (CLI는 셸에서 실행되어 보임 → 앱/CLI 간 인식 불일치 위험)
+- 따라서 환경변수 의존만으로는 자동 인식이 불완전하다.
+
+### 3.2 프로젝트 슬러그 충돌
+- 서로 다른 루트에 같은 슬러그 디렉토리가 존재(예: 터미널과 Xcode 둘 다 `-Users-user--work--lupen-main`).
+- `DiscoveredFile.projectPath`는 슬러그(디렉토리명)이므로, 단순 머지 시 두 루트의 세션이 **같은 프로젝트 그룹으로 합쳐진다**. 세션 자체는 UUID라 충돌하지 않지만, 같은 세션이 두 루트에 복제될 경우 중복 집계 위험.
+- 머지 정책 필요: 세션 ID(UUID) 기준 dedup, 그리고 "어느 루트에서 왔는지" 출처 태그를 유지할지 결정.
+
+### 3.3 샌드박스 — 유리한 점
+- `Lupen.entitlements`가 빈 `<dict/>` → **샌드박스 비활성**. 임의 경로를 보안 스코프 북마크 없이 자유롭게 읽을 수 있다. 사용자 임의 폴더 추가 기능 구현 난도가 낮다.
+
+### 3.4 인덱스/캐시 일관성
+- SQLite 인덱스는 provider별 단일 DB(`LupenPaths.indexDatabaseURL`). 멀티 루트 세션을 같은 DB에 넣어도 세션 단위라 무방하나, `ProviderConfiguration.fingerprint`에 루트 집합이 포함되므로 **루트 추가/삭제 시 재인덱싱 트리거**가 자연스럽게 걸리도록 연결해야 함.
+
+## 4. 개선 옵션
+
+### 옵션 A — 자동 인식(Auto-discovery)
+알려진 후보 경로를 부팅 시 스캔해 존재하면 자동 편입.
+- 후보: `~/.claude/projects`(기본), `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/projects`(Xcode), `CLAUDE_CONFIG_DIR`(있으면), 향후 다른 IDE 통합 경로.
+- 장점: 사용자 개입 0. "그냥 다 잡힘".
+- 단점: 후보 목록을 코드에 하드코딩 → 새 프런트엔드 등장 시 업데이트 필요. 환경변수 한계(3.1).
+
+### 옵션 B — 수동 추가(User-managed)
+Settings에 "세션 폴더" 목록 + NSOpenPanel로 추가/제거.
+- 장점: 임의 경로 지원, 명시적, 미래 호환. 구현 패턴 이미 존재(`ManageViewController.export()`의 NSOpenPanel, `PreferencesForm`의 섹션 패턴).
+- 단점: 사용자가 경로를 알고 직접 추가해야 함(발견성 낮음).
+
+### 옵션 C — 하이브리드 (권장)
+자동 인식으로 알려진 경로를 기본 편입 + Settings에서 사용자가 추가/제거/토글.
+- 이미 있는 `ProviderConfiguration.sourceRoots`를 **실제로 활성화**하는 방향과 정확히 일치.
+- 자동 발견 경로는 "감지됨" 배지로 표시하고, 사용자가 끄거나 임의 경로를 더할 수 있게.
+
+## 5. 권장 방향과 변경 범위 (Plan 후보)
+
+하이브리드(C). 데이터 모델이 이미 멀티 루트라 "파이프라인을 배열로 일반화"하는 작업이 핵심이다.
+
+1. **루트 해석 계층 신설** — provider별 "유효 루트 집합" 계산(기본 루트 + 자동 감지 + 사용자 추가 - 비활성). `sourceRoots`를 단일 진실 공급원으로.
+2. **discover 멀티 루트화** — `discoverFiles(in:)`를 루트 배열에 대해 반복 후 머지. 세션 UUID 기준 dedup, 출처(루트) 태그 보존.
+3. **FileWatcher 멀티 경로** — `startWatching(directories: [URL])`로 일반화하고 `FSEventStreamCreate`에 경로 배열 전달(스트림 1개 유지 가능).
+4. **자동 감지기** — 알려진 후보 경로 존재 검사 모듈(테스트 가능하게 순수 함수로).
+5. **Settings UI** — `PreferencesForm`에 "Session Sources" 섹션(목록 + 추가/제거, NSOpenPanel). Appearance Mode 추가 패턴(`PreferencesForm.swift:58-73`, `AppSettings` didSet→schedulePersist, `AppDelegate` withObservationTracking) 그대로 차용.
+6. **재인덱싱 연결** — 루트 집합 변경 → `fingerprint` 변경 → 재스캔/재인덱싱(`syncStoreToActiveProvider` 경로).
+7. **CLI 동기화** — `CLIRefresher.source(for:)`도 같은 루트 해석 계층을 사용하도록.
+
+### 미해결 결정 사항 (Plan 단계에서 확정 필요)
+- 자동 인식 범위: Xcode 경로만 추가할지, 일반화된 후보 목록을 둘지.
+- 슬러그 충돌 시 UI 표기: 출처별로 구분 표시할지, 합쳐서 보여줄지.
+- 자동 감지 경로를 기본 ON으로 할지(조용히 편입) vs 첫 발견 시 사용자에게 알릴지.
+- 환경변수(`CLAUDE_CONFIG_DIR`/`CODEX_HOME`) 자동 인식의 GUI 한계를 어떻게 보완할지.
+
+## 6. 참고 파일
+- `Lupen/Data/FileDiscovery.swift` — 루트/스캔
+- `Lupen/Data/FileWatcher.swift` — FSEvents 감시
+- `Lupen/Domain/Providers/ProviderConfiguration.swift` — 멀티 루트 모델(미연결)
+- `Lupen/Domain/AppStateStore.swift` — 앱 측 루트 결정
+- `Lupen/Store/SQLiteFirstStartup.swift` — 부팅/감시 시작
+- `Lupen/CLI/CLIRefresher.swift` — CLI 측 루트 결정
+- `Lupen/UI/Preferences/PreferencesForm.swift` — 설정 UI(추가 패턴 참조)
+- `Lupen/Cache/AppSettingsStorage.swift` — 설정 영속화
+- `Lupen/Domain/Codex/CodexSessionDiscovery.swift` — Codex 루트


### PR DESCRIPTION
## What this changes

Lupen only ever scanned the two built-in roots (`~/.claude/projects`,
`~/.codex/sessions`), so sessions written elsewhere — Xcode Coding
Assistant, a `CLAUDE_CONFIG_DIR`/`CODEX_HOME` location, or any folder the
user points at — were invisible. This adds a **session-source** model: each
root is an isolated, independently-indexed source rather than folding
everything into one index.

Key decisions (the diff shows the "what"; these are the "why"):

- **`ProviderKind` (parser, fixed 2) vs `SessionSource` (instance, N).** The
  two parsers (Claude/Codex) stay fixed; sources are N instances of
  `{id, name, kind, root, origin, enabled}`. `activeProvider` survives as a
  read-only projection of the active source's kind, so the ~110 GUI + ~30 CLI
  call sites that branch on Claude-vs-Codex are untouched.
- **Built-in source id == `ProviderKind.rawValue`.** A built-in maps to its
  existing `providers/<rawValue>/index.sqlite3` folder, so existing users get
  **zero re-index and zero settings migration** — the built-in paths are
  byte-identical to before (asserted by a test).
- **Whitelist + per-source isolation.** Auto-detected locations are surfaced
  disabled; only enabled sources are indexed/shown. Each source has its own
  index DB and driver, so one source can't corrupt another (vs. a union
  index, which risked cross-source data loss).
- **Composition SSOT** (`SessionSourceRegistry`): built-ins + auto-detect +
  user overrides, deduped by id **and** normalized root, feeding the picker,
  the indexing lifecycle, and CLI resolution from one place.

Surfaces: Settings ▸ Session Sources (enable / add folder with kind
inference + duplicate guard), the sidebar mode picker, the Manage window,
and the CLI (`--source <name|id>`, alongside `--provider`).

## How it was verified

- `xcodebuild test` — final regression across every touched + feature suite
  is green (276 tests in the targeted run; new tests accompany each unit:
  registry composition/dedup, persistence migration, path equivalence,
  source inference, CLI resolution/rejection, Manage source switching,
  and an end-to-end two-source isolation test).
- Each commit followed implement → tests → build → review → commit, and a
  three-layer code review (domain / pipeline+lifecycle / UI+CLI) was run;
  all findings were fixed (active-source fallback, Manage stale singleton,
  shadowed-id uniqueness, `CODEX_HOME` tilde dedup, `--source` typo
  rejection, Manage inactive-source rebuild guard).
- Manual runtime verification by the author: GUI (add/enable/switch sources,
  Manage) and CLI (`summary --source codex` routes to Codex data;
  `--source <typo>` now errors instead of silently showing the default).

Two non-defects are intentionally deferred (noted in review): CLI
`--source` re-resolves live settings per access (not a regression — the
built-in path stays cheap), and the Add-Folder flow uses stacked modals
rather than a sheet (HIG nicety on an already-verified flow).

## Checklist

- [x] `xcodebuild test` passes locally
- [ ] UI changes include a screenshot or screen recording — manually verified by author; screenshot not attached
- [x] New features add tests (domain) or list a manual-verification procedure (UI)
- [x] Vocabulary matches `docs/CONVERSATION-MODEL.md`
- [x] Cost-affecting changes are checked against Window → Verify Costs… — per-source totals verified via CLI `--source`
- [x] No hard-coded `/Users/<name>/…` paths or other personal data

## Related issues

Implements the multi-source plan (C-13). No tracking issue.
