### PR TITLE
feat(sources): manual kind switch + inline rename for session sources

### DIFF
--- a/Lupen/App/AppDelegate.swift
+++ b/Lupen/App/AppDelegate.swift
@@ -229,6 +229,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// own a driver.
     private var sqliteFirstStartups: [String: SQLiteFirstStartup] = [:]
     private var sqliteFirstCodexHome: URL?
+    /// Per-source `kind|root` the on-disk index at `providers/<id>` was built
+    /// for, seeded at launch and updated by `reconcileSourceConfigChanges()`.
+    /// A mismatch (the user changed a source's type in Settings) means the
+    /// index rows were produced by the other parser and must be wiped.
+    /// Built-in sources are excluded — their kind is fixed and the built-in
+    /// Codex root override (`codexRootPath`) has its own driver-swap path in
+    /// `sqliteFirstActivate`.
+    private var sourceIndexFingerprints: [String: String] = [:]
     private var smokeTestCompleted = false
 
     private func smokeCheckpointMetadata(_ metadata: [String: String] = [:]) -> [String: String] {
@@ -329,6 +337,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             statuslineMaintenanceScheduler.start()
         }
         startObservingProviderMode()
+        seedSourceIndexFingerprints()
+        startObservingSessionSources()
 
         // Apply the persisted appearance override before any window or the
         // status item is built, then keep NSApp.appearance in sync as the
@@ -621,6 +631,68 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.syncStoreToActiveSource()
                 self?.startObservingProviderMode()
             }
+        }
+    }
+
+    // MARK: - Source kind/root change reconciliation
+
+    private func sourceFingerprint(_ source: SessionSource) -> String {
+        "\(source.kind.rawValue)|\(source.root.path)"
+    }
+
+    private func seedSourceIndexFingerprints() {
+        for source in settings.resolvedSources where source.origin != .builtin {
+            sourceIndexFingerprints[source.id] = sourceFingerprint(source)
+        }
+    }
+
+    /// Re-arm-on-change observation of the composed source list (same pattern
+    /// as `startObservingProviderMode`), so a kind change made in Settings
+    /// invalidates that source's index promptly.
+    private func startObservingSessionSources() {
+        withObservationTracking {
+            _ = settings.resolvedSources
+        } onChange: { [weak self] in
+            DispatchQueue.main.async {
+                self?.reconcileSourceConfigChanges()
+                self?.startObservingSessionSources()
+            }
+        }
+    }
+
+    /// Diff the non-built-in sources against the recorded fingerprints. For a
+    /// source whose kind/root changed, the index at `providers/<id>` holds
+    /// rows produced by the other parser: stop its driver (if live), drop any
+    /// read-only pool the manage window opened, delete the per-source folder,
+    /// and — when it is the active source — re-activate so a fresh driver
+    /// rebuilds the index from the logs.
+    private func reconcileSourceConfigChanges() {
+        var invalidatedActiveSource = false
+        let sources = settings.resolvedSources
+        for source in sources where source.origin != .builtin {
+            let fingerprint = sourceFingerprint(source)
+            let previous = sourceIndexFingerprints[source.id]
+            sourceIndexFingerprints[source.id] = fingerprint
+            guard let previous, previous != fingerprint else { continue }
+            if let startup = sqliteFirstStartups[source.id] {
+                startup.stop()
+                sqliteFirstStartups[source.id] = nil
+            }
+            managedReadStores[source.id] = nil
+            try? FileManager.default.removeItem(
+                at: LupenPaths.providerRoot(forSourceId: source.id)
+            )
+            LoggerService.shared.info(
+                "Source \(source.id) changed to \(fingerprint) — index wiped for rebuild",
+                context: "App"
+            )
+            if settings.activeSourceId == source.id { invalidatedActiveSource = true }
+        }
+        // Forget removed sources so a later re-add starts a fresh diff.
+        let liveIds = Set(sources.map(\.id))
+        sourceIndexFingerprints = sourceIndexFingerprints.filter { liveIds.contains($0.key) }
+        if invalidatedActiveSource {
+            syncStoreToActiveSource()
         }
     }
 

