### PR TITLE
feat(store): on-demand SQLite index integrity check + repair

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -191,6 +191,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Store cache the manage window uses to read an inactive provider's index.
     private var managedReadStores: [String: ProviderStore] = [:]
     private var verifyUsageMenuItem: NSMenuItem?
+    /// Guards against overlapping "Check Index Integrity" runs (the scan is
+    /// async; a second trigger would stack alerts and double-rebuild).
+    private var isCheckingIntegrity = false
     private lazy var logWindowController = LogWindowController(logger: LoggerService.shared)
     private let smokeTest = LaunchSmokeTestConfig.current()
     private let launchDiagnosticsConfig = LaunchDiagnosticsConfig.current()
@@ -1245,23 +1248,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// are never touched. Confirm first — on a large history the
     /// background re-index can take a while to fully repopulate.
     @objc func clearCacheAndReparse(_ sender: Any?) {
-        let alert = NSAlert()
-        alert.messageText = "Rebuild Index?"
-        alert.informativeText = """
+        guard confirmRebuildAlert(informativeText: """
         Lupen will clear its derived index and re-scan every session log in the background. \
         The sidebar repopulates as sessions are re-indexed; your provider logs on disk are not modified.
 
         Use this if the numbers look wrong or after a provider format change.
-        """
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "Rebuild Index")
-        alert.addButton(withTitle: "Cancel")
-
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        """) else { return }
 
         for startup in sqliteFirstStartups.values {
             startup.rebuildIndex()
         }
+    }
+
+    /// Shared "Rebuild Index?" confirmation. Returns true when the user
+    /// confirms. Used by `clearCacheAndReparse` (full re-index) and the
+    /// corruption-repair path (A-1).
+    private func confirmRebuildAlert(informativeText: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Rebuild Index?"
+        alert.informativeText = informativeText
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Rebuild Index")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     // MARK: - Index integrity (A-1)
@@ -1270,6 +1279,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// main thread (the scan touches every page); on completion reports the
     /// result and, if corruption is found, offers a rebuild + re-scan.
     @objc func checkIndexIntegrity(_ sender: Any?) {
+        guard !isCheckingIntegrity else { return }   // a scan is already running
         let startups = Array(sqliteFirstStartups.values)
         guard !startups.isEmpty else {
             let alert = NSAlert()
@@ -1279,35 +1289,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             alert.runModal()
             return
         }
+        isCheckingIntegrity = true
         DispatchQueue.global(qos: .userInitiated).async {
             let corrupt = startups.filter { !$0.checkIntegrity() }
             DispatchQueue.main.async { [weak self] in
                 self?.presentIntegrityResult(corrupt: corrupt)
+                self?.isCheckingIntegrity = false
             }
         }
     }
 
     private func presentIntegrityResult(corrupt: [SQLiteFirstStartup]) {
-        let alert = NSAlert()
         guard !corrupt.isEmpty else {
+            let alert = NSAlert()
             alert.messageText = "Index Is Healthy"
             alert.informativeText = "No problems were found in the session index."
             alert.addButton(withTitle: "OK")
             alert.runModal()
             return
         }
-        alert.messageText = "Index Corruption Detected"
-        alert.informativeText = """
+        guard confirmRebuildAlert(informativeText: """
         Lupen found corruption in its derived session index. Rebuild it now? \
         Lupen will re-scan your session logs in the background; your logs on disk \
         are not modified.
-        """
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "Rebuild Index")
-        alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        for startup in corrupt {
-            startup.rebuildIndex()
+        """) else { return }
+        // Re-check liveness: a source may have been switched/removed while the
+        // modal was open. Only repair drivers still owned by AppDelegate, and
+        // use the file-level rebuild (a corrupt b-tree can't be wiped in place).
+        let live = Set(sqliteFirstStartups.values.map { ObjectIdentifier($0) })
+        for startup in corrupt where live.contains(ObjectIdentifier(startup)) {
+            startup.repairCorruptIndex()
         }
     }
 }

