### PR TITLE
fix(stability): drop force-unwraps on hot/launch paths

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -316,7 +316,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             settings: settings,
             rateLimitSampleStore: rateLimitSampleStore
         )
-        dashboardController = DashboardWindowController(
+        // Bind the local first, then store it — avoids a `dashboardController!`
+        // force-unwrap on the launch path.
+        let dashboard = DashboardWindowController(
             store: store,
             settings: settings,
             autoSelectFirstSessionOnShow: !launchDiagnosticsConfig.dashboardAutoSelectDisabled,
@@ -324,8 +326,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.openLogs(nil)
             }
         )
-
-        let dashboard = dashboardController!
+        dashboardController = dashboard
         statusBarController.setClickHandler { _ in
             LoggerService.shared.debug("Click handler executing — calling showDashboard", context: "App")
             dashboard.showDashboard()

--- a/Lupen/Domain/Codex/CodexUsageSessionLoader.swift
+++ b/Lupen/Domain/Codex/CodexUsageSessionLoader.swift
@@ -1057,10 +1057,17 @@ enum CodexUsageSessionLoader {
                 provider: .codex,
                 rawSessionId: visibleRawSessionId
             ).value
-            let primaryPiece = primaryPiece(
+            guard let primaryPiece = primaryPiece(
                 in: groupPieces,
                 visibleRawSessionId: visibleRawSessionId
-            )
+            ) else {
+                LoggerService.shared.logFromAnyThread(
+                    .warning,
+                    "Codex: skipping empty session group '\(visibleRawSessionId)'",
+                    context: "Store"
+                )
+                continue
+            }
             let assembledPieces = groupPieces.map { piece in
                 AssembledSessionPiece(
                     piece: piece,
@@ -1261,16 +1268,19 @@ enum CodexUsageSessionLoader {
     private static func primaryPiece(
         in pieces: [LoadedSessionPiece],
         visibleRawSessionId: String
-    ) -> LoadedSessionPiece {
+    ) -> LoadedSessionPiece? {
         if let parent = pieces.first(where: { $0.metadata.id == visibleRawSessionId }) {
             return parent
         }
+        // `.first` (not `.first!`): a grouped value is non-empty by construction,
+        // but degrade gracefully (caller skips the group) rather than trap if an
+        // empty group ever reaches here.
         return pieces.sorted { lhs, rhs in
             let lhsTime = lhs.metadata.createdAt ?? .distantPast
             let rhsTime = rhs.metadata.createdAt ?? .distantPast
             if lhsTime != rhsTime { return lhsTime < rhsTime }
             return lhs.metadata.id < rhs.metadata.id
-        }.first!
+        }.first
     }
 
     static func normalizeTurns(

--- a/Lupen/Domain/LoggerService.swift
+++ b/Lupen/Domain/LoggerService.swift
@@ -216,10 +216,15 @@ final class LoggerService {
     /// menu's "Reveal Log File in Finder" can open the directory even
     /// when file logging is disabled and no log file exists yet.
     static var logDirectoryURL: URL {
+        // Force-unwrapping `.first` would trap if the system ever returned no
+        // Application Support URL (sandbox edge cases). Fall back to the home
+        // directory instead — logging must never crash the app. (No log here:
+        // this is the logger's own path accessor.)
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
-        ).first!
+        ).first ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
         return appSupport.appendingPathComponent("Lupen/Logs")
     }
 

--- a/Lupen/Domain/LoggerService.swift
+++ b/Lupen/Domain/LoggerService.swift
@@ -216,16 +216,12 @@ final class LoggerService {
     /// menu's "Reveal Log File in Finder" can open the directory even
     /// when file logging is disabled and no log file exists yet.
     static var logDirectoryURL: URL {
-        // Force-unwrapping `.first` would trap if the system ever returned no
-        // Application Support URL (sandbox edge cases). Fall back to the home
-        // directory instead — logging must never crash the app. (No log here:
-        // this is the logger's own path accessor.)
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
-            .appendingPathComponent("Library/Application Support", isDirectory: true)
-        return appSupport.appendingPathComponent("Lupen/Logs")
+        // Defer to the canonical resolver instead of force-unwrapping `.first`
+        // and hardcoding a parallel home-dir fallback. `applicationSupportRoot()`
+        // already handles the no-URL fallback AND the `LUPEN_APP_SUPPORT_DIR`
+        // override (so logs land beside the rest of Lupen's data, not in a
+        // divergent directory). Normal path is unchanged: …/Application Support/Lupen/Logs.
+        LupenPaths.applicationSupportRoot().appendingPathComponent("Logs")
     }
 
     /// Backward-compat alias for the old private accessor.

--- a/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
+++ b/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
@@ -131,3 +131,16 @@ struct LoggerServiceConcurrencyTests {
         #expect(ts <= afterCall.addingTimeInterval(0.02))
     }
 }
+
+/// A-3: `logDirectoryURL` dropped a `.first!` force-unwrap for a home-dir
+/// fallback. Guards that the path still resolves to `…/Lupen/Logs` and never
+/// traps (the accessor the "Reveal Log File" action depends on).
+@Suite("LoggerService log directory")
+struct LoggerServiceLogDirectoryTests {
+    @Test("logDirectoryURL resolves under a Lupen/Logs path")
+    @MainActor
+    func logDirectoryShape() {
+        let url = LoggerService.logDirectoryURL
+        #expect(Array(url.pathComponents.suffix(2)) == ["Lupen", "Logs"])
+    }
+}

--- a/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
+++ b/LupenTests/Domain/LoggerServiceConcurrencyTests.swift
@@ -132,15 +132,17 @@ struct LoggerServiceConcurrencyTests {
     }
 }
 
-/// A-3: `logDirectoryURL` dropped a `.first!` force-unwrap for a home-dir
-/// fallback. Guards that the path still resolves to `…/Lupen/Logs` and never
-/// traps (the accessor the "Reveal Log File" action depends on).
+/// A-3: `logDirectoryURL` dropped a `.first!` force-unwrap and now defers to
+/// `LupenPaths.applicationSupportRoot()`. Guards that logs resolve to a `Logs`
+/// directory under the canonical app-support root (honoring the override),
+/// and that the accessor never traps.
 @Suite("LoggerService log directory")
 struct LoggerServiceLogDirectoryTests {
-    @Test("logDirectoryURL resolves under a Lupen/Logs path")
+    @Test("logDirectoryURL is the canonical app-support root + /Logs")
     @MainActor
     func logDirectoryShape() {
         let url = LoggerService.logDirectoryURL
-        #expect(Array(url.pathComponents.suffix(2)) == ["Lupen", "Logs"])
+        #expect(url.lastPathComponent == "Logs")
+        #expect(url.deletingLastPathComponent() == LupenPaths.applicationSupportRoot())
     }
 }


### PR DESCRIPTION
## What

Removes three force-unwraps on hot / launch paths that would trap the **whole app** on an unexpected state (dashboard item **A-3**), replacing each with a graceful fallback:

- **`LoggerService.logDirectoryURL`** — `.first!` on the Application Support URLs → defers to `LupenPaths.applicationSupportRoot()` (which owns the no-URL fallback). Logging must never crash the app.
- **`CodexUsageSessionLoader.primaryPiece(in:visibleRawSessionId:)`** — `.first!` → returns optional; the caller logs and skips the group instead of trapping.
- **`AppDelegate` launch** — `dashboardController!` → bind the local `DashboardWindowController` first, then assign it, so there's no unwrap.

## Why

Each of these sits on a path hit at launch or during indexing, where corrupt/unexpected input (a missing system URL, an empty session group) would otherwise `fatalError` the entire app instead of degrading. The index/logs are recoverable, so the right behavior is guard + fallback.

While fixing the logger unwrap, the hand-rolled home-dir fallback was found to duplicate `LupenPaths.applicationSupportRoot()` **and** ignore the `LUPEN_APP_SUPPORT_DIR` override — so logs could scatter to a directory the rest of Lupen no longer writes to. The logger now reuses the canonical resolver. Normal path is unchanged: `…/Application Support/Lupen/Logs`.

## Not changed (reviewed)

`SameRawReplayCarry.keysByMode[0/1/2]` was flagged but left as-is: it indexes a fixed three-element array (`[[], [], []]`) by a fixed three-mode list (`sameRawReplayModes`), so the subscript cannot trap.

## Tests

`LoggerServiceLogDirectoryTests.logDirectoryShape` — asserts the log dir is `Logs` under the canonical app-support root (robust to the override) and never traps. Behavior is otherwise unchanged for valid input, so existing suites cover regression.

Full suite: **BUILD SUCCEEDED** / **TEST SUCCEEDED** locally (macOS 26 SDK), no regressions.

## Commits

1. `0b68057` — drop the three force-unwraps.
2. `b6048fa` — code-review follow-up: resolve the log dir via `LupenPaths.applicationSupportRoot()` (reuse + honor the override).