--- a/Lupen/Domain/AppSettings.swift
+++ b/Lupen/Domain/AppSettings.swift
@@ -332,6 +332,33 @@ final class AppSettings {
         return true
     }
 
+    /// Change a source's parser kind (the Settings kind-badge menu) — the
+    /// escape hatch when `SessionSourceInference` guessed wrong or a future
+    /// directory-layout change breaks the heuristics. User-added sources only;
+    /// built-in and auto-detected sources have their kind fixed by their known
+    /// location. Re-derives the root for the new kind (Claude scans
+    /// `projects/`, Codex the codexHome) and refuses when that root would
+    /// collide with another source. The index invalidation (the old index was
+    /// built with the other parser) is handled by AppDelegate observing
+    /// `resolvedSources`. Returns whether the change was applied.
+    @discardableResult
+    func setSourceKind(id: String, to kind: ProviderKind) -> Bool {
+        guard let current = resolvedSources.source(id: id),
+              current.origin == .userAdded else { return false }
+        guard current.kind != kind else { return true }
+        let newRoot = SessionSourceInference.convertedRoot(current.root, to: kind)
+        if let duplicate = SessionSourceInference.duplicateRootSource(newRoot, in: resolvedSources),
+           duplicate.id != id {
+            return false
+        }
+        let updated = SessionSource(
+            id: current.id, name: current.name, kind: kind, root: newRoot,
+            origin: current.origin, enabled: current.enabled
+        )
+        upsertSourceOverride(updated)
+        return true
+    }
+
     /// Make `id` the active (projected) source. Only enabled sources can be
     /// activated. Returns whether it was applied.
     @discardableResult

--- a/Lupen/Domain/Providers/SessionSourceInference.swift
+++ b/Lupen/Domain/Providers/SessionSourceInference.swift
@@ -57,6 +57,41 @@ enum SessionSourceInference {
         return nil
     }
 
+    /// Re-derive the indexing root when the user manually switches a source's
+    /// kind (Settings ▸ Session Sources): Claude scans a `projects` directory,
+    /// Codex the codexHome. Walks one level up/down with the same rules as
+    /// `infer`; when the expected layout isn't there, keeps the root as-is
+    /// (the scan just finds nothing until the folder matches).
+    static func convertedRoot(
+        _ root: URL,
+        to kind: ProviderKind,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let dir = root.standardizedFileURL
+        let name = dir.lastPathComponent.lowercased()
+        switch kind {
+        case .claudeCode:
+            if name == "projects" { return normalized(dir) }
+            let projects = dir.appendingPathComponent("projects")
+            if isReadableDirectory(projects, fileManager: fileManager) {
+                return normalized(projects)
+            }
+            return normalized(dir)
+        case .codex:
+            // A Claude root is `<config>/projects`; its parent is the
+            // candidate codexHome. Otherwise the root itself is the home.
+            if name == "projects",
+               isReadableDirectory(
+                   dir.deletingLastPathComponent().appendingPathComponent("sessions"),
+                   fileManager: fileManager
+               ) {
+                return normalized(dir.deletingLastPathComponent())
+            }
+            if name == "sessions" { return normalized(dir.deletingLastPathComponent()) }
+            return normalized(dir)
+        }
+    }
+
     /// Suggest an editable display name from the source root. Prefers the most
     /// distinctive ancestor directory (skipping generic tokens like `projects`,
     /// `.claude`, the user's home) combined with the kind's short label, e.g.

