### PR TITLE
feat(conversation): in-conversation Find (⌘F) with match navigation

### DIFF
--- a/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationDetailView.swift
@@ -29,10 +29,24 @@ final class ConversationDetailView: NSView {
     /// already visible) from "new content" (reveal the target).
     private var renderedBlockIDs: [String] = []
 
+    // MARK: - In-conversation find (D-3)
+    private let findBar = ConversationFindBar(frame: .zero)
+    /// `scrollView.top == self.top` when the find bar is hidden; swapped for
+    /// `scrollView.top == findBar.bottom` while finding so the bar doesn't
+    /// cover the first card.
+    private var scrollTopToContainer: NSLayoutConstraint!
+    private var scrollTopToFindBar: NSLayoutConstraint!
+    /// Text views searched in the current find session, in document order —
+    /// `ConversationFindEngine.Match.textIndex` indexes into this.
+    private var findTextViews: [ConversationBodyTextView] = []
+    private var findMatches: [ConversationFindEngine.Match] = []
+    private var findCurrentIndex: Int?
+
     override init(frame: NSRect) {
         super.init(frame: frame)
         registerRenderers()
         setup()
+        setupFindBar()
     }
 
     @available(*, unavailable)
@@ -67,8 +81,9 @@ final class ConversationDetailView: NSView {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(scrollView)
 
+        scrollTopToContainer = scrollView.topAnchor.constraint(equalTo: topAnchor)
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollTopToContainer,
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -151,6 +166,11 @@ final class ConversationDetailView: NSView {
             scrollView.contentView.scroll(to: .zero)
             scrollView.reflectScrolledClipView(scrollView.contentView)
         }
+        // The card views were rebuilt, so any prior find snapshot is stale.
+        // Re-run the query against the fresh text views (no-op when not finding).
+        if isFinding {
+            updateFind(query: findBar.query, reveal: false)
+        }
     }
 
     /// Scroll only as much as needed to reveal `view`. When `keepIfVisible` (the
@@ -179,6 +199,163 @@ final class ConversationDetailView: NSView {
             targetY = rect.maxY - visibleHeight + topInset
         }
         let clamped = min(max(0, targetY), maxY)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: clamped))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    // MARK: - In-conversation find (D-3)