--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -785,6 +785,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         fileMenu.addItem(.separator())
 
+        // A-1: non-destructive integrity check (PRAGMA quick_check) of the
+        // derived index, run on demand off the main thread. Offers a rebuild
+        // only if corruption is found.
+        let checkIntegrityItem = NSMenuItem(
+            title: "Check Index Integrity…",
+            action: #selector(checkIndexIntegrity(_:)),
+            keyEquivalent: ""
+        )
+        checkIntegrityItem.target = self
+        fileMenu.addItem(checkIntegrityItem)
+
         // Destructive-ish — wipes the derived SQLite indexes and
         // re-scans the source logs in the background. Confirm via
         // NSAlert so a mis-click doesn't discard a finished backfill.
@@ -1178,6 +1189,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 settings: settings,
                 onRevealLogFile: { [weak self] in self?.revealLogFileInFinder(nil) },
                 onClearCacheAndReparse: { [weak self] in self?.clearCacheAndReparse(nil) },
+                onCheckIndexIntegrity: { [weak self] in self?.checkIndexIntegrity(nil) },
                 statuslineService: statuslineService
             )
         }
@@ -1248,6 +1260,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
         for startup in sqliteFirstStartups.values {
+            startup.rebuildIndex()
+        }
+    }
+
+    // MARK: - Index integrity (A-1)
+
+    /// User-triggered `PRAGMA quick_check` of the open indexes. Runs off the
+    /// main thread (the scan touches every page); on completion reports the
+    /// result and, if corruption is found, offers a rebuild + re-scan.
+    @objc func checkIndexIntegrity(_ sender: Any?) {
+        let startups = Array(sqliteFirstStartups.values)
+        guard !startups.isEmpty else {
+            let alert = NSAlert()
+            alert.messageText = "No Index to Check"
+            alert.informativeText = "The session index hasn't been opened yet. Open the dashboard, then try again."
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let corrupt = startups.filter { !$0.checkIntegrity() }
+            DispatchQueue.main.async { [weak self] in
+                self?.presentIntegrityResult(corrupt: corrupt)
+            }
+        }
+    }
+
+    private func presentIntegrityResult(corrupt: [SQLiteFirstStartup]) {
+        let alert = NSAlert()
+        guard !corrupt.isEmpty else {
+            alert.messageText = "Index Is Healthy"
+            alert.informativeText = "No problems were found in the session index."
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+        alert.messageText = "Index Corruption Detected"
+        alert.informativeText = """
+        Lupen found corruption in its derived session index. Rebuild it now? \
+        Lupen will re-scan your session logs in the background; your logs on disk \
+        are not modified.
+        """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Rebuild Index")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        for startup in corrupt {
             startup.rebuildIndex()
         }
     }

--- a/Lupen/Store/ProviderDatabase.swift
+++ b/Lupen/Store/ProviderDatabase.swift
@@ -158,6 +158,29 @@ final class ProviderDatabase: @unchecked Sendable {
         try pool.close()
     }
 