--- a/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
+++ b/Lupen/UI/Preferences/SessionSourcesSettingsSection.swift
@@ -51,8 +51,10 @@ struct SessionSourcesSettingsSection: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(source.name).fontWeight(.medium)
-                    kindBadge(source.kind)
+                    SourceNameField(source: source) { newName in
+                        settings.renameSource(id: source.id, to: newName)
+                    }
+                    kindControl(source)
                     Text(originLabel(source.origin))
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
@@ -80,14 +82,65 @@ struct SessionSourcesSettingsSection: View {
         .padding(.vertical, 2)
     }
 
-    private func kindBadge(_ kind: ProviderKind) -> some View {
+    /// The kind badge, and — for user-added sources — a menu to change the
+    /// parser kind manually. The escape hatch when the add-folder inference
+    /// guessed wrong (or a CLI directory-layout change breaks it): flipping
+    /// the kind re-derives the root and rebuilds that source's index.
+    @ViewBuilder
+    private func kindControl(_ source: SessionSource) -> some View {
+        if source.origin == .userAdded {
+            Menu {
+                ForEach(ProviderKind.allCases) { kind in
+                    Button {
+                        changeKind(of: source, to: kind)
+                    } label: {
+                        let name = ProviderRegistry.descriptor(for: kind).shortDisplayName
+                        if kind == source.kind {
+                            Label(name, systemImage: "checkmark")
+                        } else {
+                            Text(name)
+                        }
+                    }
+                }
+            } label: {
+                kindBadge(source.kind, changeable: true)
+            }
+            .menuStyle(.button)
+            // `.plain` (not `.borderless`) so the capsule badge label renders
+            // as-is instead of being restyled into a bare text button.
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Change how this folder is parsed. The source's index is rebuilt for the new type.")
+        } else {
+            kindBadge(source.kind)
+        }
+    }
+
+    private func changeKind(of source: SessionSource, to kind: ProviderKind) {
+        guard kind != source.kind else { return }
+        if !settings.setSourceKind(id: source.id, to: kind) {
+            let alert = NSAlert()
+            alert.messageText = "Can't change this source's type."
+            alert.informativeText = "Another session source already covers the folder this source would point at."
+            alert.runModal()
+        }
+    }
+
+    private func kindBadge(_ kind: ProviderKind, changeable: Bool = false) -> some View {
         let color: Color = kind == .claudeCode ? .indigo : .teal
-        return Text(ProviderRegistry.descriptor(for: kind).shortDisplayName)
-            .font(.caption2.weight(.medium))
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(color.opacity(0.15), in: Capsule())
-            .foregroundStyle(color)
+        return HStack(spacing: 2) {
+            Text(ProviderRegistry.descriptor(for: kind).shortDisplayName)
+            if changeable {
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 7, weight: .semibold))
+            }
+        }
+        .font(.caption2.weight(.medium))
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(color.opacity(0.15), in: Capsule())
+        .foregroundStyle(color)
     }
 
     private func originLabel(_ origin: SessionSource.Origin) -> String {
@@ -143,6 +196,60 @@ struct SessionSourcesSettingsSection: View {
         case .alertFirstButtonReturn: return .claudeCode
         case .alertSecondButtonReturn: return .codex
         default: return nil
+        }
+    }
+
+    /// Editable source name. Renders as the plain static label (so the row
+    /// layout is byte-identical to the pre-rename UI — a live `TextField`
+    /// inside `Form.grouped` picks up the form's trailing text alignment and
+    /// wrecked the row); double-click swaps in a bounded text field. Return
+    /// or focus loss commits through the tested `AppSettings.renameSource`
+    /// (which propagates to the mode picker and every other
+    /// `resolvedSources` reader); Esc cancels. A rejected rename (empty or
+    /// duplicate name) simply falls back to the untouched `source.name`.
+    private struct SourceNameField: View {
+        let source: SessionSource
+        /// Returns whether the rename was applied (`AppSettings.renameSource`).
+        let rename: (String) -> Bool
+
+        @State private var text = ""
+        @State private var isEditing = false
+        @FocusState private var isFocused: Bool
+
+        var body: some View {
+            if isEditing {
+                TextField("", text: $text)
+                    .textFieldStyle(.plain)
+                    .multilineTextAlignment(.leading)   // undo Form's trailing default
+                    .font(.body.weight(.medium))
+                    .frame(minWidth: 80, maxWidth: 240)
+                    .focused($isFocused)
+                    // Deferred one runloop turn: at `onAppear` the field's
+                    // backing NSTextField isn't in the window yet, so an
+                    // immediate `isFocused = true` is dropped and the user
+                    // had to click again to start typing.
+                    .onAppear {
+                        DispatchQueue.main.async { isFocused = true }
+                    }
+                    .onSubmit(commit)
+                    .onExitCommand { isEditing = false }
+                    .onChange(of: isFocused) { _, focused in
+                        if !focused, isEditing { commit() }
+                    }
+            } else {
+                Text(source.name)
+                    .fontWeight(.medium)
+                    .onTapGesture(count: 2) {
+                        text = source.name
+                        isEditing = true
+                    }
+                    .help("Double-click to rename this source")
+            }
+        }
+
+        private func commit() {
+            isEditing = false
+            _ = rename(text)
         }
     }
 

