### PR TITLE
feat(statusbar): right-click action menu on the menu-bar item

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -327,6 +327,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             LoggerService.shared.debug("Click handler executing — calling showDashboard", context: "App")
             dashboard.showDashboard()
         }
+        // Secondary (right / Control) click raises an action menu. Built
+        // fresh each click so the Verify title follows the active source.
+        statusBarController.setMenuProvider { [weak self] in
+            guard let self else { return nil }
+            return StatusBarMenuBuilder.makeMenu(
+                target: self,
+                verifyTitle: self.settings.activeProvider.verificationMenuTitle
+            )
+        }
 
         // Honour the user's "Open Dashboard on launch" preference. Skip
         // in the test host because tests don't want a window popping up.

--- a/Lupen/UI/StatusBar/StatusBarController.swift
+++ b/Lupen/UI/StatusBar/StatusBarController.swift
@@ -15,11 +15,17 @@ final class StatusBarController {
         let showsPlaceholder: Bool
     }
 
+    /// How a menu-bar click is routed. `.primary` is a plain left-click
+    /// (opens the Dashboard); `.secondary` is a right-click or a
+    /// Control-left-click (macOS convention for a context menu).
+    enum ClickKind: Equatable { case primary, secondary }
+
     private let statusItem: NSStatusItem
     private let store: AppStateStore
     private let settings: AppSettings
     private let rateLimitSampleStore: RateLimitSampleStore
     private var onButtonClick: ((NSStatusBarButton) -> Void)?
+    private var menuProvider: (() -> NSMenu?)?
 
     var button: NSStatusBarButton? { statusItem.button }
 
@@ -44,6 +50,27 @@ final class StatusBarController {
         self.onButtonClick = handler
     }
 
+    /// Supplies the context menu shown on a secondary (right / Control)
+    /// click. Rebuilt on every click so provider-dependent titles
+    /// (e.g. "Verify Costs…" vs "Verify Usage…") stay current. Returning
+    /// `nil` falls back to the primary action.
+    func setMenuProvider(_ provider: @escaping () -> NSMenu?) {
+        self.menuProvider = provider
+    }
+
+    /// Pure click classification — `.rightMouseDown`, or a
+    /// `.control`-modified left click, is a secondary (context-menu)
+    /// click; everything else opens the Dashboard. Extracted as a static
+    /// so the routing logic is unit-testable without a live status item.
+    static func classifyClick(
+        eventType: NSEvent.EventType,
+        modifiers: NSEvent.ModifierFlags
+    ) -> ClickKind {
+        if eventType == .rightMouseDown { return .secondary }
+        if eventType == .leftMouseDown, modifiers.contains(.control) { return .secondary }
+        return .primary
+    }
+
     /// Recompose the status item after an app-appearance override flip
     /// (`NSApp.appearance`). Windows redraw themselves on an appearance
     /// change, but the menu-bar icon is a non-template image whose palette is
@@ -66,17 +93,44 @@ final class StatusBarController {
         button.image = nil
         button.target = self
         button.action = #selector(statusBarButtonClicked(_:))
-        button.sendAction(on: [.leftMouseDown])  // React on mouse down, not mouse up
+        // React on mouse down, not mouse up. Right-click is included so a
+        // secondary click can raise the context menu (macOS convention).
+        button.sendAction(on: [.leftMouseDown, .rightMouseDown])
 
         applyAttributedTitle()
     }
 
     @objc private func statusBarButtonClicked(_ sender: NSStatusBarButton) {
+        let event = NSApp.currentEvent
+        let kind = Self.classifyClick(
+            eventType: event?.type ?? .leftMouseDown,
+            modifiers: event?.modifierFlags ?? []
+        )
         LoggerService.shared.info(
-            "Menu bar icon clicked — NSApp.isActive=\(NSApp.isActive)",
+            "Menu bar icon clicked — kind=\(kind), NSApp.isActive=\(NSApp.isActive)",
             context: "StatusBar"
         )
-        onButtonClick?(sender)
+        switch kind {
+        case .secondary:
+            if let menu = menuProvider?() {
+                presentMenu(menu)
+            } else {
+                onButtonClick?(sender)
+            }
+        case .primary:
+            onButtonClick?(sender)
+        }
+    }
+
+    /// Pops the context menu directly beneath the status item. Assigning
+    /// `statusItem.menu` makes the click raise the menu (instead of firing
+    /// the button action) with the standard pressed-state highlight; it is
+    /// cleared immediately afterwards so the next plain click still routes
+    /// through `statusBarButtonClicked`.
+    private func presentMenu(_ menu: NSMenu) {
+        statusItem.menu = menu
+        statusItem.button?.performClick(nil)
+        statusItem.menu = nil
     }
 
     // MARK: - Observation