+    // MARK: - Integrity (A-1)
+
+    /// Runs `PRAGMA quick_check` against the live pool and reports whether the
+    /// database is structurally sound. Returns `false` for any reported
+    /// corruption (a non-`"ok"` result) or when the check itself throws (the
+    /// file is too damaged to read).
+    ///
+    /// User-triggered (the "Check Index Integrity" menu action) rather than run
+    /// on open: `quick_check` scans every page, so keeping it off the launch
+    /// path avoids a stall on large indexes. The caller runs it off the main
+    /// thread; the pool is safe to read from any thread. The index is a derived
+    /// cache, so a `false` here is recovered by a transparent rebuild + re-scan.
+    func integrityCheck() -> Bool {
+        do {
+            let result = try pool.read { db in
+                try String.fetchOne(db, sql: "PRAGMA quick_check(1)")
+            }
+            return result == "ok"
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Storage failure recovery (plan 5.2b)
 
     /// True when `error` means the storage underneath an open pool can

--- a/Lupen/Store/SQLiteFirstStartup.swift
+++ b/Lupen/Store/SQLiteFirstStartup.swift
@@ -218,18 +218,7 @@ final class SQLiteFirstStartup: @unchecked Sendable {
     /// Source JSONL logs are never touched.
     @MainActor
     func rebuildIndex() {
-        if isProjectionActive, let appStore {
-            appStore.sessions = []
-            appStore.sessionListAggregates = [:]
-            appStore.diagnostics.restore(.empty)
-            lastDiagnosticsFingerprint = nil
-            appStore.sqliteTodayUsage = nil
-            appStore.isLoading = true
-            var progress = LaunchProgress()
-            progress.phase = .scanningFiles
-            progress.startedAt = Date()
-            appStore.launchProgress = progress
-        }
+        resetProjectionForRebuild()
         let store = coordinator.store
         let coordinator = self.coordinator
         DispatchQueue.global(qos: .userInitiated).async {
@@ -245,6 +234,50 @@ final class SQLiteFirstStartup: @unchecked Sendable {
             }
             coordinator.requestRescan()
         }
+    }
+
+    /// A-1 repair path for a *corrupt* index. Unlike `rebuildIndex()` — which
+    /// wipes rows through the open pool and would itself throw on a corrupt
+    /// b-tree — this deletes the database files and bootstraps a fresh pool
+    /// (`rebuildStorage()`, the same recovery the coordinator uses on a
+    /// persistent storage failure), then re-scans the source logs. The only
+    /// reliable recovery when the file is structurally damaged.
+    @MainActor
+    func repairCorruptIndex() {
+        resetProjectionForRebuild()
+        let database = coordinator.store.database
+        let coordinator = self.coordinator
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try database.rebuildStorage()
+            } catch {
+                LoggerService.shared.logFromAnyThread(
+                    .error,
+                    "Repair corrupt index: rebuildStorage failed — \(error)",
+                    context: "Store"
+                )
+                return
+            }
+            coordinator.requestRescan()
+        }
+    }
+
+    /// Reset the live sidebar projection to an empty "scanning" state before a
+    /// rebuild/repair re-scans (shared by `rebuildIndex()` and
+    /// `repairCorruptIndex()`).
+    @MainActor
+    private func resetProjectionForRebuild() {
+        guard isProjectionActive, let appStore else { return }
+        appStore.sessions = []
+        appStore.sessionListAggregates = [:]
+        appStore.diagnostics.restore(.empty)
+        lastDiagnosticsFingerprint = nil
+        appStore.sqliteTodayUsage = nil
+        appStore.isLoading = true
+        var progress = LaunchProgress()
+        progress.phase = .scanningFiles
+        progress.startedAt = Date()
+        appStore.launchProgress = progress
     }
 
     /// Routes the conversation outline to this driver's index

--- a/Lupen/Store/SQLiteFirstStartup.swift
+++ b/Lupen/Store/SQLiteFirstStartup.swift
@@ -203,6 +203,13 @@ final class SQLiteFirstStartup: @unchecked Sendable {
         isProjectionActive = false
     }
 
+    /// A-1: user-triggered integrity check — runs `PRAGMA quick_check` on this
+    /// source's index. Returns true when healthy. Safe to call off the main
+    /// thread (the pool is thread-safe). A `false` is repaired by `rebuildIndex()`.
+    func checkIntegrity() -> Bool {
+        coordinator.store.database.integrityCheck()
+    }
+
     /// Plan 5.2: user-triggered "Rebuild Index" — wipe every derived
     /// row and re-scan the source logs in the background. The wipe runs
     /// against the open pool (never delete DB files under a live writer

--- a/Lupen/UI/Preferences/PreferencesForm.swift
+++ b/Lupen/UI/Preferences/PreferencesForm.swift
@@ -31,6 +31,11 @@ struct PreferencesForm: View {
     /// closure is just a thin trigger.
     let onClearCacheAndReparse: () -> Void
 
+    /// Runs `PRAGMA quick_check` on the index and offers a rebuild only if
+    /// corruption is found. Mirrors `File ▸ Check Index Integrity…`; the
+    /// AppDelegate-side handler runs the scan off-main and shows the result.
+    let onCheckIndexIntegrity: () -> Void
+
     /// Statusline service — optional so callers that don't need
     /// limit-tracking UI (early test paths, partial bring-up) skip the
     /// section. Production AppDelegate always supplies one.
@@ -157,6 +162,12 @@ struct PreferencesForm: View {
                     Label("Reveal Log File in Finder", systemImage: "doc.text.magnifyingglass")
                 }
 
+                Button {
+                    onCheckIndexIntegrity()
+                } label: {
+                    Label("Check Index Integrity…", systemImage: "checkmark.shield")
+                }
+
                 Button(role: .destructive) {
                     onClearCacheAndReparse()
                 } label: {
@@ -165,7 +176,7 @@ struct PreferencesForm: View {
             } header: {
                 Text("Maintenance")
             } footer: {
-                Text("Reveal opens Finder on the Lupen log directory. Rebuild Index clears the derived index and re-scans every session log in the background — useful if numbers look wrong or after a provider format change. Source logs on disk are never modified.")
+                Text("Reveal opens Finder on the Lupen log directory. Check Index Integrity verifies the derived index and offers a rebuild only if it finds corruption. Rebuild Index clears the derived index and re-scans every session log in the background — useful if numbers look wrong or after a provider format change. Source logs on disk are never modified.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Lupen/UI/Preferences/PreferencesWindowController.swift
+++ b/Lupen/UI/Preferences/PreferencesWindowController.swift
@@ -28,6 +28,7 @@ final class PreferencesWindowController: NSWindowController, NSWindowDelegate {
         settings: AppSettings,
         onRevealLogFile: @escaping () -> Void,
         onClearCacheAndReparse: @escaping () -> Void,
+        onCheckIndexIntegrity: @escaping () -> Void,
         statuslineService: StatuslineConnectionService? = nil
     ) {
         self.settings = settings
@@ -54,6 +55,7 @@ final class PreferencesWindowController: NSWindowController, NSWindowDelegate {
             settings: settings,
             onRevealLogFile: onRevealLogFile,
             onClearCacheAndReparse: onClearCacheAndReparse,
+            onCheckIndexIntegrity: onCheckIndexIntegrity,
             statuslineService: statuslineService
         )
         let hosting = NSHostingController(rootView: root)

--- a/LupenTests/Store/ProviderDatabaseTests.swift
+++ b/LupenTests/Store/ProviderDatabaseTests.swift
@@ -131,4 +131,69 @@ struct ProviderDatabaseTests {
         }
         #expect(afterCommit == 2)
     }
+
+    // MARK: - Integrity check (A-1)
+
+    @Test("integrityCheck reports a healthy database as sound")
+    func integrityHealthy() throws {
+        let (url, cleanup) = makeTempURL()
+        defer { cleanup() }
+
+        let database = try ProviderDatabase.open(at: url)
+        defer { try? database.close() }
+        try database.pool.write { db in
+            try db.execute(sql: "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            try db.execute(sql: "INSERT INTO t (id, v) VALUES (1, 'hello')")
+        }
+        #expect(database.integrityCheck() == true)
+    }
+
+    @Test("integrityCheck reports a corrupted b-tree page as unsound")
+    func integrityCorrupt() throws {
+        let (url, cleanup) = makeTempURL()
+        defer { cleanup() }
+
+        // Seed enough rows to spill past page 1, then checkpoint into the main
+        // file so the corruption we write lands in a real b-tree page.
+        let pageSize: Int
+        do {
+            let database = try ProviderDatabase.open(at: url)
+            try database.pool.write { db in
+                try db.execute(sql: "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                for i in 0..<400 {
+                    try db.execute(
+                        sql: "INSERT INTO t (id, v) VALUES (?, ?)",
+                        arguments: [i, String(repeating: "x", count: 200)]
+                    )
+                }
+            }
+            // Checkpoint OUTSIDE a transaction (a transactional wal_checkpoint is
+            // a no-op) so all rows land in the main file — otherwise the page we
+            // corrupt sits in the WAL, not the .sqlite3 we overwrite.
+            try database.pool.barrierWriteWithoutTransaction { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+            pageSize = try database.pool.read { db in
+                try Int.fetchOne(db, sql: "PRAGMA page_size") ?? 4096
+            }
+            try database.close()
+        }
+
+        // Drop WAL/SHM so no leftover frame overlays (masks) the on-disk
+        // corruption when the file is reopened.
+        for suffix in ["-wal", "-shm"] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
+        }
+
+        // Overwrite page 2 (the table's b-tree root) with garbage, leaving the
+        // header (page 1) intact so the file still opens.
+        let handle = try FileHandle(forUpdating: url)
+        try handle.seek(toOffset: UInt64(pageSize))
+        try handle.write(contentsOf: Data(repeating: 0xFF, count: pageSize))
+        try handle.close()
+
+        let database = try ProviderDatabase.open(at: url)
+        defer { try? database.close() }
+        #expect(database.integrityCheck() == false)
+    }
 }


### PR DESCRIPTION
## What

Adds a user-triggered **"Check Index Integrity…"** maintenance action (dashboard item **A-1**) under **File** and mirrored in **Settings ▸ Maintenance**. It runs `PRAGMA quick_check` against the open session index off the main thread:

- **Healthy** → "No problems found" confirmation.
- **Corrupt** → "Rebuild Index?" → on confirm, deletes the index files and re-scans the source logs in the background.

## Why

The derived SQLite index can develop corruption (torn pages, a damaged `-wal`) that today only surfaces as a failed query mid-session. A-1 lets the user verify integrity on demand and repair it transparently — the index is a rebuildable cache, the source JSONL logs are never touched.

**Run on demand, not on open** (per design discussion): `quick_check` scans every page, so putting it on the launch path would stall startup on large indexes (e.g. a big Codex corpus). Keeping it behind a menu action avoids any launch-time cost. Import-time storage failures continue to self-heal via `ProviderIndexCoordinator`.

## How

- `ProviderDatabase.integrityCheck() -> Bool` — runs `PRAGMA quick_check(1)` on the pool; returns `false` on a non-`"ok"` result or a thrown read. GRDB stays inside `Store` (returns a plain `Bool`).
- `SQLiteFirstStartup.checkIntegrity()` (passthrough) and `repairCorruptIndex()` — repair uses `ProviderDatabase.rebuildStorage()` (delete files + fresh pool), **not** the row-wipe `rebuildIndex()`, because a `DELETE` through a corrupt b-tree would itself throw.
- `AppDelegate` — File-menu item + handler: runs the scan on a background queue, reports on the main thread, and offers the repair. Re-entrancy guarded; driver liveness re-checked after the confirm modal.
- `PreferencesForm`/`PreferencesWindowController` — Settings ▸ Maintenance mirror button.

## Tests

`ProviderDatabaseTests`:
- `integrityHealthy` — a healthy DB reports sound.
- `integrityCorrupt` — seeds multi-page data, checkpoints it into the main file, overwrites the table's b-tree root page, and verifies `integrityCheck()` returns `false`.

Full suite: **BUILD SUCCEEDED** / **TEST SUCCEEDED** locally (macOS 26 SDK), no regressions.

## Iteration (commits)

1. `32ecc9c` — integrity check + menu/Settings wiring + tests.
2. `b254c03` — code-review fixes: repair via `rebuildStorage` (a corrupt b-tree can't be wiped in place), re-entrancy + stale-driver guards, shared confirm-alert/projection-reset helpers.

## Reviewer notes

A high-effort multi-angle review ran on the branch; the findings above were fixed. Accepted-with-rationale (non-blocking): the per-startup `checkIntegrity()` passthrough is kept to preserve the Store encapsulation boundary; the check covers all open indexes (a maintenance command verifying every live index, repairing only the corrupt ones).