--- a/LupenTests/Domain/AppSettingsTests.swift
+++ b/LupenTests/Domain/AppSettingsTests.swift
@@ -448,6 +448,56 @@ struct AppSettingsTests {
         #expect(settings.enabledResolvedSources.contains { $0.id == added.id })
     }
 
+    @Test("setSourceKind flips a user-added source's kind and re-derives its root")
+    func setSourceKindFlipsKindAndRoot() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-setkind-\(UUID().uuidString)")
+        let config = tmp.appendingPathComponent(".claude_max")
+        try FileManager.default.createDirectory(
+            at: config.appendingPathComponent("projects"), withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: config.appendingPathComponent("sessions"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (settings, _) = makeSettings()
+        // The mis-inferred shape: registered as Codex rooted at the config dir.
+        let added = settings.addSource(root: config, kind: .codex)!
+        #expect(settings.setSourceKind(id: added.id, to: .claudeCode))
+        let updated = try #require(settings.resolvedSources.source(id: added.id))
+        #expect(updated.kind == .claudeCode)
+        #expect(updated.root.path == config.appendingPathComponent("projects").path)
+        #expect(updated.name == added.name)
+        #expect(updated.enabled == added.enabled)
+    }
+
+    @Test("setSourceKind refuses built-in sources and root collisions")
+    func setSourceKindRefusals() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lupen-setkind-\(UUID().uuidString)")
+        let home = tmp.appendingPathComponent("home")
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent("projects"), withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent("sessions"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (settings, _) = makeSettings()
+        #expect(settings.setSourceKind(id: "claudeCode", to: .codex) == false)
+        #expect(settings.resolvedSources.source(id: "claudeCode")?.kind == .claudeCode)
+
+        let a = settings.addSource(root: home, kind: .codex, name: "A")!
+        let b = settings.addSource(root: home.appendingPathComponent("projects"), kind: .claudeCode, name: "B")!
+        // Converting b to Codex ascends projects/ → home, which is a's root.
+        #expect(settings.setSourceKind(id: b.id, to: .codex) == false)
+        #expect(settings.resolvedSources.source(id: b.id)?.kind == .claudeCode)
+        // Same-kind call is a no-op success.
+        #expect(settings.setSourceKind(id: a.id, to: .codex))
+    }
+
     @Test("the last enabled source cannot be disabled")
     func cannotDisableLastEnabledSource() {
         let (settings, _) = makeSettings()

--- a/LupenTests/Domain/Providers/SessionSourceInferenceTests.swift
+++ b/LupenTests/Domain/Providers/SessionSourceInferenceTests.swift
@@ -84,6 +84,43 @@ struct SessionSourceInferenceTests {
         #expect(SessionSourceInference.infer(fromPickedFolder: dir)?.kind == .codex)
     }
 
+    // MARK: - convertedRoot
+
+    @Test("codex→claude conversion descends into projects/")
+    func convertedRootCodexToClaude() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let config = tmp.appendingPathComponent(".claude_max")
+        mkdir(config.appendingPathComponent("projects"))
+        mkdir(config.appendingPathComponent("sessions"))
+        // The mis-registered source's root is the config dir itself.
+        let converted = SessionSourceInference.convertedRoot(config, to: .claudeCode)
+        #expect(converted.standardizedFileURL
+            == config.appendingPathComponent("projects").standardizedFileURL)
+    }
+
+    @Test("claude→codex conversion ascends from projects/ to the home holding sessions/")
+    func convertedRootClaudeToCodex() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let home = tmp.appendingPathComponent("home")
+        mkdir(home.appendingPathComponent("projects"))
+        mkdir(home.appendingPathComponent("sessions"))
+        let converted = SessionSourceInference.convertedRoot(
+            home.appendingPathComponent("projects"), to: .codex
+        )
+        #expect(converted.standardizedFileURL == home.standardizedFileURL)
+    }
+
+    @Test("conversion keeps the root when the expected layout is absent")
+    func convertedRootKeepsRootWithoutLayout() {
+        let (tmp, cleanup) = makeTemp(); defer { cleanup() }
+        let dir = tmp.appendingPathComponent("plain")
+        mkdir(dir)
+        #expect(SessionSourceInference.convertedRoot(dir, to: .claudeCode).standardizedFileURL
+            == dir.standardizedFileURL)
+        #expect(SessionSourceInference.convertedRoot(dir, to: .codex).standardizedFileURL
+            == dir.standardizedFileURL)
+    }
+
     // MARK: - suggestName
 
     @Test("name suggestion uses the most distinctive ancestor + kind label")