--- a/Lupen/UI/StatusBar/StatusBarMenuBuilder.swift
+++ b/Lupen/UI/StatusBar/StatusBarMenuBuilder.swift
@@ -1,0 +1,68 @@
+import AppKit
+
+/// Builds the context menu raised by a secondary (right / Control) click on
+/// the menu-bar status item. macOS convention is left-click = primary action,
+/// right-click = action menu; the Dashboard, Reports, Diagnostics, Verify and
+/// Manage windows otherwise live only under the app's Window menu.
+///
+/// Pure and stateless: it takes the click `target` (the `AppDelegate`, which
+/// owns the `@objc` open actions) and a live `verifyTitle` (provider-dependent
+/// — "Verify Costs…" vs "Verify Usage…") and returns a fresh `NSMenu`. Rebuilt
+/// on every click so the Verify title tracks the active source. Keeping it free
+/// of app state makes the item set unit-testable without launching the app.
+@MainActor
+enum StatusBarMenuBuilder {
+
+    static func makeMenu(target: AnyObject, verifyTitle: String) -> NSMenu {
+        let menu = NSMenu()
+
+        menu.addItem(item(
+            "Open Dashboard", #selector(AppDelegate.openDashboard(_:)),
+            key: "0", mask: [.command], target: target
+        ))
+        menu.addItem(.separator())
+        menu.addItem(item(
+            "Reports…", #selector(AppDelegate.openReports(_:)),
+            key: "r", mask: [.command, .shift], target: target
+        ))
+        menu.addItem(item(
+            "Parse Diagnostics…", #selector(AppDelegate.openParseDiagnostics(_:)),
+            key: "d", mask: [.command, .shift], target: target
+        ))
+        menu.addItem(item(
+            verifyTitle, #selector(AppDelegate.openVerifyCosts(_:)),
+            key: "v", mask: [.command, .shift], target: target
+        ))
+        menu.addItem(item(
+            "Manage Sessions & Storage…", #selector(AppDelegate.openManageSessions(_:)),
+            key: "m", mask: [.command, .shift], target: target
+        ))
+        menu.addItem(.separator())
+        menu.addItem(item(
+            "Settings…", #selector(AppDelegate.openPreferences(_:)),
+            key: ",", mask: [.command], target: target
+        ))
+        menu.addItem(.separator())
+        // Quit routes through the responder chain to NSApp (target nil), so it
+        // works no matter which object is wired as the click target.
+        menu.addItem(item(
+            "Quit Lupen", #selector(NSApplication.terminate(_:)),
+            key: "q", mask: [.command], target: nil
+        ))
+
+        return menu
+    }
+
+    private static func item(
+        _ title: String,
+        _ action: Selector,
+        key: String,
+        mask: NSEvent.ModifierFlags,
+        target: AnyObject?
+    ) -> NSMenuItem {
+        let menuItem = NSMenuItem(title: title, action: action, keyEquivalent: key)
+        menuItem.keyEquivalentModifierMask = mask
+        menuItem.target = target
+        return menuItem
+    }
+}

