### PR TITLE
refactor(cost-color): unify the cost "attention" orange into one token

### DIFF
--- a/Lupen/UI/Reports/HourlyEfficiencyView.swift
+++ b/Lupen/UI/Reports/HourlyEfficiencyView.swift
@@ -238,7 +238,7 @@ struct HourlyEfficiencyView: View {
         if ratio >= 1.5 {
             return Color(.sRGB, red: 0.36, green: 0.55, blue: 0.85)  // cool: lenient
         } else if ratio <= 0.6 {
-            return Color(.sRGB, red: 0.95, green: 0.60, blue: 0.20)  // warm: tight
+            return .costAttention  // warm: tight (shared cost-attention token)
         } else {
             return Color.accentColor.opacity(0.85)
         }

--- a/Lupen/UI/Support/CostColor.swift
+++ b/Lupen/UI/Support/CostColor.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 /// Decided text + color for a cost figure. Shared single source of truth
 /// for the turn outline's Cost column and the sidebar session row, so the
@@ -22,6 +23,21 @@ enum CostColor {
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         return isDark
             ? NSColor(srgbRed: 232.0 / 255, green: 185.0 / 255, blue: 126.0 / 255, alpha: 1)
+            : NSColor(srgbRed: 255.0 / 255, green: 149.0 / 255, blue: 0.0, alpha: 1)
+    }
+
+    /// Warm "attention" tint for cost figures that need to stand out: an
+    /// over-threshold (session-relative outlier) amount, a provisional (≈)
+    /// estimate, and cost-efficiency callouts elsewhere (e.g. a "tight" hour
+    /// in the Hours report). The single appearance-aware source for that
+    /// orange — it replaces the raw `.systemOrange` and the per-surface inline
+    /// RGBs that used to drift between screens. Light keeps the familiar
+    /// systemOrange value (no light-mode change); dark uses a warmer amber
+    /// that reads clearly against dark rows.
+    static let attention = NSColor(name: "CostAttention") { appearance in
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        return isDark
+            ? NSColor(srgbRed: 255.0 / 255, green: 170.0 / 255, blue: 64.0 / 255, alpha: 1)
             : NSColor(srgbRed: 255.0 / 255, green: 149.0 / 255, blue: 0.0, alpha: 1)
     }
 
@@ -52,9 +68,9 @@ enum CostColor {
         }
         let amount = CostFormatter.compact(cost)
         if confidence == .partial {
-            return CostDisplay(text: "\(prefix)≈\(amount)", color: .systemOrange)
+            return CostDisplay(text: "\(prefix)≈\(amount)", color: attention)
         } else if cost >= warningThreshold {
-            return CostDisplay(text: "\(prefix)\(amount)", color: .systemOrange)
+            return CostDisplay(text: "\(prefix)\(amount)", color: attention)
         } else if let exactColor {
             return CostDisplay(text: "\(prefix)\(amount)", color: exactColor)
         } else if let accentColor {
@@ -72,4 +88,11 @@ enum CostColor {
             return CostDisplay(text: "\(prefix)\(amount)", color: .labelColor)
         }
     }
+}
+
+extension Color {
+    /// SwiftUI mirror of the `CostColor.attention` token so the SwiftUI Hours
+    /// report tints its "tight" hour from the same appearance-aware source the
+    /// AppKit cost surfaces use, instead of hardcoding its own orange.
+    static let costAttention = Color(nsColor: CostColor.attention)
 }

--- a/LupenTests/UI/Dashboard/SessionCostLabelTests.swift
+++ b/LupenTests/UI/Dashboard/SessionCostLabelTests.swift
@@ -22,7 +22,7 @@ final class SessionCostLabelTests: XCTestCase {
         let cell = makeCell()
         let d = cell.costDisplayForTesting(totalCost: 2.10, confidence: .partial)
         XCTAssertEqual(d.text, "≈$2.10")
-        XCTAssertEqual(d.color, .systemOrange)
+        XCTAssertEqual(d.color, CostColor.attention)
     }
 
     func testCostLabelResistsCompressionMoreThanTitle() {

--- a/LupenTests/UI/Dashboard/TurnOutlineCostColorTests.swift
+++ b/LupenTests/UI/Dashboard/TurnOutlineCostColorTests.swift
@@ -21,11 +21,12 @@ struct TurnOutlineCostColorTests {
                 cost: 25.0, warningThreshold: 41.2
             )?.isEqual(NSColor.labelColor) == true
         )
-        // At/above the bar: warning orange.
+        // At/above the bar: the unified attention orange (E-1 — no longer raw
+        // systemOrange; one appearance-aware token shared with the ≈ tint).
         #expect(
             TurnOutlineViewController.costColorForTesting(
                 cost: 52.81, warningThreshold: 41.2
-            )?.isEqual(NSColor.systemOrange) == true
+            )?.isEqual(CostColor.attention) == true
         )
         // No threshold supplied (default ∞): nothing is an outlier.
         #expect(
