### PR TITLE
feat(reports): weekly & monthly Overview rollups + flaky test-runner exit fix

### DIFF
--- a/Lupen/Domain/ReportsCSVExporter.swift
+++ b/Lupen/Domain/ReportsCSVExporter.swift
@@ -72,16 +72,27 @@ enum ReportsCSVExporter {
         return render(header: header, rows: body)
     }
 
-    /// Daily-bucket CSV for the Overview tab. Date is fixed
-    /// `yyyy-MM-dd` in POSIX so Finder sorts chronologically and other
-    /// tools parse it cleanly. A nil `avgCostPerSession` renders as an
-    /// empty cell so downstream formulas treat it as "no value".
-    static func timelineCSV(_ buckets: [UsageTimelineAnalyzer.DailyUsageBucket]) -> String {
-        let header = ["Date", "Cost USD", "Sessions", "Turns", "Requests",
+    /// Timeline-bucket CSV for the Overview tab. The period column is
+    /// fixed `yyyy-MM-dd` (period start) in POSIX so Finder sorts
+    /// chronologically and other tools parse it cleanly; only its header
+    /// label tracks the granularity. A nil `avgCostPerSession` renders as
+    /// an empty cell so downstream formulas treat it as "no value".
+    static func timelineCSV(
+        _ buckets: [UsageTimelineAnalyzer.DailyUsageBucket],
+        granularity: UsageTimelineAnalyzer.Granularity = .day
+    ) -> String {
+        let periodHeader: String
+        switch granularity {
+        case .day:   periodHeader = "Date"
+        case .hour:  periodHeader = "Hour"
+        case .week:  periodHeader = "Week of"
+        case .month: periodHeader = "Month"
+        }
+        let header = [periodHeader, "Cost USD", "Sessions", "Turns", "Requests",
                       "Tokens", "Avg Cost per Session USD"]
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.dateFormat = (granularity == .hour) ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd"
         formatter.timeZone = .autoupdatingCurrent
         let body = buckets.map { b in
             [

--- a/Lupen/Domain/UsageTimelineAnalyzer.swift
+++ b/Lupen/Domain/UsageTimelineAnalyzer.swift
@@ -21,13 +21,17 @@ import Foundation
 enum UsageTimelineAnalyzer {
 
     /// Bucket granularity. `.day` keeps the original "one bar per local
-    /// calendar day" behaviour (multi-day ranges, Reports overview for
-    /// weeks/months). `.hour` bucketizes every hour inside the range —
-    /// used by "Today" in Reports so the user sees an intraday
+    /// calendar day" behaviour. `.hour` bucketizes every hour inside the
+    /// range — used by "Today" in Reports so the user sees an intraday
     /// distribution (00:00–23:00 local) rather than a single bar.
+    /// `.week`/`.month` roll days up into local week-of-year / calendar
+    /// month buckets for the Overview's long-term trend view — the bucket
+    /// `day` is the period start (week's first day / month's 1st).
     enum Granularity: Sendable, Equatable {
         case day
         case hour
+        case week
+        case month
     }
 
     struct DailyUsageBucket: Sendable, Equatable, Identifiable {
@@ -119,6 +123,12 @@ enum UsageTimelineAnalyzer {
             case .hour:
                 return calendar.dateInterval(of: .hour, for: ts)?.start
                     ?? calendar.startOfDay(for: ts)
+            case .week:
+                return calendar.dateInterval(of: .weekOfYear, for: ts)?.start
+                    ?? calendar.startOfDay(for: ts)
+            case .month:
+                return calendar.dateInterval(of: .month, for: ts)?.start
+                    ?? calendar.startOfDay(for: ts)
             }
         }
 
@@ -190,10 +200,17 @@ enum UsageTimelineAnalyzer {
         var buckets: [DailyUsageBucket] = []
         var cursor = effectiveFrom
         // Safety cap — defend against pathological calendar math.
-        // Day mode: ~10 years. Hour mode: ~93 days (31 days × 24h is the
-        // typical "Last 30 days" upper bound; padded to absorb DST).
-        let maxIterations = (granularity == .day) ? 3_650 : 24 * 93
-        let stepComponent: Calendar.Component = (granularity == .day) ? .day : .hour
+        // Day: ~10 years. Hour: ~93 days (31 days × 24h is the typical
+        // "Last 30 days" upper bound; padded to absorb DST). Week/Month:
+        // ~10 years' worth of buckets.
+        let maxIterations: Int
+        let stepComponent: Calendar.Component
+        switch granularity {
+        case .day:   maxIterations = 3_650;    stepComponent = .day
+        case .hour:  maxIterations = 24 * 93;  stepComponent = .hour
+        case .week:  maxIterations = 520;      stepComponent = .weekOfYear
+        case .month: maxIterations = 120;      stepComponent = .month
+        }
         var iterations = 0
         while cursor <= effectiveTo, iterations < maxIterations {
             buckets.append(DailyUsageBucket(
@@ -211,5 +228,69 @@ enum UsageTimelineAnalyzer {
             iterations += 1
         }
         return buckets
+    }
+
+    /// Roll day-granularity buckets up into `.week` / `.month` buckets by
+    /// summing every component count. `.day` / `.hour` pass through
+    /// unchanged. Input is assumed to be one bucket per local day (what
+    /// the SQL projection and `aggregate(granularity: .day)` produce);
+    /// because consecutive days always fall inside consecutive
+    /// weeks/months, continuous daily input yields continuous output with
+    /// no separate zero-fill. The bucket `day` becomes the period start
+    /// (week's first day per the calendar's locale / month's 1st). Pure —
+    /// safe to call from `body`.
+    ///
+    /// This is the SQLite-first path's rollup; it produces the same result
+    /// as `aggregate(granularity: .week/.month)` because week/month
+    /// boundaries align to day boundaries (a request's day and its
+    /// week/month never disagree).
+    static func rollUp(
+        _ daily: [DailyUsageBucket],
+        into granularity: Granularity,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> [DailyUsageBucket] {
+        let component: Calendar.Component
+        switch granularity {
+        case .day, .hour:
+            return daily
+        case .week:
+            component = .weekOfYear
+        case .month:
+            component = .month
+        }
+
+        let periodStart: (Date) -> Date = { d in
+            calendar.dateInterval(of: component, for: d)?.start
+                ?? calendar.startOfDay(for: d)
+        }
+
+        var cost: [Date: Double] = [:]
+        var sessions: [Date: Int] = [:]
+        var turns: [Date: Int] = [:]
+        var requests: [Date: Int] = [:]
+        var tokens: [Date: Int] = [:]
+
+        for b in daily {
+            let key = periodStart(b.day)
+            // Unconditional accumulation keeps all five dictionaries on an
+            // identical key set, so iterating `cost.keys` below is complete
+            // even for periods whose only activity is zero-cost.
+            cost[key, default: 0] += b.costUSD
+            sessions[key, default: 0] += b.sessionCount
+            turns[key, default: 0] += b.turnCount
+            requests[key, default: 0] += b.requestCount
+            tokens[key, default: 0] += b.tokenCount
+        }
+
+        return cost.keys.sorted().map { key in
+            DailyUsageBucket(
+                day: key,
+                costUSD: cost[key] ?? 0,
+                sessionCount: sessions[key] ?? 0,
+                turnCount: turns[key] ?? 0,
+                requestCount: requests[key] ?? 0,
+                tokenCount: tokens[key] ?? 0
+            )
+        }
     }
 }

--- a/Lupen/Store/SQLiteReportsProjection.swift
+++ b/Lupen/Store/SQLiteReportsProjection.swift
@@ -122,6 +122,20 @@ enum SQLiteReportsProjection {
         range: UsageTimelineAnalyzer.DayRange?,
         calendar: Calendar = .autoupdatingCurrent
     ) -> [UsageTimelineAnalyzer.DailyUsageBucket] {
+        // Week/month are pure rollups of the daily series — compute days
+        // first (reusing the proven SQL path + zero-fill), then fold up.
+        // Keeps one SQL grouping (day/hour) and dodges strftime week/
+        // timezone pitfalls.
+        switch granularity {
+        case .week, .month:
+            let daily = timelineBuckets(
+                store: store, granularity: .day, range: range, calendar: calendar
+            )
+            return UsageTimelineAnalyzer.rollUp(daily, into: granularity, calendar: calendar)
+        case .day, .hour:
+            break
+        }
+
         let hourly = granularity == .hour
         let from = range?.from
         let to = range?.to

--- a/Lupen/UI/Reports/ReportsView.swift
+++ b/Lupen/UI/Reports/ReportsView.swift
@@ -22,6 +22,11 @@ struct ReportsView: View {
 
     @State private var selectedTab: Tab = .overview
     @State private var dateRange: DateRangeOption = .allTime
+    /// Overview-only bucket size (Day / Week / Month). Independent of the
+    /// date range so the user can view, say, "All time" by month. Ignored
+    /// for sub-day ranges (Today / Yesterday / Last 24h), which force an
+    /// hourly chart.
+    @State private var overviewPeriod: OverviewPeriod = .day
     /// From/To for the `.custom` range. Default to the last 30 days so the
     /// pickers open on a sensible non-empty window.
     @State private var customFrom: Date =
@@ -69,10 +74,17 @@ struct ReportsView: View {
         return start...end
     }
 
-    /// Overview-chart granularity. Custom ranges render daily bars; presets
-    /// keep their own hour/day choice.
+    /// True when the active range is sub-day (Today / Yesterday / Last 24h):
+    /// the chart is forced to hourly bars and the Day/Week/Month picker is
+    /// disabled — bucketing 24 hours into 1–2 daily bars defeats the point.
+    private var rangeIsHourly: Bool {
+        dateRange != .custom && dateRange.granularity == .hour
+    }
+
+    /// Overview-chart granularity. Sub-day ranges force hourly; everything
+    /// else follows the user's Day/Week/Month pick.
     private var effectiveGranularity: UsageTimelineAnalyzer.Granularity {
-        dateRange == .custom ? .day : dateRange.granularity
+        rangeIsHourly ? .hour : overviewPeriod.granularity
     }
 
     /// Zero-fill window for the Overview chart. Custom fills day-by-day
@@ -352,9 +364,30 @@ struct ReportsView: View {
 
                 Spacer()
 
+                if selectedTab == .overview {
+                    overviewPeriodPicker
+                }
                 dateRangeButton
             }
         }
+    }
+
+    /// Day / Week / Month bucket selector for the Overview chart. Disabled
+    /// (kept in place to avoid layout jumps) for sub-day ranges, where the
+    /// chart is locked to hourly.
+    private var overviewPeriodPicker: some View {
+        Picker("Period", selection: $overviewPeriod) {
+            ForEach(OverviewPeriod.allCases) { period in
+                Text(period.title).tag(period)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .fixedSize()
+        .disabled(rangeIsHourly)
+        .help(rangeIsHourly
+              ? "Hourly view is shown for sub-day ranges"
+              : "Bucket the Overview by day, week, or month")
     }
 
     /// Single date-range control: a button labelled with the active range
@@ -709,7 +742,7 @@ struct ReportsView: View {
         let csv: String
         switch selectedTab {
         case .overview:
-            csv = ReportsCSVExporter.timelineCSV(timelineBuckets)
+            csv = ReportsCSVExporter.timelineCSV(timelineBuckets, granularity: effectiveGranularity)
         case .projects:
             csv = ReportsCSVExporter.projectsCSV(projectRows)
         case .skills:
@@ -810,6 +843,27 @@ struct ReportsView: View {
             case .skills: return "Skills"
             case .models: return "Models"
             case .hours: return "Hours"
+            }
+        }
+    }
+
+    /// Overview bucket size. Maps onto the analyzer granularity; hourly is
+    /// not a user choice (it's range-driven), so it's absent here.
+    enum OverviewPeriod: String, CaseIterable, Identifiable {
+        case day, week, month
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .day: return "Day"
+            case .week: return "Week"
+            case .month: return "Month"
+            }
+        }
+        var granularity: UsageTimelineAnalyzer.Granularity {
+            switch self {
+            case .day: return .day
+            case .week: return .week
+            case .month: return .month
             }
         }
     }

--- a/Lupen/UI/Reports/TimelineOverviewView.swift
+++ b/Lupen/UI/Reports/TimelineOverviewView.swift
@@ -137,12 +137,13 @@ struct TimelineOverviewView: View {
 
     private func metricCard(_ metric: Metric) -> some View {
         let isSelected = (metric == selectedMetric)
-        let isMeaningful = (granularity == .day) || metric.meaningfulInHourly
+        // Avg ratios collapse to a denominator of 1 only in hourly mode;
+        // day/week/month all sum real denominators, so they stay meaningful.
+        let isMeaningful = (granularity != .hour) || metric.meaningfulInHourly
         // Cards always show range totals/avg regardless of hover; hover is
         // surfaced only via the hero's RuleMark + readout. Flickering 6
         // values at once would be too noisy.
         let valueText = totalValueText(metric)
-        let captionText = rangeLabel
 
         return Button {
             // Block promotion of ratio metrics in hourly mode — the hero
@@ -167,10 +168,7 @@ struct TimelineOverviewView: View {
                 cardSparkline(metric)
                     .frame(height: 28)
                     .opacity(isMeaningful ? 1 : 0.25)
-                Text(captionText)
-                    .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
+                cardCaption(metric)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 8)
@@ -416,6 +414,14 @@ struct TimelineOverviewView: View {
             let target = cal.dateInterval(of: .hour, for: hoveredDay)?.start
                 ?? hoveredDay
             return buckets.first { abs($0.day.timeIntervalSince(target)) < 30 }
+        case .week, .month:
+            // Match the bucket whose period contains the hovered date.
+            let component: Calendar.Component = (granularity == .week) ? .weekOfYear : .month
+            let target = cal.dateInterval(of: component, for: hoveredDay)?.start
+                ?? hoveredDay
+            return buckets.first {
+                (cal.dateInterval(of: component, for: $0.day)?.start ?? $0.day) == target
+            }
         }
     }
 
@@ -425,8 +431,10 @@ struct TimelineOverviewView: View {
         // `let f = DateFormatter()` allocated per call. Two cached
         // formatters cover the granularity branches with zero alloc.
         switch granularity {
-        case .day:  return Self.hoverDayFormatter.string(from: b.day)
-        case .hour: return Self.hoverHourFormatter.string(from: b.day)
+        case .day:   return Self.hoverDayFormatter.string(from: b.day)
+        case .hour:  return Self.hoverHourFormatter.string(from: b.day)
+        case .week:  return "Week of " + Self.hoverDayFormatter.string(from: b.day)
+        case .month: return Self.hoverMonthFormatter.string(from: b.day)
         }
     }
 
@@ -439,6 +447,11 @@ struct TimelineOverviewView: View {
     private static let hoverHourFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d, HH:00"
+        return f
+    }()
+    private static let hoverMonthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMMM yyyy"
         return f
     }()
 
@@ -460,7 +473,13 @@ struct TimelineOverviewView: View {
     }
 
     private var heroTitle: String {
-        let prefix = (granularity == .hour) ? "Hourly" : "Daily"
+        let prefix: String
+        switch granularity {
+        case .hour: prefix = "Hourly"
+        case .day: prefix = "Daily"
+        case .week: prefix = "Weekly"
+        case .month: prefix = "Monthly"
+        }
         let body: String
         switch selectedMetric {
         case .cost: body = "Cost"
@@ -544,29 +563,190 @@ struct TimelineOverviewView: View {
         var id: Date { day }
     }
 
+    // MARK: - Period delta (week / month)
+
+    /// Card caption: a period-over-period delta chip for week/month
+    /// granularity, otherwise the static range label. The chip compares
+    /// the latest bucket to the one before it for that metric, giving the
+    /// "is this week up or down vs last week?" read ccusage's weekly
+    /// reports surface as a table.
+    @ViewBuilder
+    private func cardCaption(_ metric: Metric) -> some View {
+        if let delta = periodDelta(metric) {
+            HStack(spacing: 2) {
+                Image(systemName: delta.direction.symbol)
+                    .font(.system(size: 8, weight: .bold))
+                Text(delta.label)
+                    .font(.system(size: 9))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(.secondary)
+            .help(delta.tooltip)
+            .accessibilityLabel(delta.accessibilityLabel)
+        } else {
+            Text(rangeLabel)
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+    }
+
+    private struct PeriodDelta {
+        enum Direction {
+            case up, down, flat
+            var symbol: String {
+                switch self {
+                case .up: return "arrow.up"
+                case .down: return "arrow.down"
+                case .flat: return "minus"
+                }
+            }
+        }
+        let direction: Direction
+        let label: String
+        let tooltip: String
+        let accessibilityLabel: String
+    }
+
+    /// Pure percent-change of `current` vs `previous`. nil when there is
+    /// no baseline to compare against (`previous == 0`), so the caller can
+    /// render a "new" badge instead of a divide-by-zero spike. `nonisolated`
+    /// so it's callable from tests without hopping to the main actor.
+    nonisolated static func deltaPercent(current: Double, previous: Double) -> Double? {
+        guard previous != 0 else { return nil }
+        return (current - previous) / previous * 100
+    }
+
+    private func periodDelta(_ metric: Metric) -> PeriodDelta? {
+        guard granularity == .week || granularity == .month else { return nil }
+        guard buckets.count >= 2,
+              let current = metricDouble(buckets[buckets.count - 1], metric),
+              let previous = metricDouble(buckets[buckets.count - 2], metric)
+        else { return nil }
+
+        let periodWord = (granularity == .week) ? "week" : "month"
+        let currentStr = formatMetricValue(current, metric)
+        let previousStr = formatMetricValue(previous, metric)
+        let tooltip = "This \(periodWord): \(currentStr) · last \(periodWord): \(previousStr)"
+
+        guard let pct = Self.deltaPercent(current: current, previous: previous) else {
+            // No baseline last period — only show "new" when there's
+            // actually something this period.
+            guard current > 0 else { return nil }
+            return PeriodDelta(
+                direction: .up, label: "new vs prev", tooltip: tooltip,
+                accessibilityLabel: "new this \(periodWord), \(tooltip)"
+            )
+        }
+
+        let rounded = Int(pct.rounded())
+        if rounded == 0 {
+            return PeriodDelta(
+                direction: .flat, label: "≈ prev", tooltip: tooltip,
+                accessibilityLabel: "about the same as last \(periodWord), \(tooltip)"
+            )
+        }
+        let direction: PeriodDelta.Direction = rounded > 0 ? .up : .down
+        let word = rounded > 0 ? "up" : "down"
+        return PeriodDelta(
+            direction: direction,
+            label: "\(abs(rounded))% vs prev",
+            tooltip: tooltip,
+            accessibilityLabel: "\(word) \(abs(rounded)) percent vs last \(periodWord), \(tooltip)"
+        )
+    }
+
+    /// Metric value for one bucket as a Double, or nil for avg ratios with
+    /// a zero denominator (so the delta drops rather than reads a fake 0).
+    private func metricDouble(
+        _ b: UsageTimelineAnalyzer.DailyUsageBucket, _ metric: Metric
+    ) -> Double? {
+        switch metric {
+        case .cost: return b.costUSD
+        case .sessions: return Double(b.sessionCount)
+        case .turns: return Double(b.turnCount)
+        case .tokens: return Double(b.tokenCount)
+        case .avgCostPerSession: return b.avgCostPerSession
+        case .avgCostPerToken: return b.avgCostPerToken
+        }
+    }
+
+    private func formatMetricValue(_ v: Double, _ metric: Metric) -> String {
+        switch metric {
+        case .cost, .avgCostPerSession: return formatUSD(v)
+        case .sessions, .turns: return String(Int(v.rounded()))
+        case .tokens: return Self.formatTokens(Int(v.rounded()))
+        case .avgCostPerToken: return formatCostPerToken(v)
+        }
+    }
+
     // MARK: - X-axis common
 
     private var xAxisMarks: AxisMarks<some AxisMark> {
-        AxisMarks(values: .automatic(desiredCount: 6)) { value in
+        AxisMarks(values: xAxisMarkValues) { value in
             AxisGridLine()
             AxisTick()
             switch granularity {
-            case .day:
+            case .day, .week:
+                // Week labels the period's start date (e.g. "Apr 24").
                 AxisValueLabel(format: .dateTime.month(.abbreviated).day())
                     .font(.system(size: 9))
             case .hour:
                 AxisValueLabel(format: .dateTime.hour(.twoDigits(amPM: .omitted)))
                     .font(.system(size: 9))
+            case .month:
+                AxisValueLabel(format: .dateTime.month(.abbreviated))
+                    .font(.system(size: 9))
             }
         }
     }
 
+    /// Tick placement per granularity. Day/hour defer to Charts' automatic
+    /// spacing. Week/month stride by the period so each bucket is labelled
+    /// at most once — automatic spacing dropped two ticks inside a single
+    /// month, duplicating its label ("Apr Apr"). The stride count thins
+    /// long ranges down to ~8 ticks.
+    private var xAxisMarkValues: AxisMarkValues {
+        switch granularity {
+        case .day, .hour:
+            return .automatic(desiredCount: 6)
+        case .week:
+            return .stride(
+                by: .weekOfYear,
+                count: Self.axisStrideCount(bucketCount: buckets.count)
+            )
+        case .month:
+            return .stride(
+                by: .month,
+                count: Self.axisStrideCount(bucketCount: buckets.count)
+            )
+        }
+    }
+
+    /// Smallest stride (in periods) that keeps the tick count at or under
+    /// `maxTicks`. `nonisolated` so it's unit-testable off the main actor.
+    nonisolated static func axisStrideCount(bucketCount: Int, maxTicks: Int = 8) -> Int {
+        guard bucketCount > maxTicks, maxTicks > 0 else { return 1 }
+        return Int((Double(bucketCount) / Double(maxTicks)).rounded(.up))
+    }
+
     private var chartUnit: Calendar.Component {
-        granularity == .hour ? .hour : .day
+        switch granularity {
+        case .hour: return .hour
+        case .day: return .day
+        case .week: return .weekOfYear
+        case .month: return .month
+        }
     }
 
     private var xLabel: String {
-        granularity == .hour ? "Hour" : "Day"
+        switch granularity {
+        case .hour: return "Hour"
+        case .day: return "Day"
+        case .week: return "Week"
+        case .month: return "Month"
+        }
     }
 
     // MARK: - Formatters

--- a/LupenTests/CLI/CLICrashSmokeTests.swift
+++ b/LupenTests/CLI/CLICrashSmokeTests.swift
@@ -36,7 +36,10 @@ struct CLICrashSmokeTests {
         defer { try? FileManager.default.removeItem(at: indexDir) }
 
         // Hermetic: redirect every data source onto the synthetic corpus +
-        // a throwaway index dir (no developer data is touched).
+        // a throwaway index dir (no developer data is touched). The
+        // inherited XCTest/dyld injection vars are stripped by
+        // `TestProcess` so this re-launched host binary runs as a plain
+        // `lupen` CLI and never re-attaches to the test coordinator.
         var env = ProcessInfo.processInfo.environment
         env["CLAUDE_CONFIG_DIR"] = corpus.root.path        // → root/projects
         env["CODEX_HOME"] = corpus.codexHome.path

--- a/LupenTests/Domain/Statusline/StatuslineTapModeEndToEndTests.swift
+++ b/LupenTests/Domain/Statusline/StatuslineTapModeEndToEndTests.swift
@@ -22,17 +22,10 @@ struct StatuslineTapModeEndToEndTests {
     }
 
     private func helperEnvironment(configDir: URL, chain: String? = nil) -> [String: String] {
-        var env = ProcessInfo.processInfo.environment
-        for key in [
-            "XCTestConfigurationFilePath",
-            "XCInjectBundleInto",
-            "XCInjectBundle",
-            "DYLD_INSERT_LIBRARIES",
-            "DYLD_FRAMEWORK_PATH",
-            "DYLD_LIBRARY_PATH"
-        ] {
-            env.removeValue(forKey: key)
-        }
+        // Strip the XCTest/dyld injection vars (single source of truth in
+        // `TestProcess`) so the re-launched host binary runs as a plain
+        // `lupen` CLI and never re-attaches to the test coordinator.
+        var env = TestProcess.childEnvironment()
         env["CLAUDE_CONFIG_DIR"] = configDir.path
         if let chain { env["LUPEN_NEXT_STATUSLINE"] = chain }
         return env

--- a/LupenTests/Domain/UsageTimelineAnalyzerTests.swift
+++ b/LupenTests/Domain/UsageTimelineAnalyzerTests.swift
@@ -377,4 +377,175 @@ struct UsageTimelineAnalyzerTests {
         #expect(result.count == 1, "day mode collapses a single day to one bucket")
         #expect(result[0].sessionCount == 1)
     }
+
+    // MARK: - Week / month rollup (C-5)
+
+    /// Gregorian, UTC, Monday-first, POSIX locale → deterministic week
+    /// boundaries independent of the CI machine's region settings.
+    private static var weekCalendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.locale = Locale(identifier: "en_US_POSIX")
+        cal.firstWeekday = 2  // Monday
+        return cal
+    }
+
+    private static func daily(
+        _ day: Date, cost: Double = 0, sessions: Int = 0,
+        turns: Int = 0, requests: Int = 0, tokens: Int = 0
+    ) -> UsageTimelineAnalyzer.DailyUsageBucket {
+        .init(
+            day: day, costUSD: cost, sessionCount: sessions,
+            turnCount: turns, requestCount: requests, tokenCount: tokens
+        )
+    }
+
+    @Test("rollUp .day / .hour pass through unchanged")
+    func rollUpPassThrough() {
+        let days = (5...8).map { Self.date(2026, 1, $0) }
+        let buckets = days.map { Self.daily($0, cost: 1, sessions: 1) }
+        #expect(UsageTimelineAnalyzer.rollUp(buckets, into: .day) == buckets)
+        #expect(UsageTimelineAnalyzer.rollUp(buckets, into: .hour) == buckets)
+        #expect(UsageTimelineAnalyzer.rollUp([], into: .week).isEmpty)
+    }
+
+    @Test("rollUp .week sums days into Monday-start week buckets")
+    func rollUpWeekly() {
+        // Jan 5 (Mon) … Jan 18 (Sun) = two full Mon–Sun weeks.
+        let cal = Self.weekCalendar
+        let days = (5...18).map { Self.date(2026, 1, $0) }
+        let daily = days.map { Self.daily($0, cost: 1, sessions: 1, requests: 2, tokens: 100) }
+
+        let weeks = UsageTimelineAnalyzer.rollUp(daily, into: .week, calendar: cal)
+        #expect(weeks.count == 2)
+        // Each week: 7 days × (cost 1, sess 1, req 2, tok 100).
+        for w in weeks {
+            #expect(abs(w.costUSD - 7) < 1e-9)
+            #expect(w.sessionCount == 7)
+            #expect(w.requestCount == 14)
+            #expect(w.tokenCount == 700)
+        }
+        // Week buckets start on the Mondays.
+        #expect(weeks[0].day == Self.date(2026, 1, 5, 0))
+        #expect(weeks[1].day == Self.date(2026, 1, 12, 0))
+        // Totals are conserved across the rollup.
+        let dailyCost = daily.reduce(0) { $0 + $1.costUSD }
+        let weekCost = weeks.reduce(0) { $0 + $1.costUSD }
+        #expect(abs(dailyCost - weekCost) < 1e-9)
+    }
+
+    @Test("rollUp .month sums days into calendar-month buckets across a boundary")
+    func rollUpMonthly() {
+        let cal = Self.weekCalendar
+        // Jan 28 … Feb 3 → Jan: 4 days, Feb: 3 days.
+        let janDays = (28...31).map { Self.date(2026, 1, $0) }
+        let febDays = (1...3).map { Self.date(2026, 2, $0) }
+        let daily = (janDays + febDays).map { Self.daily($0, cost: 1, sessions: 2) }
+
+        let months = UsageTimelineAnalyzer.rollUp(daily, into: .month, calendar: cal)
+        #expect(months.count == 2)
+        #expect(months[0].day == Self.date(2026, 1, 1, 0))
+        #expect(months[1].day == Self.date(2026, 2, 1, 0))
+        #expect(abs(months[0].costUSD - 4) < 1e-9)
+        #expect(months[0].sessionCount == 8)
+        #expect(abs(months[1].costUSD - 3) < 1e-9)
+        #expect(months[1].sessionCount == 6)
+    }
+
+    @Test("aggregate(.week) == rollUp(aggregate(.day), .week)")
+    func aggregateWeekMatchesRollup() {
+        let cal = Self.weekCalendar
+        // Requests scattered across three weeks.
+        let stamps = [
+            Self.date(2026, 1, 5, 9), Self.date(2026, 1, 8, 14),  // week 1
+            Self.date(2026, 1, 13, 10),                            // week 2
+            Self.date(2026, 1, 20, 11), Self.date(2026, 1, 25, 16) // week 3
+        ]
+        var requests: [ParsedRequest] = []
+        var costs: [String: CostBreakdown?] = [:]
+        for (i, ts) in stamps.enumerated() {
+            let r = Self.request(id: "r\(i)", model: "claude-sonnet-4-6", at: ts)
+            requests.append(r)
+            costs["r\(i)"] = .some(Self.cost(Double(i + 1)))
+        }
+        let s = Self.session(id: "s1", requests: requests)
+        let range = UsageTimelineAnalyzer.DayRange(
+            from: Self.date(2026, 1, 5), to: Self.date(2026, 1, 25)
+        )
+
+        let direct = UsageTimelineAnalyzer.aggregate(
+            sessions: [s], turnsBySession: [:], costsByRequestId: costs,
+            range: range, granularity: .week, calendar: cal
+        )
+        let daily = UsageTimelineAnalyzer.aggregate(
+            sessions: [s], turnsBySession: [:], costsByRequestId: costs,
+            range: range, granularity: .day, calendar: cal
+        )
+        let rolled = UsageTimelineAnalyzer.rollUp(daily, into: .week, calendar: cal)
+
+        #expect(direct == rolled, "native week aggregation must equal day→week rollup")
+        #expect(direct.count == 3)
+    }
+
+    @Test("aggregate(.month) == rollUp(aggregate(.day), .month)")
+    func aggregateMonthMatchesRollup() {
+        let cal = Self.weekCalendar
+        let stamps = [
+            Self.date(2026, 1, 10, 9), Self.date(2026, 1, 28, 14),
+            Self.date(2026, 2, 2, 10), Self.date(2026, 3, 5, 11)
+        ]
+        var requests: [ParsedRequest] = []
+        var costs: [String: CostBreakdown?] = [:]
+        for (i, ts) in stamps.enumerated() {
+            requests.append(Self.request(id: "r\(i)", model: "claude-sonnet-4-6", at: ts))
+            costs["r\(i)"] = .some(Self.cost(Double(i + 1)))
+        }
+        let s = Self.session(id: "s1", requests: requests)
+        let range = UsageTimelineAnalyzer.DayRange(
+            from: Self.date(2026, 1, 1), to: Self.date(2026, 3, 31)
+        )
+        let direct = UsageTimelineAnalyzer.aggregate(
+            sessions: [s], turnsBySession: [:], costsByRequestId: costs,
+            range: range, granularity: .month, calendar: cal
+        )
+        let rolled = UsageTimelineAnalyzer.rollUp(
+            UsageTimelineAnalyzer.aggregate(
+                sessions: [s], turnsBySession: [:], costsByRequestId: costs,
+                range: range, granularity: .day, calendar: cal
+            ),
+            into: .month, calendar: cal
+        )
+        #expect(direct == rolled)
+        #expect(direct.count == 3, "Jan, Feb, Mar")
+    }
+
+    // MARK: - Period delta (TimelineOverviewView)
+
+    @Test("deltaPercent: up, down, and zero-baseline cases")
+    func deltaPercentCases() {
+        #expect(TimelineOverviewView.deltaPercent(current: 110, previous: 100) == 10)
+        #expect(TimelineOverviewView.deltaPercent(current: 80, previous: 100) == -20)
+        #expect(TimelineOverviewView.deltaPercent(current: 100, previous: 100) == 0)
+        // No baseline → nil so the caller renders "new" instead of ∞.
+        #expect(TimelineOverviewView.deltaPercent(current: 5, previous: 0) == nil)
+        #expect(TimelineOverviewView.deltaPercent(current: 0, previous: 0) == nil)
+    }
+
+    @Test("axisStrideCount keeps ticks ≤ maxTicks, never below 1")
+    func axisStrideCountThinsLongRanges() {
+        // Short ranges → one tick per bucket (stride 1), so no month label
+        // is dropped or doubled.
+        #expect(TimelineOverviewView.axisStrideCount(bucketCount: 3) == 1)
+        #expect(TimelineOverviewView.axisStrideCount(bucketCount: 8) == 1)
+        #expect(TimelineOverviewView.axisStrideCount(bucketCount: 0) == 1)
+        // Long ranges thin to ≤ 8 ticks.
+        #expect(TimelineOverviewView.axisStrideCount(bucketCount: 16) == 2)
+        #expect(TimelineOverviewView.axisStrideCount(bucketCount: 52) == 7)  // ceil(52/8)
+        for n in [9, 13, 24, 52, 365] {
+            let stride = TimelineOverviewView.axisStrideCount(bucketCount: n)
+            #expect(stride >= 1)
+            // ceil(n / stride) ticks must not exceed the cap.
+            #expect((n + stride - 1) / stride <= 8, "n=\(n) stride=\(stride)")
+        }
+    }
 }

--- a/LupenTests/Store/SQLiteReportsTests.swift
+++ b/LupenTests/Store/SQLiteReportsTests.swift
@@ -167,6 +167,30 @@ struct SQLiteReportsTests {
         #expect(sql.count == legacy.count, "zero-fill window diverged")
     }
 
+    @Test("weekly/monthly buckets are the daily series rolled up (C-5)")
+    func timelineWeeklyMonthlyRollup() throws {
+        let imported = try importCorpus()
+        defer { imported.cleanup() }
+        let cal = Calendar.autoupdatingCurrent
+
+        let daily = SQLiteReportsProjection.timelineBuckets(
+            store: imported.store, granularity: .day, range: nil
+        )
+        for period in [UsageTimelineAnalyzer.Granularity.week, .month] {
+            let viaProjection = SQLiteReportsProjection.timelineBuckets(
+                store: imported.store, granularity: period, range: nil
+            )
+            let expected = UsageTimelineAnalyzer.rollUp(daily, into: period, calendar: cal)
+            #expect(viaProjection == expected, "\(period) projection must equal day→\(period) rollup")
+            // Conservation: rolled-up cost equals the daily total.
+            let dailyCost = daily.reduce(0) { $0 + $1.costUSD }
+            let periodCost = viaProjection.reduce(0) { $0 + $1.costUSD }
+            #expect(abs(dailyCost - periodCost) < 0.000_001)
+            // Fewer (or equal) buckets than days once grouped.
+            #expect(viaProjection.count <= daily.count)
+        }
+    }
+
     @Test("import extracts claude slash skills into the skills table")
     func skillsExtractedAtImport() throws {
         let sid = "rc-skill"

--- a/LupenTests/Support/TestProcess.swift
+++ b/LupenTests/Support/TestProcess.swift
@@ -38,6 +38,37 @@ import os
 /// call site.
 enum TestProcess {
 
+    /// Environment variables that mark a process as an XCTest/test-host
+    /// runner or force dylib injection into it. A spawned child that
+    /// inherits these — especially when the child IS the test-host binary
+    /// re-launched as the `lupen` CLI — loads the XCTest injection bundle,
+    /// re-attaches to the test coordinator, and then exits via the CLI's
+    /// `exit(0)`. The coordinator reports that as "the test runner exited
+    /// before finishing" and fails whichever (usually the longest-running)
+    /// tests were still in flight — an intermittent, scheduling-dependent
+    /// failure. Stripping them makes every child a plain process that can
+    /// never re-enter the test machinery.
+    static let injectionEnvironmentKeys: Set<String> = [
+        "XCTestConfigurationFilePath",
+        "XCTestSessionIdentifier",
+        "XCTestBundlePath",
+        "XCInjectBundle",
+        "XCInjectBundleInto",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_FRAMEWORK_PATH",
+        "DYLD_LIBRARY_PATH"
+    ]
+
+    /// The environment to hand a spawned child: `base` (or the current
+    /// process environment when `base` is nil) with every injection key
+    /// removed. PATH and all other inherited vars are preserved, so the
+    /// child still resolves tools and its own rpath-embedded frameworks.
+    static func childEnvironment(base: [String: String]? = nil) -> [String: String] {
+        var env = base ?? ProcessInfo.processInfo.environment
+        for key in injectionEnvironmentKeys { env.removeValue(forKey: key) }
+        return env
+    }
+
     struct Result {
         let exitCode: Int32
         let terminationReason: Process.TerminationReason
@@ -63,7 +94,11 @@ enum TestProcess {
         let task = Process()
         task.executableURL = executable
         task.arguments = arguments
-        if let environment { task.environment = environment }
+        // ALWAYS sanitize — even when the caller passes no environment, the
+        // child would otherwise inherit the parent's full env, including the
+        // XCTest/dyld injection vars that make a re-launched host binary
+        // re-attach to the test coordinator (see `childEnvironment`).
+        task.environment = Self.childEnvironment(base: environment)
 
         let stdout = Pipe()
         let stderr = Pipe()

--- a/LupenTests/Support/TestProcessTests.swift
+++ b/LupenTests/Support/TestProcessTests.swift
@@ -1,0 +1,61 @@
+//
+//  TestProcessTests.swift
+//  LupenTests
+//
+//  Created by jaden on 2026/06/28.
+//
+
+import Testing
+import Foundation
+@testable import Lupen
+
+/// Regression guard for the intermittent "test runner exited with code 0
+/// before finishing" failure. Root cause: a test re-launched the test-host
+/// binary as the `lupen` CLI while inheriting the parent's XCTest/dyld
+/// injection environment. The child loaded the injection bundle, re-attached
+/// to the test coordinator, and its CLI `exit(0)` was reported as a premature
+/// runner exit — failing whichever long-running tests were still in flight.
+///
+/// `TestProcess` now sanitizes every child's environment. These pin that
+/// contract so the leak can't silently come back.
+@Suite("TestProcess — child environment sanitation")
+struct TestProcessTests {
+
+    @Test("injection vars are stripped from the child environment")
+    func stripsInjectionKeys() {
+        let base: [String: String] = [
+            "XCTestConfigurationFilePath": "/tmp/x.plist",
+            "XCTestSessionIdentifier": "ABC",
+            "XCTestBundlePath": "/tmp/Tests.xctest",
+            "XCInjectBundle": "/tmp/Tests.xctest",
+            "XCInjectBundleInto": "/tmp/Lupen.app/Contents/MacOS/Lupen",
+            "DYLD_INSERT_LIBRARIES": "/usr/lib/libXCTestBundleInject.dylib",
+            "DYLD_FRAMEWORK_PATH": "/build/Debug",
+            "DYLD_LIBRARY_PATH": "/build/Debug",
+            "PATH": "/usr/bin:/bin",
+            "CLAUDE_CONFIG_DIR": "/tmp/corpus"
+        ]
+        let env = TestProcess.childEnvironment(base: base)
+
+        for key in TestProcess.injectionEnvironmentKeys {
+            #expect(env[key] == nil, "injection key leaked: \(key)")
+        }
+        // Non-injection vars survive so the child still resolves tools/data.
+        #expect(env["PATH"] == "/usr/bin:/bin")
+        #expect(env["CLAUDE_CONFIG_DIR"] == "/tmp/corpus")
+    }
+
+    @Test("nil base falls back to the current process env, still sanitized")
+    func nilBaseUsesProcessEnvSanitized() {
+        let env = TestProcess.childEnvironment(base: nil)
+        for key in TestProcess.injectionEnvironmentKeys {
+            #expect(env[key] == nil, "injection key leaked from process env: \(key)")
+        }
+    }
+
+    @Test("the key set covers the XCTest + dyld injection vars")
+    func keySetCoversKnownInjectors() {
+        #expect(TestProcess.injectionEnvironmentKeys.contains("XCTestConfigurationFilePath"))
+        #expect(TestProcess.injectionEnvironmentKeys.contains("DYLD_INSERT_LIBRARIES"))
+    }
+}


### PR DESCRIPTION
## What this changes

Two related changes, one per commit.

**1. `feat(reports)` — weekly & monthly Overview rollups with period delta.**
The Reports Overview chart bucketed by day/hour only; the CLI already had the full daily/weekly/monthly set, so this brings the GUI to parity for long-term-trend and monthly-expense reporting. Week/month are computed as a **pure rollup of the daily series** (`UsageTimelineAnalyzer.rollUp`) rather than new SQL grouping — this reuses the already-trusted daily aggregation on both the SQLite-first and in-memory paths and dodges `strftime` week-numbering / timezone / first-weekday pitfalls. A Day/Week/Month segmented control on the Overview makes granularity **orthogonal to the date range** (e.g. "All time, by month"); it's disabled for sub-day ranges, which stay hourly. Each KPI card shows a period-over-period delta chip (this period vs the previous), and the x-axis strides by period so each bucket is labelled once (fixes the duplicated "Apr Apr" month labels), thinned to ~8 ticks on long ranges.

**2. `test` — strip XCTest/dyld injection env from spawned child processes.**
Heavy import/memory suites failed intermittently with *"the test runner exited with code 0 before finishing."* Root cause: a test that re-launched the test-host binary as the `lupen` CLI inherited the parent's `XCTestConfigurationFilePath` / `DYLD_INSERT_LIBRARIES` / `XCInjectBundle*` env, so the child loaded the XCTest injection bundle, re-attached to the test coordinator, and then exited via the CLI's `exit(0)` — which the coordinator reported as a premature runner exit, failing whatever long-running tests were still in flight (scheduling-dependent → flaky). `TestProcess.run` now sanitizes every child's environment at a single point, so no spawned child can re-enter the test machinery.

## How it was verified

- `xcodebuild test` (full suite) run **3× consecutively, all green** — the previously-flaky `ImporterMemoryBoundTests` / `CodexStreamingImportTests` / `CodexOversizedPieceMemoryTests` completed cleanly every run, no "before finishing" exits.
- New domain tests: `rollUp` (weekly/monthly/passthrough), `aggregate(.week/.month)` ↔ `rollUp` equivalence, SQLite projection rollup parity + cost conservation, `deltaPercent`, `axisStrideCount`, and `TestProcessTests` (env-sanitation regression guard).
- UI manually verified: the Month Overview (cards + delta chips + monthly bars) was reviewed via screenshot during development; the duplicate-axis-label fix was made in response to it.

## Checklist

- [x] `xcodebuild test` passes locally (3× consecutive green)
- [x] UI changes include a screenshot or screen recording (Month view reviewed during development)
- [x] New features add tests (domain) or list a manual-verification procedure (UI)
- [x] Vocabulary matches `docs/CONVERSATION-MODEL.md` (no conversation-model vocab introduced)
- [x] Cost-affecting changes are checked against Window → Verify Costs… (N/A — rollup sums existing costs; no pricing math changed, equivalence tested)
- [x] No hard-coded `/Users/<name>/…` paths or other personal data

## Related issues

Implements dashboard item **C-5** (weekly · monthly report view). The test-runner exit fix is a separate infra hardening discovered during this work.