--- a/LupenTests/UI/StatusBar/StatusBarClickRoutingTests.swift
+++ b/LupenTests/UI/StatusBar/StatusBarClickRoutingTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import AppKit
+@testable import Lupen
+
+@Suite("StatusBarController — click classification")
+@MainActor
+struct StatusBarClickRoutingTests {
+
+    @Test("plain left click opens the Dashboard (primary)")
+    func leftClickIsPrimary() {
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: []) == .primary)
+    }
+
+    @Test("right click raises the menu (secondary)")
+    func rightClickIsSecondary() {
+        #expect(StatusBarController.classifyClick(eventType: .rightMouseDown, modifiers: []) == .secondary)
+    }
+
+    @Test("Control-left click raises the menu (secondary)")
+    func controlLeftClickIsSecondary() {
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: [.control]) == .secondary)
+    }
+
+    @Test("a right click stays secondary even with Control held")
+    func controlRightClickIsSecondary() {
+        #expect(StatusBarController.classifyClick(eventType: .rightMouseDown, modifiers: [.control]) == .secondary)
+    }
+
+    @Test("non-Control modifiers on a left click stay primary")
+    func modifiedLeftClickStaysPrimary() {
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: [.shift]) == .primary)
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: [.command]) == .primary)
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: [.option]) == .primary)
+    }
+
+    @Test("Control combined with another modifier still secondary")
+    func controlPlusOtherModifierIsSecondary() {
+        #expect(StatusBarController.classifyClick(eventType: .leftMouseDown, modifiers: [.control, .shift]) == .secondary)
+    }
+}

--- a/LupenTests/UI/StatusBar/StatusBarMenuBuilderTests.swift
+++ b/LupenTests/UI/StatusBar/StatusBarMenuBuilderTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import AppKit
+@testable import Lupen
+
+@Suite("StatusBarMenuBuilder — context menu composition")
+@MainActor
+struct StatusBarMenuBuilderTests {
+
+    private func makeMenu(verifyTitle: String = "Verify Costs…") -> (NSMenu, NSObject) {
+        let target = NSObject()
+        return (StatusBarMenuBuilder.makeMenu(target: target, verifyTitle: verifyTitle), target)
+    }
+
+    @Test("item titles appear in the expected order, separators included")
+    func titleOrder() {
+        let (menu, _) = makeMenu()
+        let titles = menu.items.map { $0.isSeparatorItem ? "—" : $0.title }
+        #expect(titles == [
+            "Open Dashboard",
+            "—",
+            "Reports…",
+            "Parse Diagnostics…",
+            "Verify Costs…",
+            "Manage Sessions & Storage…",
+            "—",
+            "Settings…",
+            "—",
+            "Quit Lupen",
+        ])
+    }
+
+    @Test("each action item maps to its AppDelegate selector")
+    func actionSelectors() {
+        let (menu, _) = makeMenu()
+        func action(_ title: String) -> Selector? {
+            menu.items.first { $0.title == title }?.action
+        }
+        #expect(action("Open Dashboard") == #selector(AppDelegate.openDashboard(_:)))
+        #expect(action("Reports…") == #selector(AppDelegate.openReports(_:)))
+        #expect(action("Parse Diagnostics…") == #selector(AppDelegate.openParseDiagnostics(_:)))
+        #expect(action("Verify Costs…") == #selector(AppDelegate.openVerifyCosts(_:)))
+        #expect(action("Manage Sessions & Storage…") == #selector(AppDelegate.openManageSessions(_:)))
+        #expect(action("Settings…") == #selector(AppDelegate.openPreferences(_:)))
+        #expect(action("Quit Lupen") == #selector(NSApplication.terminate(_:)))
+    }
+
+    @Test("key equivalents and modifier masks match the Window-menu shortcuts")
+    func keyEquivalents() {
+        let (menu, _) = makeMenu()
+        func item(_ title: String) -> NSMenuItem? { menu.items.first { $0.title == title } }
+        #expect(item("Open Dashboard")?.keyEquivalent == "0")
+        #expect(item("Open Dashboard")?.keyEquivalentModifierMask == [.command])
+        #expect(item("Reports…")?.keyEquivalent == "r")
+        #expect(item("Reports…")?.keyEquivalentModifierMask == [.command, .shift])
+        #expect(item("Parse Diagnostics…")?.keyEquivalentModifierMask == [.command, .shift])
+        #expect(item("Verify Costs…")?.keyEquivalent == "v")
+        #expect(item("Manage Sessions & Storage…")?.keyEquivalent == "m")
+        #expect(item("Settings…")?.keyEquivalent == ",")
+        #expect(item("Settings…")?.keyEquivalentModifierMask == [.command])
+        #expect(item("Quit Lupen")?.keyEquivalent == "q")
+        #expect(item("Quit Lupen")?.keyEquivalentModifierMask == [.command])
+    }
+
+    @Test("non-quit items target the supplied object; Quit routes to the responder chain")
+    func targets() {
+        let (menu, target) = makeMenu()
+        for menuItem in menu.items where !menuItem.isSeparatorItem {
+            if menuItem.title == "Quit Lupen" {
+                #expect(menuItem.target == nil)   // → NSApp via responder chain
+            } else {
+                #expect(menuItem.target === target)
+            }
+        }
+    }
+
+    @Test("the Verify title is injected live (provider-dependent)")
+    func verifyTitleInjected() {
+        let (menu, _) = makeMenu(verifyTitle: "Verify Usage…")
+        let titles = menu.items.map(\.title)
+        #expect(titles.contains("Verify Usage…"))
+        #expect(!titles.contains("Verify Costs…"))
+        // It is the Verify action regardless of the displayed title.
+        let verifyItem = menu.items.first { $0.title == "Verify Usage…" }
+        #expect(verifyItem?.action == #selector(AppDelegate.openVerifyCosts(_:)))
+    }
+
+    @Test("exactly three separators partition the action groups")
+    func separatorCount() {
+        let (menu, _) = makeMenu()
+        #expect(menu.items.filter(\.isSeparatorItem).count == 3)
+    }
+}