### PR DESCRIPTION
## Motivation
Users who split Claude environments by plan (personal / enterprise) via `CLAUDE_CONFIG_DIR` — e.g. `~/.claude_max`, `~/.claude_enterprise` — get those directories misdetected as Codex when adding them to Session Sources. Modern Claude config dirs carry a flat `sessions/` (metadata *.json) alongside `projects/` (JSONL sessions), and the add-folder inference checks `sessions/` first, so it reads them as a codexHome.

The inference logic itself is left untouched (layout rules unchanged); instead this adds a manual correction path so a misdetected source can be fixed in place. Source names are also made editable, for users tracking multiple Claude environments side by side.

## Summary
- Settings ▸ Session Sources: the kind badge on user-added sources becomes a menu — flipping Claude Code ↔ Codex goes through the new `AppSettings.setSourceKind`, which re-derives the indexing root (`SessionSourceInference.convertedRoot` walks between a Claude `projects/` dir and a codexHome) and refuses collisions with an existing source.
- Source names are editable in place (double-click), committing through the tested `AppSettings.renameSource`, so the mode picker and every other `resolvedSources` reader update together — useful when tracking multiple Claude environments side by side.
- `AppDelegate` observes `resolvedSources` and, when a source's kind|root fingerprint changes, stops its index driver, wipes `providers/<id>`, and rebuilds — stale rows from the wrong parser don't survive a kind flip.

## Test plan
- [x] `SessionSourceInferenceTests` (28) — including new `convertedRoot` cases
- [x] `AppSettingsTests` — including new `setSourceKindFlipsKindAndRoot` / `setSourceKindRefusals`
- [x] Manual: isolated debug instance — rename propagates to mode picker; kind flip rebuilds the source index

## Known follow-ups (from multi-agent review)
The reconcile path in `AppDelegate` has known gaps to address separately: the `providers/<id>` wipe races a non-blocking coordinator stop, non-active drivers aren't restarted until relaunch, fingerprints are in-memory only, and remove/re-add recycles a stale index for the same id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)