+
+    private func setupFindBar() {
+        findBar.translatesAutoresizingMaskIntoConstraints = false
+        findBar.isHidden = true
+        addSubview(findBar)
+
+        scrollTopToFindBar = scrollView.topAnchor.constraint(equalTo: findBar.bottomAnchor)
+        NSLayoutConstraint.activate([
+            findBar.topAnchor.constraint(equalTo: topAnchor),
+            findBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            findBar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            findBar.heightAnchor.constraint(equalToConstant: ConversationFindBar.barHeight),
+        ])
+
+        findBar.onQueryChanged = { [weak self] query in self?.updateFind(query: query, reveal: true) }
+        findBar.onNext = { [weak self] in self?.stepFind(forward: true) }
+        findBar.onPrevious = { [weak self] in self?.stepFind(forward: false) }
+        findBar.onClose = { [weak self] in self?.endFind() }
+    }
+
+    /// True while the find bar is mounted and visible.
+    var isFinding: Bool { !findBar.isHidden }
+
+    /// Reveal the find bar and focus its field. Re-applies the current query so
+    /// reopening over an existing search restores its highlights.
+    func beginFind() {
+        guard !isFinding else { findBar.focusField(); return }
+        findBar.isHidden = false
+        scrollTopToContainer.isActive = false
+        scrollTopToFindBar.isActive = true
+        updateFind(query: findBar.query, reveal: true)
+        findBar.focusField()
+    }
+
+    /// Hide the find bar and drop all match highlights.
+    func endFind() {
+        guard isFinding else { return }
+        clearHighlights()
+        findTextViews = []
+        findMatches = []
+        findCurrentIndex = nil
+        scrollTopToFindBar.isActive = false
+        scrollTopToContainer.isActive = true
+        findBar.isHidden = true
+    }
+
+    /// Advance to the next / previous match (wraps). No-op without matches.
+    func findNext() { stepFind(forward: true) }
+    func findPrevious() { stepFind(forward: false) }
+
+    private func stepFind(forward: Bool) {
+        guard !findMatches.isEmpty else { NSSound.beep(); return }
+        findCurrentIndex = ConversationFindEngine.step(
+            current: findCurrentIndex, count: findMatches.count, forward: forward
+        )
+        applyHighlights()
+        revealCurrentMatch()
+        findBar.setCount(current: findCurrentIndex, total: findMatches.count)
+    }
+
+    /// Rebuild the match set for `query` against the live card text views.
+    private func updateFind(query: String, reveal: Bool) {
+        findTextViews = conversationTextViews()
+        let texts = findTextViews.map(\.string)
+        findMatches = ConversationFindEngine.matches(in: texts, query: query)
+        findCurrentIndex = findMatches.isEmpty ? nil : 0
+        applyHighlights()
+        if reveal { revealCurrentMatch() }
+        findBar.setCount(current: findCurrentIndex, total: findMatches.count)
+    }
+
+    /// All `ConversationBodyTextView`s in the card stack, in document order
+    /// (depth-first) — covers prompt/assistant/thinking/activity bodies, whether
+    /// direct card bodies or sections inside a `ConversationMarkdownView`.
+    private func conversationTextViews() -> [ConversationBodyTextView] {
+        var found: [ConversationBodyTextView] = []
+        func walk(_ view: NSView) {
+            for sub in view.subviews {
+                if let tv = sub as? ConversationBodyTextView { found.append(tv) }
+                walk(sub)
+            }
+        }
+        for card in stack.arrangedSubviews { walk(card) }
+        return found
+    }
+
+    private func clearHighlights() {
+        for textView in findTextViews {
+            guard let lm = textView.layoutManager else { continue }
+            let full = NSRange(location: 0, length: (textView.string as NSString).length)
+            lm.removeTemporaryAttribute(.backgroundColor, forCharacterRange: full)
+            lm.removeTemporaryAttribute(.foregroundColor, forCharacterRange: full)
+        }
+    }
+
+    private func applyHighlights() {
+        clearHighlights()
+        for (i, match) in findMatches.enumerated() {
+            guard findTextViews.indices.contains(match.textIndex) else { continue }
+            let textView = findTextViews[match.textIndex]
+            // Defensive: a temporary attribute on a range past the view's
+            // current length throws NSRangeException. The range is rebuilt from
+            // this same view's string, so it holds today — guard anyway against
+            // a future renderer that mutates a body in place without a rebuild.
+            guard let lm = textView.layoutManager,
+                  NSMaxRange(match.range) <= (textView.string as NSString).length else { continue }
+            // Current match gets a stronger tint; black foreground keeps the
+            // matched text legible on the yellow/orange in both appearances
+            // (mirrors QueryHighlighter's contrast handling).
+            let background = (i == findCurrentIndex)
+                ? NSColor.systemOrange
+                : NSColor.findHighlightColor
+            lm.addTemporaryAttributes(
+                [.backgroundColor: background, .foregroundColor: NSColor.black],
+                forCharacterRange: match.range
+            )
+        }
+    }
+
+    private func revealCurrentMatch() {
+        guard let index = findCurrentIndex, findMatches.indices.contains(index) else { return }
+        let match = findMatches[index]
+        guard findTextViews.indices.contains(match.textIndex) else { return }
+        let textView = findTextViews[match.textIndex]
+        guard let lm = textView.layoutManager, let tc = textView.textContainer,
+              NSMaxRange(match.range) <= (textView.string as NSString).length else { return }
+        let glyphRange = lm.glyphRange(forCharacterRange: match.range, actualCharacterRange: nil)
+        var rect = lm.boundingRect(forGlyphRange: glyphRange, in: tc)
+        rect.origin.x += textView.textContainerOrigin.x
+        rect.origin.y += textView.textContainerOrigin.y
+        let inDocument = textView.convert(rect, to: documentView)
+        scrollDocumentRectIntoView(inDocument)
+    }
+
+    /// Scroll the minimum amount to bring `rect` (in documentView coords) into
+    /// view, leaving room below the find bar at the top. (Named to avoid
+    /// colliding with `NSView.scrollRectToVisible(_:)`.)
+    private func scrollDocumentRectIntoView(_ rect: NSRect) {
+        let clip = scrollView.contentView.bounds
+        let visibleHeight = clip.height
+        let documentHeight = max(documentView.bounds.height, stack.fittingSize.height)
+        let maxY = max(0, documentHeight - visibleHeight)
+        let topInset = ConversationFindBar.barHeight + 8
+
+        var targetY = clip.origin.y
+        if rect.minY < clip.minY + topInset {
+            targetY = rect.minY - topInset
+        } else if rect.maxY > clip.maxY {
+            targetY = rect.maxY - visibleHeight + 12
+        }
+        let clamped = min(max(0, targetY), maxY)
+        guard abs(clamped - clip.origin.y) > 0.5 else { return }
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: clamped))
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }

--- a/Lupen/UI/Dashboard/Conversation/ConversationFindBar.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationFindBar.swift
@@ -1,0 +1,135 @@
+import AppKit
+
+/// Slim find bar shown atop the Conversation detail (D-3). A search field +
+/// match counter + prev/next + close. It owns no find logic — it reports user
+/// intent through closures and the host (`ConversationDetailView`) drives the
+/// match model and highlighting.
+///
+/// Keyboard: Return = next, Shift+Return = previous, Esc = close. ⌘G / ⇧⌘G are
+/// handled by the menu → `DetailViewController` while the bar is open.
+@MainActor
+final class ConversationFindBar: NSView, NSSearchFieldDelegate {
+
+    private let field = NSSearchField()
+    private let countLabel = NSTextField(labelWithString: "")
+    private let prevButton = NSButton()
+    private let nextButton = NSButton()
+    private let closeButton = NSButton()
+
+    /// Fired on every keystroke with the live query.
+    var onQueryChanged: ((String) -> Void)?
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    var onClose: (() -> Void)?
+
+    static let barHeight: CGFloat = 36
+
+    var query: String { field.stringValue }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        field.placeholderString = "Find in conversation"
+        field.delegate = self
+        field.sendsWholeSearchString = false
+        field.focusRingType = .none
+        field.controlSize = .small
+        field.font = .systemFont(ofSize: 12)
+
+        countLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.alignment = .right
+        countLabel.setContentHuggingPriority(.required, for: .horizontal)
+        countLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        configureIconButton(prevButton, symbol: "chevron.up", tip: "Previous match (⇧⌘G)", action: #selector(prevClicked))
+        configureIconButton(nextButton, symbol: "chevron.down", tip: "Next match (⌘G)", action: #selector(nextClicked))
+        configureIconButton(closeButton, symbol: "xmark", tip: "Close (Esc)", action: #selector(closeClicked))
+
+        let stack = NSStackView(views: [field, countLabel, prevButton, nextButton, closeButton])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separator)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            field.widthAnchor.constraint(greaterThanOrEqualToConstant: 180),
+
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func configureIconButton(_ button: NSButton, symbol: String, tip: String, action: Selector) {
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tip)
+        button.bezelStyle = .accessoryBar
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.toolTip = tip
+        button.target = self
+        button.action = action
+        button.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    /// Make the search field the first responder and select its text.
+    func focusField() {
+        window?.makeFirstResponder(field)
+        field.selectText(nil)
+    }
+
+    /// Update the "current/total" counter. `current` is a 0-based index.
+    func setCount(current: Int?, total: Int) {
+        if total == 0 {
+            countLabel.stringValue = query.isEmpty ? "" : "No matches"
+        } else {
+            countLabel.stringValue = "\((current ?? 0) + 1)/\(total)"
+        }
+        prevButton.isEnabled = total > 0
+        nextButton.isEnabled = total > 0
+    }
+
+    // MARK: - Actions
+
+    @objc private func prevClicked() { onPrevious?() }
+    @objc private func nextClicked() { onNext?() }
+    @objc private func closeClicked() { onClose?() }
+
+    // MARK: - NSSearchFieldDelegate
+
+    func controlTextDidChange(_ obj: Notification) {
+        onQueryChanged?(field.stringValue)
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        switch commandSelector {
+        case #selector(NSResponder.insertNewline(_:)):
+            onNext?()
+            return true
+        case #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)):
+            onPrevious?()                       // Shift+Return
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            onClose?()                          // Esc
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Lupen/UI/Dashboard/Conversation/ConversationFindEngine.swift
+++ b/Lupen/UI/Dashboard/Conversation/ConversationFindEngine.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Pure find logic for the in-conversation find bar. It operates on plain
+/// strings (the rendered text of each conversation card, in document order) so
+/// it is fully unit-testable without AppKit text views — the view layer maps a
+/// `Match.textIndex` back to the actual `ConversationBodyTextView`.
+///
+/// Range finding is delegated to `QueryHighlighter.ranges(in:query:)` so the
+/// in-conversation find and the sidebar/outline highlight match identically
+/// (case-insensitive, non-overlapping, UTF-16 offsets).
+enum ConversationFindEngine {
+
+    /// A single occurrence: which text view (by document-order index) and the
+    /// UTF-16 range within that view's string.
+    struct Match: Equatable {
+        let textIndex: Int
+        let range: NSRange
+    }
+
+    /// All occurrences of `query` across `texts`, in document order (text 0
+    /// first, then by position within each text). Empty/whitespace query — or
+    /// no occurrence — yields `[]`.
+    static func matches(in texts: [String], query: String) -> [Match] {
+        var result: [Match] = []
+        for (index, text) in texts.enumerated() {
+            for range in QueryHighlighter.ranges(in: text, query: query) {
+                result.append(Match(textIndex: index, range: range))
+            }
+        }
+        return result
+    }
+
+    /// The current-match index after stepping forward/back with wraparound.
+    /// - `count == 0` → `nil` (nothing to select).
+    /// - `current == nil` (no selection yet) → first match when going forward,
+    ///   last when going back.
+    /// - otherwise advances cyclically.
+    static func step(current: Int?, count: Int, forward: Bool) -> Int? {
+        guard count > 0 else { return nil }
+        guard let current else { return forward ? 0 : count - 1 }
+        if forward { return (current + 1) % count }
+        return (current - 1 + count) % count
+    }
+}

--- a/Lupen/UI/Dashboard/DetailViewController.swift
+++ b/Lupen/UI/Dashboard/DetailViewController.swift
@@ -808,6 +808,9 @@ final class DetailViewController: NSViewController {
     }
 
     private func showTab(_ index: Int) {
+        // Leaving the Conversation tab dismisses its find bar (the other tabs
+        // aren't searchable) so stale match highlights don't linger.
+        if index != 0 { conversationView.endFind() }
         // First visit to Raw/Usage for this selection: run the parked
         // loader (plan 4.2 — hidden tabs never fetch).
         if Self.lazyTabIndexes.contains(index),
@@ -819,6 +822,39 @@ final class DetailViewController: NSViewController {
         }
         for (i, tabView) in currentTabViews.enumerated() {
             tabView.isHidden = (i != index)
+        }
+    }
+
+    // MARK: - Find (D-3)
+
+    /// ⌘F via the responder chain. When focus is in the detail pane and the
+    /// Conversation tab is showing, open its in-conversation find bar. On any
+    /// other tab, forward to the next responder so the sidebar's session search
+    /// keeps the shortcut (context-aware Find).
+    @objc func focusSearchField(_ sender: Any?) {
+        guard segmentedControl.selectedSegment == 0 else {
+            nextResponder?.tryToPerform(#selector(focusSearchField(_:)), with: sender)
+            return
+        }
+        conversationView.beginFind()
+    }
+
+    /// ⌘G / ⇧⌘G. While the conversation find bar is active, drive its match
+    /// navigation; otherwise forward so the Turn-outline match navigation keeps
+    /// the shortcut unchanged.
+    @objc func navigateToNextMatch(_ sender: Any?) {
+        if conversationView.isFinding {
+            conversationView.findNext()
+        } else {
+            nextResponder?.tryToPerform(#selector(navigateToNextMatch(_:)), with: sender)
+        }
+    }
+
+    @objc func navigateToPreviousMatch(_ sender: Any?) {
+        if conversationView.isFinding {
+            conversationView.findPrevious()
+        } else {
+            nextResponder?.tryToPerform(#selector(navigateToPreviousMatch(_:)), with: sender)
         }
     }
 

--- a/Lupen/UI/Support/QueryHighlighter.swift
+++ b/Lupen/UI/Support/QueryHighlighter.swift
@@ -13,6 +13,32 @@ import AppKit
 /// Pure function — no side effects, no state, unit-testable.
 enum QueryHighlighter {
 
+    /// Every case-insensitive occurrence of `query` within `string`, as
+    /// `NSRange`s (UTF-16 offsets, ready for `NSAttributedString` /
+    /// `NSLayoutManager`). Empty or whitespace-only queries — and any string
+    /// with no occurrence — return `[]`. Non-overlapping, left to right.
+    ///
+    /// Shared by the sidebar/outline highlight (`applied(to:query:)`) and the
+    /// in-conversation find (which needs the raw ranges to drive temporary
+    /// layout-manager highlighting + scroll-to-match).
+    static func ranges(in string: String, query: String) -> [NSRange] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var ranges: [NSRange] = []
+        var searchStart = string.startIndex
+        while searchStart < string.endIndex,
+              let match = string.range(
+                  of: trimmed,
+                  options: .caseInsensitive,
+                  range: searchStart..<string.endIndex
+              ) {
+            ranges.append(NSRange(match, in: string))
+            searchStart = match.upperBound
+        }
+        return ranges
+    }
+
     /// Return a copy of `base` with `NSColor.findHighlightColor`
     /// background on every case-insensitive occurrence of `query`.
     ///
@@ -23,23 +49,7 @@ enum QueryHighlighter {
         to base: NSAttributedString,
         query: String
     ) -> NSAttributedString {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return base }
-
-        let string = base.string
-        var ranges: [NSRange] = []
-        var searchStart = string.startIndex
-
-        while searchStart < string.endIndex,
-              let match = string.range(
-                  of: trimmed,
-                  options: .caseInsensitive,
-                  range: searchStart..<string.endIndex
-              ) {
-            ranges.append(NSRange(match, in: string))
-            searchStart = match.upperBound
-        }
-
+        let ranges = ranges(in: base.string, query: query)
         guard !ranges.isEmpty else { return base }
 
         let result = NSMutableAttributedString(attributedString: base)

--- a/LupenTests/UI/Dashboard/Conversation/ConversationFindEngineTests.swift
+++ b/LupenTests/UI/Dashboard/Conversation/ConversationFindEngineTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Lupen
+
+@Suite("ConversationFindEngine")
+struct ConversationFindEngineTests {
+
+    typealias Match = ConversationFindEngine.Match
+
+    // MARK: - matches(in:query:)
+
+    @Test("empty query yields no matches")
+    func emptyQuery() {
+        #expect(ConversationFindEngine.matches(in: ["hello", "world"], query: "").isEmpty)
+        #expect(ConversationFindEngine.matches(in: ["hello", "world"], query: "  ").isEmpty)
+    }
+
+    @Test("no texts yields no matches")
+    func noTexts() {
+        #expect(ConversationFindEngine.matches(in: [], query: "x").isEmpty)
+    }
+
+    @Test("no occurrence yields no matches")
+    func noOccurrence() {
+        #expect(ConversationFindEngine.matches(in: ["hello", "world"], query: "zzz").isEmpty)
+    }
+
+    @Test("matches carry the document-order text index and range")
+    func textIndexAndRange() {
+        let texts = ["the cache layer", "no hits here", "cache again and cache"]
+        let m = ConversationFindEngine.matches(in: texts, query: "cache")
+        #expect(m == [
+            Match(textIndex: 0, range: NSRange(location: 4, length: 5)),
+            Match(textIndex: 2, range: NSRange(location: 0, length: 5)),
+            Match(textIndex: 2, range: NSRange(location: 16, length: 5)),
+        ])
+    }
+
+    @Test("matches are case-insensitive")
+    func caseInsensitive() {
+        let m = ConversationFindEngine.matches(in: ["Cache", "CACHE"], query: "cache")
+        #expect(m.count == 2)
+        #expect(m.map(\.textIndex) == [0, 1])
+    }
+
+    @Test("ordering: all of text 0 before text 1")
+    func documentOrder() {
+        let m = ConversationFindEngine.matches(in: ["a a", "a"], query: "a")
+        #expect(m.map(\.textIndex) == [0, 0, 1])
+    }
+
+    // MARK: - step(current:count:forward:)
+
+    @Test("step with no matches is nil")
+    func stepEmpty() {
+        #expect(ConversationFindEngine.step(current: nil, count: 0, forward: true) == nil)
+        #expect(ConversationFindEngine.step(current: 2, count: 0, forward: false) == nil)
+    }
+
+    @Test("first step from no selection: forward→0, back→last")
+    func stepFromNil() {
+        #expect(ConversationFindEngine.step(current: nil, count: 5, forward: true) == 0)
+        #expect(ConversationFindEngine.step(current: nil, count: 5, forward: false) == 4)
+    }
+
+    @Test("forward advances and wraps")
+    func stepForwardWrap() {
+        #expect(ConversationFindEngine.step(current: 0, count: 3, forward: true) == 1)
+        #expect(ConversationFindEngine.step(current: 2, count: 3, forward: true) == 0)
+    }
+
+    @Test("backward retreats and wraps")
+    func stepBackwardWrap() {
+        #expect(ConversationFindEngine.step(current: 2, count: 3, forward: false) == 1)
+        #expect(ConversationFindEngine.step(current: 0, count: 3, forward: false) == 2)
+    }
+
+    @Test("single match stays put on either direction")
+    func stepSingle() {
+        #expect(ConversationFindEngine.step(current: 0, count: 1, forward: true) == 0)
+        #expect(ConversationFindEngine.step(current: 0, count: 1, forward: false) == 0)
+    }
+}

--- a/LupenTests/UI/Support/QueryHighlighterTests.swift
+++ b/LupenTests/UI/Support/QueryHighlighterTests.swift
@@ -108,4 +108,62 @@ struct QueryHighlighterTests {
         let highlighted = (result.string as NSString).substring(with: foundRange!)
         #expect(highlighted == "리팩토링")
     }
+
+    // MARK: - ranges(in:query:)
+
+    @Test("ranges: empty / whitespace query yields none")
+    func rangesEmpty() {
+        #expect(QueryHighlighter.ranges(in: "hello world", query: "").isEmpty)
+        #expect(QueryHighlighter.ranges(in: "hello world", query: "   \t").isEmpty)
+    }
+
+    @Test("ranges: no occurrence yields none")
+    func rangesNoMatch() {
+        #expect(QueryHighlighter.ranges(in: "hello world", query: "xyz").isEmpty)
+    }
+
+    @Test("ranges: single occurrence offset/length")
+    func rangesSingle() {
+        #expect(QueryHighlighter.ranges(in: "fix the cache layer", query: "cache")
+                == [NSRange(location: 8, length: 5)])
+    }
+
+    @Test("ranges: multiple non-overlapping, left to right")
+    func rangesMultiple() {
+        #expect(QueryHighlighter.ranges(in: "ok then ok again", query: "ok")
+                == [NSRange(location: 0, length: 2), NSRange(location: 8, length: 2)])
+    }
+
+    @Test("ranges: case-insensitive")
+    func rangesCaseInsensitive() {
+        #expect(QueryHighlighter.ranges(in: "Hello HELLO", query: "hello")
+                == [NSRange(location: 0, length: 5), NSRange(location: 6, length: 5)])
+    }
+
+    @Test("ranges: overlapping query advances past each match (no infinite loop)")
+    func rangesOverlapAdvance() {
+        // "aa" in "aaaa" → matches at 0 and 2 (non-overlapping, upperBound advance).
+        #expect(QueryHighlighter.ranges(in: "aaaa", query: "aa")
+                == [NSRange(location: 0, length: 2), NSRange(location: 2, length: 2)])
+    }
+
+    @Test("ranges: UTF-16 offsets survive astral characters before the match")
+    func rangesUTF16Offsets() {
+        // "👍" is a surrogate pair (2 UTF-16 units). The NSRange for "ok" after it
+        // must be expressed in UTF-16 units so NSAttributedString/NSLayoutManager
+        // address it correctly.
+        let s = "👍 ok"
+        let r = QueryHighlighter.ranges(in: s, query: "ok")
+        #expect(r == [NSRange(location: 3, length: 2)])
+        #expect((s as NSString).substring(with: r[0]) == "ok")
+    }
+
+    @Test("ranges: Korean multi-byte")
+    func rangesKorean() {
+        let s = "캐시 리팩토링 해줘 리팩토링"
+        let r = QueryHighlighter.ranges(in: s, query: "리팩토링")
+        #expect(r.count == 2)
+        #expect((s as NSString).substring(with: r[0]) == "리팩토링")
+        #expect((s as NSString).substring(with: r[1]) == "리팩토링")
+    }
 }


### PR DESCRIPTION
## What

Adds an **in-conversation Find bar** to the Conversation detail tab (dashboard item **D-3**). When the conversation is focused, **⌘F** opens a search field that highlights every case-insensitive match across the turn's body text — prompt, assistant, thinking and activity cards — and **⌘G / ⇧⌘G / Return / ⇧Return / the ◀ ▶ buttons** cycle through matches (wrapping), scrolling each into view with an **"n/m"** counter. **Esc** closes the bar; the current match is tinted orange, the rest yellow.

Find is **context-aware**: when focus is in the sidebar or the Turn outline, ⌘F and ⌘G keep their existing behavior (session search / outline match navigation) — there is no regression to those paths.

## Why

The conversation detail had no find at all — the only search was the sidebar field, which matches prompt text and highlights the Turn outline. Searching the actual rendered conversation (long assistant replies, thinking, tool activity) is a baseline expectation for long sessions.

## How

- **Pure, unit-tested logic** is split out:
  - `QueryHighlighter.ranges(in:query:)` — extracted from the existing `applied(to:query:)` (which now reuses it; behavior-preserving).
  - `ConversationFindEngine` — `matches(in:query:)` builds a flat `(textIndex, range)` list across the card text views in document order; `step(current:count:forward:)` cycles the current index with wraparound.
- **View layer** (`ConversationDetailView`) mounts the find bar (swapping the scroll view's top constraint so the bar never covers the first card), walks the card stack to collect `ConversationBodyTextView`s, highlights matches with **non-destructive `NSLayoutManager` temporary attributes** (cleared on close / query change / tab switch / turn rebuild), and scrolls the current match into view via `boundingRect(forGlyphRange:in:)`.
- **Routing** (`DetailViewController`) implements `focusSearchField` / `navigateToNextMatch` / `navigateToPreviousMatch`, handling them only on the Conversation tab and otherwise forwarding up the responder chain (`nextResponder?.tryToPerform`) so the sidebar / outline keep the shortcuts. Leaving the Conversation tab dismisses the bar.

## Scope

Collapsed cards (Thinking / activity / expandable tool details) are **out of scope** for this iteration — only visible body text is searched. Auto-expanding matches inside collapsed cards is deferred.

## Tests

19 new unit tests over the pure logic:
- `ConversationFindEngineTests` (11) — `matches` (empty/whitespace/no-text/no-occurrence/document-order/case) and `step` (empty/from-nil/forward+backward wrap/single).
- `QueryHighlighterTests` (8 added) — `ranges` incl. multiple, case-insensitive, overlap advance, UTF-16/astral offsets, Korean.

Full suite: **BUILD SUCCEEDED** / **TEST SUCCEEDED** locally (macOS 26 SDK), no regressions. Runtime-verified.

## Reviewer notes

- An independent review returned PASS (no blocker/major). A defensive range-vs-length guard was added in `applyHighlights`/`revealCurrentMatch` so a future in-place body mutation can't address a stale range (`NSRangeException`).
- Follow-up (non-blocking): the per-keystroke re-scan isn't debounced. The scanned text is bounded to one Turn, so it's a hardening improvement rather than a current issue.