@@ -65,7 +66,7 @@ struct TurnOutlineCostColorTests {
                 cost: 25.0,
                 exactColor: .systemCyan,
                 warningThreshold: 20.0
-            )?.isEqual(NSColor.systemOrange) == true
+            )?.isEqual(CostColor.attention) == true
         )
         // Below the bar the aggregate tint wins.
         #expect(
@@ -83,7 +84,7 @@ struct TurnOutlineCostColorTests {
             TurnOutlineViewController.costColorForTesting(
                 cost: 0.5,
                 confidence: .partial
-            )?.isEqual(NSColor.systemOrange) == true
+            )?.isEqual(CostColor.attention) == true
         )
         #expect(
             TurnOutlineViewController.costColorForTesting(

--- a/LupenTests/UI/Support/CostColorTests.swift
+++ b/LupenTests/UI/Support/CostColorTests.swift
@@ -17,9 +17,11 @@ final class CostColorTests: XCTestCase {
     }
 
     func testPartialIsApproxOrange() {
+        // E-1: the provisional (≈) tint is the unified `attention` token, not
+        // raw systemOrange, so it matches the outlier tint and is dark-aware.
         let d = CostColor.display(cost: 2.10, confidence: .partial)
         XCTAssertEqual(d.text, "≈$2.10")
-        XCTAssertEqual(d.color, .systemOrange)
+        XCTAssertEqual(d.color, CostColor.attention)
     }
 
     func testSmallAmountIsDim() {
@@ -37,7 +39,20 @@ final class CostColorTests: XCTestCase {
     func testWarningThresholdForcesOrange() {
         let d = CostColor.display(cost: 5.0, confidence: .exact, warningThreshold: 1.0)
         XCTAssertEqual(d.text, "$5.00")
-        XCTAssertEqual(d.color, .systemOrange)
+        XCTAssertEqual(d.color, CostColor.attention)
+    }
+
+    // MARK: - E-1: single appearance-aware attention token
+
+    func testAttentionIsUnifiedTokenNotRawSystemOrange() {
+        // The unified token must be its own appearance-aware color, not the
+        // raw system orange the surfaces used to hardcode independently.
+        XCTAssertNotEqual(CostColor.attention, NSColor.systemOrange)
+        // Partial and outlier paths share the very same token.
+        let partial = CostColor.display(cost: 2.0, confidence: .partial).color
+        let outlier = CostColor.display(cost: 9.0, confidence: .exact, warningThreshold: 1.0).color
+        XCTAssertEqual(partial, outlier)
+        XCTAssertEqual(partial, CostColor.attention)
     }
 
     func testPrefixIsPrepended() {


### PR DESCRIPTION
## What this changes

Cost figures used several independent oranges for the *same* meaning, so the same amount could read as a slightly different orange per screen (and the dark-mode tones drifted): `CostColor.display()` returned raw `.systemOrange` for over-threshold (session-relative outlier) and provisional (`≈`) amounts, the sidebar used a separate appearance-aware `CostColor.accent`, and `HourlyEfficiencyView` hardcoded its own warm RGB for a "tight" hour.

This consolidates the cost **"attention"** orange into a single appearance-aware token, `CostColor.attention` (light keeps the familiar `systemOrange` value → no light-mode change; dark uses a clearer warm amber), and routes the `display()` outlier/partial paths through it. A `Color.costAttention` SwiftUI mirror lets the Hours report tint its "tight" hour from the same source. Categorical chart series (Timeline *turns*, Models *fast*) are intentionally left alone — they're series identity, not cost semantics — so this stays a tight token-unification, not a chart re-palette. Implements dashboard item **E-1**.

## How it was verified

- `xcodebuild test` (full suite) passes locally; cost-color tests updated to assert the unified token, plus a new pin that the partial (`≈`) and outlier paths share the very same token and that it is not raw `systemOrange`.
- Multi-agent code review (correctness / cross-file / cleanup / conventions): no correctness issues; one cleanup finding (two unused SwiftUI bridges added speculatively) was applied — only the consumed `costAttention` bridge remains.
- Runtime-verified in dark mode (the only place the tone visibly changes): turn-outline outlier cost, sidebar `≈`, and the Hours "tight" bars now share one orange.

## Checklist

- [x] `xcodebuild test` passes locally
- [x] UI changes include a screenshot or screen recording (runtime-verified in dark mode; change is a color-token consolidation)
- [x] New features add tests (domain) or list a manual-verification procedure (UI)
- [x] Vocabulary matches `docs/CONVERSATION-MODEL.md` (no conversation-model vocab touched)
- [x] Cost-affecting changes are checked against Window → Verify Costs… (N/A — tint only, no cost math changed)
- [x] No hard-coded `/Users/<name>/…` paths or other personal data

## Related issues

Implements dashboard item **E-1** (시맨틱 비용-색 ladder 일원화).