### PR DESCRIPTION
## What

Adds a **right-click / Control-click action menu** to the menu-bar status item (dashboard item **D-2**). Right-clicking the icon now raises:

`Open Dashboard` · ─ · `Reports…` · `Parse Diagnostics…` · `<Verify…>` · `Manage Sessions & Storage…` · ─ · `Settings…` · ─ · `Quit Lupen`

…so those windows are reachable without going through the app's Window menu. Each item shows its keyboard-shortcut hint for discoverability.

**Left-click is unchanged** — it still opens the Dashboard.

## Why

The status item only bound `.leftMouseDown` (→ open Dashboard immediately); there was no right-click menu, so Reports/Diagnostics/Verify/Manage lived only under the app's Window menu. This brings the menu-bar interaction in line with the macOS convention (left-click = primary action, right-click = context menu).

Per the chosen approach, the previously-removed quick-stats dropdown popover is **not** revived — this PR is the right-click menu only, minimizing behavior change and regression surface.

## How

- `StatusBarController` — `sendAction(on:)` now includes `.rightMouseDown`; a pure `classifyClick(eventType:modifiers:)` routes primary (left) vs secondary (right / Control-left); `presentMenu` uses the standard `statusItem.menu` swap + `performClick` idiom. Left-click path is untouched, with a safe fallback to the primary action when no menu provider is set.
- `StatusBarMenuBuilder` (new) — pure `@MainActor` builder returning a fresh `NSMenu`; rebuilt per click so the Verify title follows the active source. `Quit` uses `target = nil` to route to `NSApp.terminate` via the responder chain.
- `AppDelegate` — one wiring line: `setMenuProvider`.

## Tests

13 new unit tests (pure logic, no live app needed):
- `StatusBarClickRoutingTests` — `classifyClick` across left/right/Control-left/Control-right/modified-left.
- `StatusBarMenuBuilderTests` — item order, separators, selectors, key equivalents/masks, targets (incl. `Quit → nil`), live Verify-title injection.

Full suite: **BUILD SUCCEEDED** / **TEST SUCCEEDED** locally (macOS 26 SDK), no regressions.

## Reviewer notes

- The `statusItem.menu` swap + `performClick` is the intended, safe idiom (the menu runs modally, so the `= nil` reset is correctly sequenced); not switching to `popUp`, which would lose the status-item pressed-state highlight.
- The context menu's key equivalents are informational only — it is shown transiently and is not in `NSApp.mainMenu`, so there's no global shortcut registration/conflict.